### PR TITLE
VB-756 Migration endpoint restricted to migration roles

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/MigrateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/MigrateController.kt
@@ -25,7 +25,7 @@ class MigrateController(
   private val migrateVisitService: MigrateVisitService
 ) {
 
-  @PreAuthorize("hasRole('VISIT_SCHEDULER')")
+  @PreAuthorize("hasAnyRole('MIGRATE_VISITS', 'MIGRATION_ADMIN')")
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/MigrateVisitTest.kt
@@ -61,7 +61,7 @@ class MigrateVisitTest : IntegrationTestBase() {
 
   @BeforeEach
   internal fun setUp() {
-    roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
+    roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS"))
   }
 
   @AfterEach
@@ -535,8 +535,8 @@ class MigrateVisitTest : IntegrationTestBase() {
   }
 
   private fun callMigrateVisit(jsonString: String): ResponseSpec {
-    val responseSpec = webTestClient.post().uri(TEST_END_POINT)
-      .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
+    return webTestClient.post().uri(TEST_END_POINT)
+      .headers(roleVisitSchedulerHttpHeaders)
       .contentType(MediaType.APPLICATION_JSON)
       .body(
         BodyInserters.fromValue(
@@ -544,7 +544,6 @@ class MigrateVisitTest : IntegrationTestBase() {
         )
       )
       .exchange()
-    return responseSpec
   }
 
   private fun callMigrateVisit(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceTest.kt
@@ -168,7 +168,7 @@ class SessionServiceTest {
       val sessions = sessionService.getVisitSessions("MDI")
 
       // Then
-      assertThat(sessions).size().isEqualTo(5) // expiry date is inclusiv
+      assertThat(sessions).size().isEqualTo(5) // expiry date is inclusive
       assertDate(sessions[0].startTimestamp, "2021-01-06T11:30:00", WEDNESDAY)
       assertDate(sessions[1].startTimestamp, "2021-01-13T11:30:00", WEDNESDAY)
       assertDate(sessions[2].startTimestamp, "2021-01-20T11:30:00", WEDNESDAY)


### PR DESCRIPTION
## What does this pull request do?
Sets the pre-auth to a migration role independant of the visit scheduler roles

## What is the intent behind these changes?
Prevent unauthorised access to the migration endpoint