### PR TITLE
VB-1251: Allow visit status to go from RESERVED to CHANGING

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -121,7 +121,7 @@ class VisitService(
     ) {
       return RESERVED
     }
-    return visitEntity.visitStatus
+    return CHANGING
   }
 
   fun changeVisitSlot(applicationReference: String, changeVisitSlotRequestDto: ChangeVisitSlotRequestDto): VisitDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/ChangeReservedSlotTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/ChangeReservedSlotTest.kt
@@ -275,6 +275,58 @@ class ChangeReservedSlotTest(@Autowired private val objectMapper: ObjectMapper) 
   }
 
   @Test
+  fun `change reserved slot by application reference - start date has changed back to match booked slot`() {
+
+    // Given
+    val visitBooked = createVisit(visitStatus = BOOKED)
+    val visitReserved = createVisit(visitStatus = RESERVED, reference = visitBooked.reference)
+
+    val updateRequest = ChangeVisitSlotRequestDto(
+      startTimestamp = visitBooked.visitStart,
+      visitContact = ContactDto("John Smith", "01234 567890")
+    )
+
+    val applicationReference = visitReserved.applicationReference
+
+    // When
+    val responseSpec = callVisitReserveSlotChange(webTestClient, roleVisitSchedulerHttpHeaders, updateRequest, applicationReference)
+
+    // Then
+
+    responseSpec
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.visitStatus").isEqualTo(CHANGING.name)
+      .returnResult()
+  }
+
+  @Test
+  fun `change reserved slot by application reference - start restriction has changed back to match booked slot`() {
+
+    // Given
+    val visitBooked = createVisit(visitStatus = BOOKED)
+    val visitReserved = createVisit(visitStatus = RESERVED, reference = visitBooked.reference)
+
+    val updateRequest = ChangeVisitSlotRequestDto(
+      visitRestriction = visitBooked.visitRestriction,
+      visitContact = ContactDto("John Smith", "01234 567890")
+    )
+
+    val applicationReference = visitReserved.applicationReference
+
+    // When
+    val responseSpec = callVisitReserveSlotChange(webTestClient, roleVisitSchedulerHttpHeaders, updateRequest, applicationReference)
+
+    // Then
+
+    responseSpec
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.visitStatus").isEqualTo(CHANGING.name)
+      .returnResult()
+  }
+
+  @Test
   fun `change reserved slot by application reference - only one visit contact allowed`() {
 
     // Given


### PR DESCRIPTION
## What does this pull request do?

When amending a `BOOKED` visit and the reserved slot changes, if the visit now matches the restriction and date/time of the `BOOKED` visit then move the status to `CHANGING` rather than keeping it `RESERVED`.

## What is the intent behind these changes?

To make sure the status of the visit being amended matches what is happening and the capacity counts remain accurate.