### PR TITLE
VB-1213 Amending to solve booking count issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -175,7 +175,7 @@ class VisitController(
     @PathVariable reference: String,
     @RequestBody @Valid reserveVisitSlotDto: ReserveVisitSlotDto
   ): VisitDto {
-    return visitService.reserveVisitSlot(reference.trim(), reserveVisitSlotDto)
+    return visitService.changeBookedVisit(reference.trim(), reserveVisitSlotDto)
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -50,7 +50,7 @@ class VisitController(
   @PostMapping(VISIT_RESERVE_SLOT)
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
-    summary = "Reserve a slot (date/time slot) for a visit ",
+    summary = "Reserve a slot (date/time slot) for a visit (a starting point)",
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(
@@ -91,7 +91,7 @@ class VisitController(
   @PutMapping(VISIT_RESERVED_SLOT_CHANGE)
   @ResponseStatus(HttpStatus.OK)
   @Operation(
-    summary = "Change a reserved slot and associated details for a visit ",
+    summary = "Change a reserved slot and associated details for a visit (before booking)",
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(
@@ -139,7 +139,7 @@ class VisitController(
   @PutMapping(VISIT_CHANGE)
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
-    summary = "Change a booked visit",
+    summary = "Change a booked visit, (a starting point)",
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(
@@ -182,7 +182,7 @@ class VisitController(
   @PutMapping(VISIT_BOOK)
   @ResponseStatus(HttpStatus.OK)
   @Operation(
-    summary = "Book a visit",
+    summary = "Book a visit (end of flow)",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/VisitStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/VisitStatus.kt
@@ -5,6 +5,7 @@ enum class VisitStatus(
   val description: String,
 ) {
   RESERVED("Reserved"),
+  CHANGING("Changing"),
   BOOKED("Booked"),
   CANCELLED("Cancelled")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -16,12 +16,13 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
 
   @Query(
     "SELECT v.applicationReference FROM Visit v " +
-      "WHERE v.visitStatus = 'RESERVED' AND v.modifyTimestamp < :expiredDateAndTime"
+      "WHERE (v.visitStatus = 'RESERVED' OR v.visitStatus = 'CHANGING')" +
+      " AND v.modifyTimestamp < :expiredDateAndTime"
   )
   fun findExpiredApplicationReferences(expiredDateAndTime: LocalDateTime): List<String>
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  fun deleteAllByApplicationReferenceInAndVisitStatus(applicationReference: List<String>, status: VisitStatus)
+  fun deleteAllByApplicationReferenceInAndVisitStatusIn(applicationReference: List<String>, status: List<VisitStatus>)
 
   fun findByReference(reference: String): Visit?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -84,4 +84,9 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
     "SELECT v FROM Visit v WHERE v.reference = :reference AND v.visitStatus = 'BOOKED' "
   )
   fun findBookedVisit(reference: String): Visit?
+
+  @Query(
+    "SELECT CASE WHEN (COUNT(v) = 1) THEN TRUE ELSE FALSE END  FROM Visit v WHERE v.reference = :bookingReference AND v.visitStatus = 'BOOKED' "
+  )
+  fun isValidBookingReference(bookingReference: String): Boolean
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -58,7 +58,7 @@ class VisitService(
         prisonId = reserveVisitSlotDto.prisonId,
         visitRoom = reserveVisitSlotDto.visitRoom,
         visitType = reserveVisitSlotDto.visitType,
-        visitStatus = getStartingStatus(bookingReference, prisonId= reserveVisitSlotDto.prisonId, prisonerId = reserveVisitSlotDto.prisonerId, startTimestamp = reserveVisitSlotDto.startTimestamp),
+        visitStatus = getStartingStatus(bookingReference, prisonId = reserveVisitSlotDto.prisonId, prisonerId = reserveVisitSlotDto.prisonerId, startTimestamp = reserveVisitSlotDto.startTimestamp),
         visitRestriction = reserveVisitSlotDto.visitRestriction,
         visitStart = reserveVisitSlotDto.startTimestamp,
         visitEnd = reserveVisitSlotDto.endTimestamp,
@@ -87,7 +87,7 @@ class VisitService(
     return VisitDto(visitEntity)
   }
 
-  private fun getStartingStatus(bookingReference: String, prisonId: String? =null, prisonerId : String?=null,startTimestamp:LocalDateTime ) : VisitStatus {
+  private fun getStartingStatus(bookingReference: String, prisonId: String? = null, prisonerId: String? = null, startTimestamp: LocalDateTime): VisitStatus {
 
     val bookedVisit = this.visitRepository.findBookedVisit(bookingReference)
 
@@ -106,8 +106,8 @@ class VisitService(
 
     changeVisitSlotRequestDto.visitRestriction?.let { visitRestriction -> visitEntity.visitRestriction = visitRestriction }
     changeVisitSlotRequestDto.startTimestamp?.let {
-        visitEntity.visitStart = it
-        visitEntity.visitStatus = getStartingStatus(visitEntity.reference, startTimestamp = changeVisitSlotRequestDto.startTimestamp)
+      visitEntity.visitStart = it
+      visitEntity.visitStatus = getStartingStatus(visitEntity.reference, startTimestamp = changeVisitSlotRequestDto.startTimestamp)
     }
     changeVisitSlotRequestDto.endTimestamp?.let { visitEnd -> visitEntity.visitEnd = visitEnd }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/task/VisitTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/task/VisitTask.kt
@@ -27,7 +27,7 @@ class VisitTask(
     val expiredApplicationReferences = visitService.findExpiredApplicationReferences()
     log.debug("Expired visits: ${expiredApplicationReferences.count()}")
     if (expiredApplicationReferences.isNotEmpty()) {
-      visitService.deleteAllReservedVisitsByApplicationReference(expiredApplicationReferences)
+      visitService.deleteAllExpiredVisitsByApplicationReference(expiredApplicationReferences)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/ChangeBookedVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/ChangeBookedVisitTest.kt
@@ -106,12 +106,12 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
   }
 
   @Test
-  fun `change visit has given reference - with new application`() {
+  fun `change visit has given reference`() {
 
     // Given
     val reference = bookedVisit.reference
 
-    val reserveVisitSlotDto = createReserveVisitSlotDto(startTimestamp = bookedVisit.visitStart.minusHours(10))
+    val reserveVisitSlotDto = createReserveVisitSlotDto()
 
     // When
     val responseSpec = callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, reference)
@@ -129,7 +129,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
     assertThat(reservedVisit).isNotNull
     reservedVisit?.let {
       assertThat(reservedVisit.id).isNotEqualTo(bookedVisit.id)
-      assertThat(reservedVisit.visitStatus).isEqualTo(VisitStatus.RESERVED)
+      assertThat(reservedVisit.visitStatus).isEqualTo(VisitStatus.CHANGING)
       verify(telemetryClient).trackEvent(
         eq("visit-scheduler-prison-visit-created"),
         org.mockito.kotlin.check {
@@ -141,7 +141,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
           assertThat(it["visitRoom"]).isEqualTo(reservedVisit.visitRoom)
           assertThat(it["visitRestriction"]).isEqualTo(reservedVisit.visitRestriction.name)
           assertThat(it["visitStart"]).isEqualTo(reservedVisit.visitStart.toString())
-          assertThat(it["visitStatus"]).isEqualTo("RESERVED")
+          assertThat(it["visitStatus"]).isEqualTo(VisitStatus.CHANGING.name)
         },
         isNull()
       )
@@ -150,12 +150,10 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
   }
 
   @Test
-  fun `change visit with given reference from another booked visit - with no new application`() {
-
+  fun `changed booked visit creates new visit when prisonId has changed`() {
     // Given
-
-    val reserveVisitSlotDto = createReserveVisitSlotDto()
     val reference = bookedVisit.reference
+    val reserveVisitSlotDto = createReserveVisitSlotDto(prisonId = "NEW" + bookedVisit.prisonId)
 
     // When
     val responseSpec = callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, reference)
@@ -167,44 +165,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
       .returnResult()
 
     val visit = objectMapper.readValue(returnResult.responseBody, VisitDto::class.java)
-
-    val reservedVisit = visitRepository.findByApplicationReference(visit.applicationReference)
-
-    assertThat(reservedVisit).isNotNull
-    reservedVisit?.let {
-      assertThat(reservedVisit.id).isEqualTo(bookedVisit.id)
-      assertThat(reservedVisit.visitStatus).isEqualTo(VisitStatus.BOOKED)
-      // And
-
-      verify(telemetryClient).trackEvent(
-        eq("visit-scheduler-prison-visit-updated"),
-        org.mockito.kotlin.check {
-          assertThat(it["reference"]).isEqualTo(visit.reference)
-          assertThat(it["reference"]).isEqualTo(visit.reference)
-          assertThat(it["prisonerId"]).isEqualTo(visit.prisonerId)
-          assertThat(it["prisonId"]).isEqualTo(visit.prisonId)
-          assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
-          assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
-          assertThat(it["visitStatus"]).isEqualTo("BOOKED")
-        },
-        isNull()
-      )
-
-      verify(telemetryClient, times(1)).trackEvent(eq("visit-scheduler-prison-visit-updated"), any(), isNull())
-    }
-  }
-
-  @Test
-  fun `changed booked visit creates new visit when prisonId has changed`() {
-    // Given
-    val reference = bookedVisit.reference
-    val reserveVisitSlotDto = createReserveVisitSlotDto(prisonId = "NEW" + bookedVisit.prisonId)
-
-    // When
-    callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, reference)
-
-    // Then
-    assertThat(visitRepository.findAllByReference(reference).size).isEqualTo(2)
+    assertThat(visitRepository.findByApplicationReference(visit.applicationReference)!!.visitStatus).isEqualTo(VisitStatus.RESERVED)
   }
 
   @Test
@@ -214,10 +175,16 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
     val reserveVisitSlotDto = createReserveVisitSlotDto(prisonerId = "NEW" + bookedVisit.prisonerId)
 
     // When
-    callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, reference)
+    val responseSpec = callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, reference)
 
     // Then
-    assertThat(visitRepository.findAllByReference(reference).size).isEqualTo(2)
+    val returnResult = responseSpec.expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reference").isEqualTo(reference)
+      .returnResult()
+
+    val visit = objectMapper.readValue(returnResult.responseBody, VisitDto::class.java)
+    assertThat(visitRepository.findByApplicationReference(visit.applicationReference)!!.visitStatus).isEqualTo(VisitStatus.RESERVED)
   }
 
   @Test
@@ -227,10 +194,16 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
     val reserveVisitSlotDto = createReserveVisitSlotDto(startTimestamp = bookedVisit.visitStart.minusDays(1))
 
     // When
-    callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, reference)
+    val responseSpec = callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, reference)
 
     // Then
-    assertThat(visitRepository.findAllByReference(reference).size).isEqualTo(2)
+    val returnResult = responseSpec.expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reference").isEqualTo(reference)
+      .returnResult()
+
+    val visit = objectMapper.readValue(returnResult.responseBody, VisitDto::class.java)
+    assertThat(visitRepository.findByApplicationReference(visit.applicationReference)!!.visitStatus).isEqualTo(VisitStatus.RESERVED)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/ChangeReservedSlotTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/ChangeReservedSlotTest.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitorSupportDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callVisitReserveSlotChange
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.getVisitReserveSlotChangeUrl
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitContactCreator
-import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitCreator
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitDeleter
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitNoteCreator
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitSupportCreator
@@ -37,6 +36,8 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.VISIT_COM
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.VISIT_OUTCOMES
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.RESERVED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
@@ -61,30 +62,40 @@ class ChangeReservedSlotTest(@Autowired private val objectMapper: ObjectMapper) 
     val visitTime: LocalDateTime = LocalDateTime.of(2021, 11, 1, 12, 30, 44)
   }
 
+  private fun createVisit(
+    visitStatus: VisitStatus = RESERVED,
+    prisonerId: String = "FF0000BB",
+    prisonId: String = "BBB",
+    visitRoom: String = "B1",
+    visitStart: LocalDateTime = visitTime.plusDays(2),
+    visitEnd: LocalDateTime = visitTime.plusDays(2).plusHours(1),
+    visitType: VisitType = VisitType.SOCIAL,
+    visitRestriction: VisitRestriction = VisitRestriction.OPEN,
+    reference: String = ""
+  ): Visit {
+
+    return visitRepository.saveAndFlush(
+      Visit(
+        visitStatus = visitStatus,
+        prisonerId = prisonerId,
+        prisonId = prisonId,
+        visitRoom = visitRoom,
+        visitStart = visitStart,
+        visitEnd = visitEnd,
+        visitType = visitType,
+        visitRestriction = visitRestriction,
+        _reference = reference
+      )
+    )
+  }
+
   @BeforeEach
   internal fun setUp() {
 
     roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
 
-    visitMin = visitCreator(visitRepository)
-      .withPrisonerId("FF0000AA")
-      .withPrisonId("AAA")
-      .withVisitRoom("A1")
-      .withVisitStart(visitTime)
-      .withVisitEnd(visitTime.plusHours(1))
-      .withVisitType(VisitType.SOCIAL)
-      .withVisitStatus(VisitStatus.RESERVED)
-      .save()
-
-    visitFull = visitCreator(visitRepository)
-      .withPrisonerId("FF0000BB")
-      .withPrisonId("BBB")
-      .withVisitRoom("B1")
-      .withVisitStart(visitTime.plusDays(2))
-      .withVisitEnd(visitTime.plusDays(2).plusHours(1))
-      .withVisitType(VisitType.SOCIAL)
-      .withVisitStatus(VisitStatus.RESERVED)
-      .save()
+    visitMin = createVisit(visitStatus = RESERVED)
+    visitFull = createVisit(visitStatus = RESERVED)
 
     visitNoteCreator(visit = visitFull, text = "Some text outcomes", type = VISIT_OUTCOMES)
     visitNoteCreator(visit = visitFull, text = "Some text concerns", type = VISITOR_CONCERN)
@@ -104,8 +115,8 @@ class ChangeReservedSlotTest(@Autowired private val objectMapper: ObjectMapper) 
     // Given
 
     val updateRequest = ChangeVisitSlotRequestDto(
-      startTimestamp = visitTime.plusDays(2),
-      endTimestamp = visitTime.plusDays(2).plusHours(1),
+      startTimestamp = visitFull.visitStart,
+      endTimestamp = visitFull.visitEnd,
       visitRestriction = VisitRestriction.CLOSED,
       visitContact = ContactDto("John Smith", "01234 567890"),
       visitors = setOf(VisitorDto(123L, visitContact = true), VisitorDto(124L, visitContact = false)),
@@ -130,7 +141,7 @@ class ChangeReservedSlotTest(@Autowired private val objectMapper: ObjectMapper) 
       .jsonPath("$.startTimestamp").isEqualTo(updateRequest.startTimestamp.toString())
       .jsonPath("$.endTimestamp").isEqualTo(updateRequest.endTimestamp.toString())
       .jsonPath("$.visitType").isEqualTo(visitFull.visitType.name)
-      .jsonPath("$.visitStatus").isEqualTo(VisitStatus.RESERVED.name)
+      .jsonPath("$.visitStatus").isEqualTo(RESERVED.name)
       .jsonPath("$.visitRestriction").isEqualTo(updateRequest.visitRestriction!!.name)
       .jsonPath("$.visitContact.name").isEqualTo(updateRequest.visitContact!!.name)
       .jsonPath("$.visitContact.telephone").isEqualTo(updateRequest.visitContact!!.telephone)
@@ -156,6 +167,38 @@ class ChangeReservedSlotTest(@Autowired private val objectMapper: ObjectMapper) 
       isNull()
     )
     verify(telemetryClient, times(1)).trackEvent(eq("visit-scheduler-prison-visit-updated"), any(), isNull())
+  }
+
+  @Test
+  fun `change reserved slot by application reference - start date has not change`() {
+
+    // Given
+    val visitBooked = createVisit(visitStatus = BOOKED)
+    val visitReserved = createVisit(visitStatus = RESERVED, reference = visitBooked.reference)
+
+    val updateRequest = ChangeVisitSlotRequestDto(
+      startTimestamp = visitReserved.visitStart,
+      endTimestamp = visitReserved.visitEnd,
+      visitRestriction = visitReserved.visitRestriction,
+      visitContact = ContactDto("John Smith", "01234 567890"),
+      visitors = setOf(VisitorDto(123L, visitContact = true), VisitorDto(124L, visitContact = false)),
+      visitorSupport = setOf(VisitorSupportDto("OTHER", "Some Text")),
+    )
+
+    val applicationReference = visitReserved.applicationReference
+
+    // When
+    val responseSpec = callVisitReserveSlotChange(webTestClient, roleVisitSchedulerHttpHeaders, updateRequest, applicationReference)
+
+    // Then
+
+    responseSpec
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reference").isEqualTo(visitReserved.reference)
+      .jsonPath("$.applicationReference").isEqualTo(applicationReference)
+      .jsonPath("$.visitStatus").isEqualTo(VisitStatus.CHANGING.name)
+      .returnResult()
   }
 
   @Test


### PR DESCRIPTION
New approach reverted changes from this morning,
now uses status

## What does this pull request do?

it makes the booking count more accurate and does not mess up the confirm flow 

## What is the intent behind these changes?

to help the use know how many slots are booked