### PR TITLE
VB-749 Refactor current create visit endpoint to remove migration data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateContactOnVisitRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateContactOnVisitRequestDto.kt
@@ -2,12 +2,16 @@ package uk.gov.justice.digital.hmpps.visitscheduler.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 data class CreateContactOnVisitRequestDto(
   @Schema(description = "Contact Name", example = "John Smith", required = true)
   @field:NotBlank
+  @field:Size(min = 3)
   val name: String,
+
   @Schema(description = "Contact Phone Number", example = "01234 567890", required = true)
   @field:NotBlank
+  @field:Size(min = 11)
   val telephone: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateContactOnVisitRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateContactOnVisitRequestDto.kt
@@ -2,16 +2,13 @@ package uk.gov.justice.digital.hmpps.visitscheduler.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.constraints.NotBlank
-import javax.validation.constraints.Size
 
 data class CreateContactOnVisitRequestDto(
   @Schema(description = "Contact Name", example = "John Smith", required = true)
   @field:NotBlank
-  @field:Size(min = 3)
   val name: String,
 
   @Schema(description = "Contact Phone Number", example = "01234 567890", required = true)
   @field:NotBlank
-  @field:Size(min = 11)
   val telephone: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateVisitRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateVisitRequestDto.kt
@@ -34,8 +34,6 @@ data class CreateVisitRequestDto(
   @Schema(description = "The finishing date and time of the visit", example = "2018-12-01T13:45:00", required = true)
   @field:NotNull
   val endTimestamp: LocalDateTime,
-  @Schema(description = "Create legacy data", required = false)
-  val legacyData: CreateLegacyDataRequestDto? = null,
   @Schema(description = "Contact associated with the visit", required = false)
   @field:Valid
   val visitContact: CreateContactOnVisitRequestDto?,
@@ -43,7 +41,4 @@ data class CreateVisitRequestDto(
   val visitors: List<@Valid CreateVisitorOnVisitRequestDto>? = listOf(),
   @Schema(description = "List of additional support associated with the visit", required = false)
   val visitorSupport: List<@Valid CreateSupportOnVisitRequestDto>? = listOf(),
-  @Schema(description = "Visit notes", required = false)
-  val visitNotes: List<@Valid VisitNoteDto>? = listOf(),
-
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateVisitRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/CreateVisitRequestDto.kt
@@ -37,8 +37,9 @@ data class CreateVisitRequestDto(
   @Schema(description = "Contact associated with the visit", required = false)
   @field:Valid
   val visitContact: CreateContactOnVisitRequestDto?,
-  @Schema(description = "List of visitors associated with the visit", required = false)
-  val visitors: List<@Valid CreateVisitorOnVisitRequestDto>? = listOf(),
+  @Schema(description = "List of visitors associated with the visit", required = true)
+  @field:NotNull
+  val visitors: List<@Valid CreateVisitorOnVisitRequestDto>? = null,
   @Schema(description = "List of additional support associated with the visit", required = false)
   val visitorSupport: List<@Valid CreateSupportOnVisitRequestDto>? = listOf(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.STATUS_CHANGED_REASON
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.VISIT_OUTCOMES
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
-import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.LegacyData
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitContact
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
@@ -28,7 +27,6 @@ import java.util.function.Supplier
 @Service
 @Transactional
 class VisitService(
-  private val legacyDataRepository: LegacyDataRepository,
   private val visitRepository: VisitRepository,
   private val supportTypeRepository: SupportTypeRepository,
 ) {
@@ -63,16 +61,6 @@ class VisitService(
         supportTypeRepository.findByName(it.type) ?: throw SupportNotFoundException("Invalid support ${it.type} not found")
         visitEntity.support.add(createVisitSupport(visitEntity, it.type, it.text))
       }
-    }
-
-    createVisitRequest.visitNotes?.let { visitNotes ->
-      visitNotes.distinctBy { it.type }.forEach {
-        visitEntity.visitNotes.add(createVisitNote(visitEntity, it.type, it.text))
-      }
-    }
-
-    createVisitRequest.legacyData?.let {
-      saveLegacyData(visitEntity, it.leadVisitorId)
     }
 
     return VisitDto(visitEntity)
@@ -174,15 +162,6 @@ class VisitService(
       text = text,
       visit = visit
     )
-  }
-
-  private fun saveLegacyData(visit: Visit, leadPersonId: Long) {
-    val legacyData = LegacyData(
-      visitId = visit.id,
-      leadPersonId = leadPersonId
-    )
-
-    legacyDataRepository.saveAndFlush(legacyData)
   }
 
   private fun createVisitContact(visit: Visit, name: String, telephone: String): VisitContact {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitSupport
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitVisitor
 import uk.gov.justice.digital.hmpps.visitscheduler.model.specification.VisitSpecification
-import uk.gov.justice.digital.hmpps.visitscheduler.repository.LegacyDataRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SupportTypeRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.util.function.Supplier

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
@@ -56,7 +56,7 @@ class CreateVisitTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `migrate visit`() {
+  fun `created visit`() {
 
     // Given
     val jsonBody = BodyInserters.fromValue(
@@ -90,7 +90,7 @@ class CreateVisitTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when migrate visit has no visitors then bad request is returned`() {
+  fun `when visit has no visitors then bad request is returned`() {
 
     // Given
     val createVisitRequest = CreateVisitRequestDto(
@@ -115,7 +115,7 @@ class CreateVisitTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `migrate visit - duplicates are ignored`() {
+  fun `created visit - duplicates are ignored`() {
 
     // Given
 
@@ -154,7 +154,7 @@ class CreateVisitTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `migrate visit - invalid support`() {
+  fun `created visit - invalid support`() {
 
     // Given
 
@@ -181,7 +181,7 @@ class CreateVisitTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `migrate visit - invalid request`() {
+  fun `created visit - invalid request`() {
 
     // Given
     val jsonBody = BodyInserters.fromValue(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
-import org.springframework.http.ReactiveHttpOutputMessage
 import org.springframework.http.client.reactive.ClientHttpRequest
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import org.springframework.web.reactive.function.BodyInserter
@@ -201,7 +200,6 @@ class CreateVisitTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isUnauthorized
   }
-
 
   private fun callMigrateVisit(
     authHttpHeaders: (HttpHeaders) -> Unit,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
@@ -1,0 +1,219 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.integration
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ReactiveHttpOutputMessage
+import org.springframework.http.client.reactive.ClientHttpRequest
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+import org.springframework.web.reactive.function.BodyInserter
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateContactOnVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateSupportOnVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateVisitorOnVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitDeleter
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
+import java.time.LocalDateTime
+
+private const val TEST_END_POINT = "/visits"
+
+@DisplayName("POST /visits")
+class CreateVisitTest : IntegrationTestBase() {
+
+  private lateinit var roleVisitSchedulerHttpHeaders: (HttpHeaders) -> Unit
+
+  @Autowired
+  private lateinit var visitRepository: VisitRepository
+
+  @BeforeEach
+  internal fun setUp() {
+    roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
+  }
+
+  @AfterEach
+  internal fun deleteAllVisits() = visitDeleter(visitRepository)
+
+  private fun createVisitRequest(): CreateVisitRequestDto {
+    return CreateVisitRequestDto(
+      prisonId = "MDI",
+      prisonerId = "FF0000FF",
+      visitRoom = "A1",
+      visitType = VisitType.SOCIAL,
+      startTimestamp = visitTime,
+      endTimestamp = visitTime.plusHours(1),
+      visitStatus = VisitStatus.RESERVED,
+      visitRestriction = VisitRestriction.OPEN,
+      visitContact = CreateContactOnVisitRequestDto("John Smith", "01234 567890"),
+      visitors = listOf(CreateVisitorOnVisitRequestDto(123)),
+      visitorSupport = listOf(CreateSupportOnVisitRequestDto("OTHER", "Some Text")),
+    )
+  }
+
+  @Test
+  fun `migrate visit`() {
+
+    // Given
+    val jsonBody = BodyInserters.fromValue(
+      createVisitRequest()
+    )
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, jsonBody)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reference").isNotEmpty
+      .jsonPath("$.prisonId").isEqualTo("MDI")
+      .jsonPath("$.prisonerId").isEqualTo("FF0000FF")
+      .jsonPath("$.visitRoom").isEqualTo("A1")
+      .jsonPath("$.visitType").isEqualTo(VisitType.SOCIAL.name)
+      .jsonPath("$.startTimestamp").isEqualTo(visitTime.toString())
+      .jsonPath("$.endTimestamp").isEqualTo(visitTime.plusHours(1).toString())
+      .jsonPath("$.visitStatus").isEqualTo(VisitStatus.RESERVED.name)
+      .jsonPath("$.visitRestriction").isEqualTo(VisitRestriction.OPEN.name)
+      .jsonPath("$.visitContact.name").isNotEmpty
+      .jsonPath("$.visitContact.name").isEqualTo("John Smith")
+      .jsonPath("$.visitContact.telephone").isEqualTo("01234 567890")
+      .jsonPath("$.visitors.length()").isEqualTo(1)
+      .jsonPath("$.visitors[0].nomisPersonId").isEqualTo(123)
+      .jsonPath("$.visitorSupport.length()").isEqualTo(1)
+      .jsonPath("$.visitorSupport[0].type").isEqualTo("OTHER")
+      .jsonPath("$.visitorSupport[0].text").isEqualTo("Some Text")
+      .jsonPath("$.createdTimestamp").isNotEmpty
+  }
+
+  @Test
+  fun `migrate visit - duplicates are ignored`() {
+
+    // Given
+
+    val createVisitRequest = CreateVisitRequestDto(
+      prisonerId = "FF0000FF",
+      prisonId = "MDI",
+      startTimestamp = visitTime,
+      endTimestamp = visitTime.plusHours(1),
+      visitType = VisitType.SOCIAL,
+      visitStatus = VisitStatus.RESERVED,
+      visitRestriction = VisitRestriction.OPEN,
+      visitRoom = "A1",
+      visitContact = CreateContactOnVisitRequestDto("John Smith", "01234 567890"),
+      visitors = listOf(
+        CreateVisitorOnVisitRequestDto(123),
+        CreateVisitorOnVisitRequestDto(123)
+      ),
+      visitorSupport = listOf(
+        CreateSupportOnVisitRequestDto("OTHER", "Some Text"),
+        CreateSupportOnVisitRequestDto("OTHER", "Some Text")
+      )
+    )
+
+    val jsonBody = BodyInserters.fromValue(
+      createVisitRequest
+    )
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, jsonBody)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.visitors.length()").isEqualTo(1)
+      .jsonPath("$.visitorSupport.length()").isEqualTo(1)
+  }
+
+  @Test
+  fun `migrate visit - invalid support`() {
+
+    // Given
+
+    val migratedVisitRequestDto = CreateVisitRequestDto(
+      prisonerId = "FF0000FF",
+      prisonId = "MDI",
+      startTimestamp = visitTime,
+      endTimestamp = visitTime.plusHours(1),
+      visitType = VisitType.SOCIAL,
+      visitStatus = VisitStatus.RESERVED,
+      visitRestriction = VisitRestriction.OPEN,
+      visitRoom = "A1",
+      visitContact = CreateContactOnVisitRequestDto("John Smith", "01234 567890"),
+      visitorSupport = listOf(CreateSupportOnVisitRequestDto("ANYTHINGWILLDO")),
+    )
+
+    val jsonBody = BodyInserters.fromValue(migratedVisitRequestDto)
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, jsonBody)
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `migrate visit - invalid request`() {
+
+    // Given
+    val jsonBody = BodyInserters.fromValue(
+      mapOf("wrongProperty" to "wrongValue")
+    )
+
+    // When
+    val responseSpec = webTestClient.post().uri(TEST_END_POINT)
+      .headers(roleVisitSchedulerHttpHeaders)
+      .body(jsonBody)
+      .exchange()
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `access forbidden when no role`() {
+
+    // Given
+    val authHttpHeaders = setAuthorisation(roles = listOf())
+    val jsonBody = BodyInserters.fromValue(createVisitRequest())
+
+    // When
+    val responseSpec = callMigrateVisit(authHttpHeaders, jsonBody)
+
+    // Then
+    responseSpec.expectStatus().isForbidden
+  }
+
+  @Test
+  fun `unauthorised when no token`() {
+    // Given
+    val jsonBody = BodyInserters.fromValue(createVisitRequest())
+
+    // When
+    val responseSpec = webTestClient.post().uri(TEST_END_POINT)
+      .body(jsonBody)
+      .exchange()
+
+    // Then
+    responseSpec.expectStatus().isUnauthorized
+  }
+
+
+  private fun callMigrateVisit(
+    authHttpHeaders: (HttpHeaders) -> Unit,
+    jsonBody: BodyInserter<*, in ClientHttpRequest>?
+  ): ResponseSpec {
+    return webTestClient.post().uri(TEST_END_POINT)
+      .headers(authHttpHeaders)
+      .body(jsonBody)
+      .exchange()
+  }
+
+  companion object {
+    val visitTime: LocalDateTime = LocalDateTime.of(2021, 11, 1, 12, 30, 44)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/CreateVisitTest.kt
@@ -90,6 +90,31 @@ class CreateVisitTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when migrate visit has no visitors then bad request is returned`() {
+
+    // Given
+    val createVisitRequest = CreateVisitRequestDto(
+      prisonerId = "FF0000FF",
+      prisonId = "MDI",
+      startTimestamp = visitTime,
+      endTimestamp = visitTime.plusHours(1),
+      visitType = VisitType.SOCIAL,
+      visitStatus = VisitStatus.RESERVED,
+      visitRestriction = VisitRestriction.OPEN,
+      visitRoom = "A1",
+      visitContact = CreateContactOnVisitRequestDto("John Smith", "01234 567890")
+    )
+
+    val jsonBody = BodyInserters.fromValue(createVisitRequest)
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, jsonBody)
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+  }
+
+  @Test
   fun `migrate visit - duplicates are ignored`() {
 
     // Given


### PR DESCRIPTION
## What does this pull request do?

Removed migration code from create visit, because migration is handled via different end point 

## What is the intent behind these changes?

To avoid POC issues, and to increase maintainability and a adaptability of code base