### PR TITLE
Vb 412 booked slot count

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/CreateVisitRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/CreateVisitRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.data
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitType
 import java.time.LocalDateTime
@@ -23,6 +24,7 @@ data class CreateVisitRequest(
   ) @NotNull val endTimestamp: LocalDateTime,
   @Schema(description = "Visit Type", example = "STANDARD_SOCIAL", required = true) @NotNull val visitType: VisitType,
   @Schema(description = "Visit Status", example = "RESERVED", required = true) @NotNull val visitStatus: VisitStatus,
+  @Schema(description = "Visit Restriction", example = "OPEN", required = true) @NotNull val visitRestriction: VisitRestriction,
   @Schema(description = "Visit Room", example = "A1", required = true) @field:NotBlank val visitRoom: String,
   @Schema(description = "Visitor Concerns", required = false) val visitorConcerns: String? = null,
   @Schema(description = "Main Contact associated with the visit", required = false) @field:Valid val mainContact: CreateContactOnVisitRequest?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/UpdateVisitRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/UpdateVisitRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.data
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitType
 import java.time.LocalDateTime
@@ -21,6 +22,7 @@ data class UpdateVisitRequest(
   ) val endTimestamp: LocalDateTime? = null,
   @Schema(description = "Visit Type", example = "STANDARD_SOCIAL", required = false) val visitType: VisitType? = null,
   @Schema(description = "Visit Status", example = "RESERVED", required = false) val visitStatus: VisitStatus? = null,
+  @Schema(description = "Visit Restriction", example = "OPEN", required = true) val visitRestriction: VisitRestriction? = null,
   @Schema(description = "Visit Room", example = "A1", required = false) val visitRoom: String? = null,
   @Schema(description = "Visitor Concerns", required = false) val visitorConcerns: String? = null,
   @Schema(description = "Main Contact associated with the visit", required = false) @field:Valid val mainContact: CreateContactOnVisitRequest? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/VisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/VisitDto.kt
