### PR TITLE
domain events namespace secrets added for build

### DIFF
--- a/helm_deploy/visit-scheduler/values.yaml
+++ b/helm_deploy/visit-scheduler/values.yaml
@@ -36,6 +36,10 @@ generic-service:
       SPRING_DATASOURCE_PASSWORD: "database_password"
       DATABASE_NAME: "database_name"
       DATABASE_ENDPOINT: "rds_instance_endpoint"
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ACCESS_KEY_ID: "access_key_id"
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_SECRET_ACCESS_KEY: "secret_access_key"
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
 
   allowlist:
     office: "217.33.148.210/32"


### PR DESCRIPTION
## What does this pull request do?
Adds hmpps-domain-events-topic to the helm namespace secrets config

## What is the intent behind these changes?
The build is currently failing to deploy due to 'Error: secret "hmpps-domain-events-topic" not found'