### PR TITLE
moved S from separator to excluded

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/QuotableEncoder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/QuotableEncoder.kt
@@ -5,8 +5,8 @@ import kotlin.random.Random
 class QuotableEncoder(private val delimiter: String = "-", private val minLength: Int = 1, private val chunkSize: Int = 2) {
 
   private val seed = arrayOf("2", "a", "7", "1", "y", "x", "m", "q", "r", "b", "0", "8", "d", "5", "n", "p", "6", "e", "g", "j", "v", "3", "w", "9", "k", "4")
-  private val separator = arrayOf("c", "s", "f", "h", "u", "i", "t")
-  // Exclude characters which are too similar to numbers "l","o","z"
+  private val separator = arrayOf("c", "f", "h", "u", "i", "t")
+  // Exclude characters which are too similar to numbers "l","o","s","z"
 
   init {
     require(delimiter.length in 0..1) {


### PR DESCRIPTION
## What does this pull request do?
Removed the letter 'S' from the list of separators.

## What is the intent behind these changes?
To improve reference readability.