### PR TITLE
lock on visit delete

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/repository/VisitRepository.kt
@@ -2,10 +2,16 @@ package uk.gov.justice.digital.hmpps.visitscheduler.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.Visit
+import javax.persistence.LockModeType
 
 @Repository
 interface VisitRepository : JpaRepository<Visit, String>, JpaSpecificationExecutor<Visit> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  fun deleteAllByIdIn(visitId: List<String>)
+
   fun findByPrisonerId(prisonerId: String): List<Visit>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerService.kt
@@ -338,6 +338,10 @@ class VisitSchedulerService(
       }
   }
 
+  fun deleteAllVisits(expired: List<VisitDto>) {
+    visitRepository.deleteAllByIdIn(expired.map { it.id }.toList())
+  }
+
   fun getAvailableSupport(): List<AvailableSupport> {
     return supportRepository.findAll().sortedBy { it.code }.map { AvailableSupport(it) }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/task/VisitTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/task/VisitTask.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.task
 
-import org.hibernate.StaleStateException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -35,13 +34,7 @@ class VisitTask(
       log.debug("Expired visits: ${expired.count()}")
     }
 
-    expired.forEach {
-      try {
-        visitSchedulerService.deleteVisit(it.id)
-      } catch (e: StaleStateException) {
-        log.debug("Visit id ${it.id} is stale")
-      }
-    }
+    visitSchedulerService.deleteAllVisits(expired)
   }
 
   companion object {


### PR DESCRIPTION
## What does this pull request do?
Locks visits for the scheduled delete expired reservation task

## What is the intent behind these changes?
Prevent stale state warnings in the logs