### PR TITLE
VB-1225 `applicationReference` missing on existing bookings

### DIFF
--- a/src/main/resources/db/migration/V2_05__fix_missing_application_reference_defect.sql
+++ b/src/main/resources/db/migration/V2_05__fix_missing_application_reference_defect.sql
@@ -1,0 +1,2 @@
+UPDATE visit SET application_reference = reference
+WHERE application_reference IS NULL OR  LENGTH(application_reference) = 0;


### PR DESCRIPTION
## What does this pull request do?

fixes `applicationReference` missing on existing bookings

## What is the intent behind these changes?

to fix a bug, other wise old visits will not be avalable