### PR TITLE
VB-1242 Using getBookedVisit on /visits/{reference}

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -425,7 +425,7 @@ class VisitController(
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")
   @GetMapping(GET_VISIT_BY_REFERENCE)
   @Operation(
-    summary = "Get a booked visit",
+    summary = "Get a visit",
     description = "Retrieve visit by visit reference",
     responses = [
       ApiResponse(
@@ -454,10 +454,10 @@ class VisitController(
       ),
     ]
   )
-  fun getBookedVisitByReference(
+  fun getVisitByReference(
     @Schema(description = "reference", example = "v9-d7-ed-7u", required = true)
     @PathVariable reference: String
   ): VisitDto {
-    return visitService.getBookedVisitByReference(reference.trim())
+    return visitService.getVisitByReference(reference.trim())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -384,8 +384,8 @@ class VisitService(
   }
 
   @Transactional(readOnly = true)
-  fun getBookedVisitByReference(reference: String): VisitDto {
-    return VisitDto(visitRepository.findBookedVisit(reference) ?: throw VisitNotFoundException("Visit reference $reference not found"))
+  fun getVisitByReference(reference: String): VisitDto {
+    return VisitDto(visitRepository.findByReference(reference) ?: throw VisitNotFoundException("Visit reference $reference not found"))
   }
 
   private fun createVisitNote(visit: Visit, type: VisitNoteType, text: String): VisitNote {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/VisitByReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/VisitByReferenceTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.helper.callVisitByReference
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitCreator
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.visitDeleter
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.CANCELLED
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
 
@@ -33,12 +34,33 @@ class VisitByReferenceTest : IntegrationTestBase() {
   internal fun deleteAllVisits() = visitDeleter(visitRepository)
 
   @Test
-  fun `Visit by reference`() {
+  fun `Booked visit by reference`() {
 
     // Given
     val createdVisit = visitCreator(visitRepository)
       .withPrisonerId("FF0000AA")
       .withVisitStatus(BOOKED)
+      .withVisitStart(visitTime)
+      .save()
+
+    val reference = createdVisit.reference
+
+    // When
+    val responseSpec = callVisitByReference(webTestClient, reference, roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reference").isEqualTo(reference)
+  }
+
+  @Test
+  fun `Canceled visit by reference`() {
+
+    // Given
+    val createdVisit = visitCreator(visitRepository)
+      .withPrisonerId("FF0000AA")
+      .withVisitStatus(CANCELLED)
       .withVisitStart(visitTime)
       .save()
 


### PR DESCRIPTION
## What does this pull request do?

Fixes a defect VB-1242 - Using getBookedVisit on /visits/{reference} should be allowing to get booked and canceled visits

## What is the intent behind these changes?

to allow the cancellation sync code to get canceled Visits 