@@ -23,6 +23,10 @@ data class VisitDto(
   val visitStatus: String,
   @Schema(description = "Visit Status Description", example = "Reserved", required = true)
   val visitStatusDescription: String,
+  @Schema(description = "Visit Restriction", example = "OPEN", required = true)
+  val visitRestriction: String,
+  @Schema(description = "Visit Restriction Description", example = "Open", required = true)
+  val visitRestrictionDescription: String,
   @Schema(
     description = "The date and time of the visit",
     example = "2018-12-01T13:45:00",
@@ -57,6 +61,8 @@ data class VisitDto(
     visitStatusDescription = visitEntity.status.description,
     visitType = visitEntity.visitType.name,
     visitTypeDescription = visitEntity.visitType.description,
+    visitRestriction = visitEntity.visitRestriction.name,
+    visitRestrictionDescription = visitEntity.visitRestriction.description,
     visitRoom = visitEntity.visitRoom,
     visitorConcerns = visitEntity.visitorConcerns,
     mainContact = visitEntity.mainContact?.let { ContactDto(it) },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/VisitSession.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/VisitSession.kt
@@ -27,14 +27,14 @@ data class VisitSession(
   @Schema(description = "The number of concurrent visits which may take place within this session", example = "1", required = true)
   val openVisitCapacity: Int,
 
-  @Schema(description = "The count of open visit bookings already reserved or booked for this session", example = "1", required = true)
-  val openVisitBookedCount: Int,
+  @Schema(description = "The count of open visit bookings already reserved or booked for this session", example = "1", required = false)
+  var openVisitBookedCount: Int? = 0,
 
   @Schema(description = "The number of closed visits which may take place within this session", example = "1", required = true)
   val closedVisitCapacity: Int,
 
-  @Schema(description = "The count of closed visit bookings already reserved or booked for this session", example = "1", required = true)
-  val closedVisitBookedCount: Int,
+  @Schema(description = "The count of closed visit bookings already reserved or booked for this session", example = "1", required = false)
+  var closedVisitBookedCount: Int? = 0,
 
   @Schema(description = "The start timestamp for this visit session", example = "1", required = true)
   val startTimestamp: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/filter/VisitFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/data/filter/VisitFilter.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.data.filter
 
+import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitStatus
 import java.time.LocalDateTime
 
@@ -10,6 +11,7 @@ data class VisitFilter(
   val startDateTime: LocalDateTime? = null,
   val endDateTime: LocalDateTime? = null,
   val status: VisitStatus? = null,
+  val visitRestriction: VisitRestriction? = null,
   val createTimestamp: LocalDateTime? = null,
   val modifyTimestamp: LocalDateTime? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/Visit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/Visit.kt
@@ -55,6 +55,10 @@ data class Visit(
   @Enumerated(EnumType.STRING)
   var status: VisitStatus,
 
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  var visitRestriction: VisitRestriction,
+
   @Column
   var visitorConcerns: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/VisitRestriction.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/VisitRestriction.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.jpa
+
+@Suppress("unused")
+enum class VisitRestriction(
+  val description: String,
+) {
+  OPEN("Open"),
+  CLOSED("Closed"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/specification/VisitSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/jpa/specification/VisitSpecification.kt
@@ -30,7 +30,7 @@ class VisitSpecification(private val filter: VisitFilter) : Specification<Visit>
     }
 
     filter.endDateTime?.run {
-      predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(Visit::visitStart.name), this))
+      predicates.add(criteriaBuilder.lessThan(root.get(Visit::visitStart.name), this))
     }
 
     filter.nomisPersonId?.run {
@@ -40,6 +40,10 @@ class VisitSpecification(private val filter: VisitFilter) : Specification<Visit>
 
     filter.status?.run {
       predicates.add(criteriaBuilder.equal(root.get<String>(Visit::status.name), this))
+    }
+
+    filter.visitRestriction?.run {
+      predicates.add(criteriaBuilder.equal(root.get<String>(Visit::visitRestriction.name), this))
     }
 
     filter.createTimestamp?.run {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerService.kt
@@ -220,6 +220,7 @@ class VisitSchedulerService(
         prisonerId = createVisitRequest.prisonerId,
         visitType = createVisitRequest.visitType,
         status = createVisitRequest.visitStatus,
+        visitRestriction = createVisitRequest.visitRestriction,
         visitRoom = createVisitRequest.visitRoom,
         visitStart = createVisitRequest.startTimestamp,
         visitEnd = createVisitRequest.endTimestamp,
@@ -260,6 +261,7 @@ class VisitSchedulerService(
     updateVisitRequest.endTimestamp?.let { visitEnd -> visitEntity.visitEnd = visitEnd }
     updateVisitRequest.visitType?.let { visitType -> visitEntity.visitType = visitType }
     updateVisitRequest.visitStatus?.let { status -> visitEntity.status = status }
+    updateVisitRequest.visitRestriction?.let { visitRestriction -> visitEntity.visitRestriction = visitRestriction }
     updateVisitRequest.visitRoom?.let { visitRoom -> visitEntity.visitRoom = visitRoom }
     updateVisitRequest.visitorConcerns?.let { visitorConcerns -> visitEntity.visitorConcerns = visitorConcerns }
     updateVisitRequest.sessionId?.let { sessionId -> visitEntity.sessionTemplateId = sessionId }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.data.filter.VisitFilter
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitContact
+import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitSupport
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitVisitor
@@ -76,7 +77,31 @@ class VisitSchedulerService(
       available = filterNonAssociationByPrisonerId(available, prisonerId)
     }
 
+    populateBookedCounts(available)
+
     return available.sortedWith(compareBy { it.startTimestamp })
+  }
+
+  private fun populateBookedCounts(available: List<VisitSession>) {
+    available.forEach {
+      it.openVisitBookedCount = visitBookedCount(it, VisitRestriction.OPEN)
+      it.closedVisitBookedCount = visitBookedCount(it, VisitRestriction.CLOSED)
+    }
+  }
+
+  fun visitBookedCount(session: VisitSession, restriction: VisitRestriction): Int {
+    return visitRepository.findAll(
+      VisitSpecification(
+        VisitFilter(
+          prisonId = session.prisonId,
+          startDateTime = session.startTimestamp,
+          endDateTime = session.endTimestamp,
+          visitRestriction = restriction
+        )
+      )
+    ).count {
+      it.status == VisitStatus.BOOKED || it.status == VisitStatus.RESERVED
+    }
   }
 
   private fun filterNonAssociationByPrisonerId(visitSessions: List<VisitSession>?, prisonerId: String): List<VisitSession> {
@@ -144,16 +169,17 @@ class VisitSchedulerService(
     else
       sessionTemplate.startDate
 
+    // Create a VisitSession for every date from the template start date in increments of
+    // frequency until the lastBookableSessionDay + 1
     return sessionTemplate.startDate.datesUntil(
       lastBookableSessionDay.plusDays(1), sessionTemplate.frequency.frequencyPeriod
     )
-      .map { date ->
+      .map {
+        date ->
         VisitSession(
           sessionTemplateId = sessionTemplate.id,
           prisonId = sessionTemplate.prisonId,
           startTimestamp = LocalDateTime.of(date, sessionTemplate.startTime),
-          closedVisitBookedCount = 0,
-          openVisitBookedCount = 0,
           openVisitCapacity = sessionTemplate.openCapacity,
           closedVisitCapacity = sessionTemplate.closedCapacity,
           endTimestamp = LocalDateTime.of(date, sessionTemplate.endTime),
@@ -163,7 +189,7 @@ class VisitSchedulerService(
           restrictions = sessionTemplate.restrictions
         )
       }
-      // remove sessions are before the bookable period
+      // remove created VisitSessions which are before the bookable period
       .filter { session -> session.startTimestamp > LocalDateTime.of(firstBookableSessionDay, LocalTime.MIDNIGHT) }
       .toList()
   }
@@ -252,8 +278,7 @@ class VisitSchedulerService(
   fun updateVisit(reference: String, updateVisitRequest: UpdateVisitRequest): VisitDto {
     log.info("Updating visit for $reference")
 
-    val visitEntity = visitRepository.findByReference(reference)
-    visitEntity ?: throw VisitNotFoundException("Visit id  $reference not found")
+    val visitEntity = visitRepository.findByReference(reference) ?: throw VisitNotFoundException("Visit id  $reference not found")
 
     updateVisitRequest.prisonerId?.let { prisonerId -> visitEntity.prisonerId = prisonerId }
     updateVisitRequest.prisonId?.let { prisonId -> visitEntity.prisonId = prisonId }

--- a/src/main/resources/db/migration/V1_0__create_visit_table.sql
+++ b/src/main/resources/db/migration/V1_0__create_visit_table.sql
@@ -10,6 +10,7 @@ CREATE TABLE visit
     visit_start             timestamp with time zone NOT NULL,
     visit_end               timestamp with time zone NOT NULL,
     status                  VARCHAR(80)     NOT NULL,
+    visit_restriction       VARCHAR(80)     NOT NULL,
     visitor_concerns        text,
     create_timestamp        timestamp default current_timestamp,
     modify_timestamp        timestamp default current_timestamp

--- a/src/main/resources/db/migration/V1_7__create_visit_restriction_column.sql
+++ b/src/main/resources/db/migration/V1_7__create_visit_restriction_column.sql
@@ -1,7 +1,0 @@
-ALTER TABLE visit
-    ADD COLUMN visit_restriction   VARCHAR(80)
-;
-
-UPDATE visit SET visit_restriction = 'OPEN';
-
-ALTER TABLE visit ALTER COLUMN visit_restriction SET NOT NULL;

--- a/src/main/resources/db/migration/V1_7__create_visit_restriction_column.sql
+++ b/src/main/resources/db/migration/V1_7__create_visit_restriction_column.sql
@@ -1,0 +1,7 @@
+ALTER TABLE visit
+    ADD COLUMN visit_restriction   VARCHAR(80)
+;
+
+UPDATE visit SET visit_restriction = 'OPEN';
+
+ALTER TABLE visit ALTER COLUMN visit_restriction SET NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.jpa.SessionFrequency
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitContact
+import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitSupport
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitType
@@ -92,6 +93,7 @@ fun defaultVisit(): Visit {
     visitEnd = LocalDateTime.of(2021, 10, 23, 11, 30),
     visitType = VisitType.STANDARD_SOCIAL,
     status = VisitStatus.RESERVED,
+    visitRestriction = VisitRestriction.OPEN,
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -59,6 +59,11 @@ class VisitBuilder(
     return this
   }
 
+  fun withRestriction(restriction: VisitRestriction): VisitBuilder {
+    this.visit = visit.copy(visitRestriction = restriction)
+    return this
+  }
+
   fun withVisitorConcerns(concerns: String): VisitBuilder {
     this.visit = visit.copy(visitorConcerns = concerns)
     return this

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/resource/VisitResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/resource/VisitResourceIntTest.kt
@@ -257,9 +257,9 @@ class VisitResourceIntTest : IntegrationTestBase() {
         .expectStatus().isOk
         .expectBody()
         .jsonPath("$.length()").isEqualTo(1)
-        .jsonPath("$[-1].prisonerId").isEqualTo("FF0000AA")
-        .jsonPath("$[-1].startTimestamp").isEqualTo(visitTime.toString())
-        .jsonPath("$[-1].reference").exists()
+        .jsonPath("$[0].prisonerId").isEqualTo("FF0000AA")
+        .jsonPath("$[0].startTimestamp").isEqualTo(visitTime.toString())
+        .jsonPath("$[0].reference").exists()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/resource/VisitResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/resource/VisitResourceIntTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitSupportCreator
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitVisitorCreator
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.Visit
+import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.repository.VisitRepository
@@ -43,6 +44,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
       startTimestamp = visitTime,
       endTimestamp = visitTime.plusHours(1),
       visitStatus = VisitStatus.RESERVED,
+      visitRestriction = VisitRestriction.OPEN,
       mainContact = CreateContactOnVisitRequest("John Smith", "01234 567890"),
       contactList = listOf(CreateVisitorOnVisitRequest(123)),
       supportList = listOf(CreateSupportOnVisitRequest("OTHER", "Some Text")),
@@ -78,6 +80,8 @@ class VisitResourceIntTest : IntegrationTestBase() {
         .jsonPath("$[0].endTimestamp").isEqualTo(visitTime.plusHours(1).toString())
         .jsonPath("$[0].visitStatus").isEqualTo("RESERVED")
         .jsonPath("$[0].visitStatusDescription").isEqualTo("Reserved")
+        .jsonPath("$[0].visitRestriction").isEqualTo("OPEN")
+        .jsonPath("$[0].visitRestrictionDescription").isEqualTo("Open")
         .jsonPath("$[0].mainContact.contactName").isNotEmpty
         .jsonPath("$[0].mainContact.contactName").isEqualTo("John Smith")
         .jsonPath("$[0].mainContact.contactPhone").isEqualTo("01234 567890")
@@ -99,6 +103,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         endTimestamp = visitTime.plusHours(1),
         visitType = VisitType.STANDARD_SOCIAL,
         visitStatus = VisitStatus.RESERVED,
+        visitRestriction = VisitRestriction.OPEN,
         visitRoom = "A1",
         mainContact = CreateContactOnVisitRequest("John Smith", "01234 567890"),
         contactList = listOf(
@@ -141,6 +146,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         endTimestamp = visitTime.plusHours(1),
         visitType = VisitType.STANDARD_SOCIAL,
         visitStatus = VisitStatus.RESERVED,
+        visitRestriction = VisitRestriction.OPEN,
         visitRoom = "A1",
         mainContact = CreateContactOnVisitRequest("John Smith", "01234 567890"),
         supportList = listOf(CreateSupportOnVisitRequest("ANYTHINGWILLDO")),
@@ -466,6 +472,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         endTimestamp = visitTime.plusDays(2).plusHours(1),
         visitType = VisitType.FAMILY,
         visitStatus = VisitStatus.BOOKED,
+        visitRestriction = VisitRestriction.CLOSED,
         mainContact = CreateContactOnVisitRequest("John Smith", "01234 567890"),
         contactList = listOf(CreateVisitorOnVisitRequest(123L)),
         supportList = listOf(CreateSupportOnVisitRequest("OTHER", "Some Text")),
@@ -488,6 +495,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         .jsonPath("$.endTimestamp").isEqualTo(updateRequest.endTimestamp.toString())
         .jsonPath("$.visitType").isEqualTo(updateRequest.visitType!!.name)
         .jsonPath("$.visitStatus").isEqualTo(updateRequest.visitStatus!!.name)
+        .jsonPath("$.visitRestriction").isEqualTo(updateRequest.visitRestriction!!.name)
         .jsonPath("$.mainContact.contactName").isNotEmpty
         .jsonPath("$.mainContact.contactName").isEqualTo(updateRequest.mainContact!!.contactName)
         .jsonPath("$.mainContact.contactPhone").isEqualTo(updateRequest.mainContact!!.contactPhone)
@@ -512,6 +520,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         endTimestamp = visitTime.plusDays(2).plusHours(1),
         visitType = VisitType.FAMILY,
         visitStatus = VisitStatus.BOOKED,
+        visitRestriction = VisitRestriction.CLOSED,
         mainContact = CreateContactOnVisitRequest("John Smith", "01234 567890"),
         contactList = listOf(CreateVisitorOnVisitRequest(123L)),
         supportList = listOf(CreateSupportOnVisitRequest("OTHER", "Some Text")),
@@ -534,6 +543,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         .jsonPath("$.endTimestamp").isEqualTo(updateRequest.endTimestamp.toString())
         .jsonPath("$.visitType").isEqualTo(updateRequest.visitType!!.name)
         .jsonPath("$.visitStatus").isEqualTo(updateRequest.visitStatus!!.name)
+        .jsonPath("$.visitRestriction").isEqualTo(updateRequest.visitRestriction!!.name)
         .jsonPath("$.mainContact.contactName").isNotEmpty
         .jsonPath("$.mainContact.contactName").isEqualTo(updateRequest.mainContact!!.contactName)
         .jsonPath("$.mainContact.contactPhone").isEqualTo(updateRequest.mainContact!!.contactPhone)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerServiceTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.jpa.SessionFrequency
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.SupportType
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.Visit
+import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.jpa.repository.SessionTemplateRepository
@@ -341,6 +342,7 @@ class VisitSchedulerServiceTest {
               visitType = VisitType.STANDARD_SOCIAL,
               prisonId = prisonId,
               status = VisitStatus.BOOKED,
+              visitRestriction = VisitRestriction.OPEN,
               visitRoom = "123c",
               visitorConcerns = "some more text",
               sessionTemplateId = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitSchedulerServiceTest.kt
@@ -71,7 +71,7 @@ class VisitSchedulerServiceTest {
   @DisplayName("simple session generation")
   inner class SlotGeneration {
 
-    private fun mockRepositoryResponse(response: List<SessionTemplate>) {
+    private fun mockSessionRepositoryResponse(response: List<SessionTemplate>) {
       whenever(
         sessionTemplateRepository.findValidSessionTemplatesByPrisonId(
           "MDI",
@@ -79,6 +79,11 @@ class VisitSchedulerServiceTest {
           LocalDate.parse("2021-01-01").plusDays(100)
         )
       ).thenReturn(response)
+    }
+
+    private fun mockVisitRepositoryResponse(response: List<Visit>) {
+      whenever(visitRepository.findAll(any(VisitSpecification::class.java)))
+        .thenReturn(response)
     }
 
     @Test
@@ -90,7 +95,7 @@ class VisitSchedulerServiceTest {
         endTime = LocalTime.parse("12:30"), // future time
         frequency = SessionFrequency.DAILY
       )
-      mockRepositoryResponse(listOf(dailySession))
+      mockSessionRepositoryResponse(listOf(dailySession))
 
       val sessions = visitSchedulerService.getVisitSessions("MDI")
       assertThat(sessions).size().isEqualTo(7) // expiry date is inclusive
@@ -116,7 +121,7 @@ class VisitSchedulerServiceTest {
         endTime = LocalTime.parse("12:30"),
         frequency = SessionFrequency.WEEKLY
       )
-      mockRepositoryResponse(listOf(weeklySession))
+      mockSessionRepositoryResponse(listOf(weeklySession))
 
       val sessions = visitSchedulerService.getVisitSessions("MDI")
       assertThat(sessions).size().isEqualTo(5) // expiry date is inclusive
@@ -140,7 +145,7 @@ class VisitSchedulerServiceTest {
         endTime = LocalTime.parse("12:30"),
         frequency = SessionFrequency.WEEKLY
       )
-      mockRepositoryResponse(listOf(weeklySession))
+      mockSessionRepositoryResponse(listOf(weeklySession))
 
       val sessions = visitSchedulerService.getVisitSessions("MDI")
       assertThat(sessions).size().isEqualTo(5) // expiry date is inclusive
@@ -161,7 +166,7 @@ class VisitSchedulerServiceTest {
         endTime = LocalTime.parse("12:30"), // future time
         frequency = SessionFrequency.SINGLE
       )
-      mockRepositoryResponse(listOf(singleSession))
+      mockSessionRepositoryResponse(listOf(singleSession))
 
       val sessions = visitSchedulerService.getVisitSessions("MDI")
       assertThat(sessions).size().isEqualTo(1)
@@ -177,7 +182,7 @@ class VisitSchedulerServiceTest {
         expiryDate = LocalDate.parse("2021-01-01").minusDays(1),
         frequency = SessionFrequency.DAILY
       )
-      mockRepositoryResponse(listOf(dailySession))
+      mockSessionRepositoryResponse(listOf(dailySession))
 
       val sessions = visitSchedulerService.getVisitSessions("MDI")
       assertThat(sessions).size().isEqualTo(0)
@@ -202,7 +207,7 @@ class VisitSchedulerServiceTest {
         id = 2
       )
 
-      mockRepositoryResponse(listOf(monthlySession, dailySession))
+      mockSessionRepositoryResponse(listOf(monthlySession, dailySession))
 
       val sessions = visitSchedulerService.getVisitSessions("MDI")
       assertThat(sessions).size().isEqualTo(5)
@@ -222,6 +227,82 @@ class VisitSchedulerServiceTest {
           LocalDateTime.parse("2021-01-05T16:00"),
           LocalDateTime.parse("2021-02-01T11:30")
         )
+    }
+
+    @Test
+    fun `Single Session without Visit has zero Open and zero Closed slot count`() {
+      val singleSession = sessionTemplate(
+        startDate = LocalDate.parse("2021-02-01"),
+        startTime = LocalTime.parse("11:30"), // future time
+        endTime = LocalTime.parse("12:30"), // future time
+        frequency = SessionFrequency.SINGLE
+      )
+      mockSessionRepositoryResponse(listOf(singleSession))
+
+      val sessions = visitSchedulerService.getVisitSessions("MDI")
+      assertThat(sessions).size().isEqualTo(1)
+      assertThat(sessions[0].openVisitBookedCount).isEqualTo(0)
+      assertThat(sessions[0].closedVisitBookedCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `Single Session with BOOKED Visit has booked slot count`() {
+      val singleSession = sessionTemplate(
+        startDate = LocalDate.parse("2021-02-01"),
+        startTime = LocalTime.parse("11:30"), // future time
+        endTime = LocalTime.parse("12:30"), // future time
+        frequency = SessionFrequency.SINGLE
+      )
+      mockSessionRepositoryResponse(listOf(singleSession))
+
+      val visit = Visit(
+        prisonerId = "Anythingwilldo",
+        visitStart = LocalDate.parse("2021-02-01").atTime(11, 30),
+        visitEnd = LocalDate.parse("2021-02-01").atTime(12, 30),
+        visitType = VisitType.STANDARD_SOCIAL,
+        prisonId = "MDI",
+        status = VisitStatus.BOOKED,
+        visitRestriction = VisitRestriction.OPEN,
+        visitRoom = "123c",
+        visitorConcerns = "some more text",
+        sessionTemplateId = null,
+      )
+      mockVisitRepositoryResponse(listOf(visit))
+
+      val sessions = visitSchedulerService.getVisitSessions("MDI")
+      assertThat(sessions).size().isEqualTo(1)
+      assertThat(sessions[0].openVisitBookedCount).isEqualTo(1)
+      assertThat(sessions[0].closedVisitBookedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `Single Session with RESERVED Visit has booked slot count`() {
+      val singleSession = sessionTemplate(
+        startDate = LocalDate.parse("2021-02-01"),
+        startTime = LocalTime.parse("11:30"), // future time
+        endTime = LocalTime.parse("12:30"), // future time
+        frequency = SessionFrequency.SINGLE
+      )
+      mockSessionRepositoryResponse(listOf(singleSession))
+
+      val visit = Visit(
+        prisonerId = "Anythingwilldo",
+        visitStart = LocalDate.parse("2021-02-01").atTime(11, 30),
+        visitEnd = LocalDate.parse("2021-02-01").atTime(12, 30),
+        visitType = VisitType.STANDARD_SOCIAL,
+        prisonId = "MDI",
+        status = VisitStatus.RESERVED,
+        visitRestriction = VisitRestriction.OPEN,
+        visitRoom = "123c",
+        visitorConcerns = "some more text",
+        sessionTemplateId = null,
+      )
+      mockVisitRepositoryResponse(listOf(visit))
+
+      val sessions = visitSchedulerService.getVisitSessions("MDI")
+      assertThat(sessions).size().isEqualTo(1)
+      assertThat(sessions[0].openVisitBookedCount).isEqualTo(1)
+      assertThat(sessions[0].closedVisitBookedCount).isEqualTo(1)
     }
   }
 


### PR DESCRIPTION
## What does this pull request do?
Adds open / closed restriction to visit
Adds open / closed booked visit count to available session
Corrects defect in visit session end date criteria

## What is the intent behind these changes?
Add booked slot count values to /visit-sessions endpoint to replace the hard coded values with actual counts