### PR TITLE
Feature/vb 1253 server side prevent cancellation or amendment after visit start time

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -18,7 +18,6 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.temporal.ChronoUnit
 
 @Component
 class VisitEntityHelper(
@@ -30,7 +29,7 @@ class VisitEntityHelper(
     prisonerId: String = "FF0000AA",
     prisonId: String = "MDI",
     visitRoom: String = "A1",
-    visitStart: LocalDateTime = LocalDateTime.now().plusDays(2).truncatedTo(ChronoUnit.SECONDS),
+    visitStart: LocalDateTime = LocalDateTime.of((LocalDateTime.now().year + 1), 11, 1, 12, 30, 44),
     visitEnd: LocalDateTime = visitStart.plusHours(1),
     visitType: VisitType = VisitType.SOCIAL,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -29,7 +29,7 @@ class VisitEntityHelper(
     prisonerId: String = "FF0000AA",
     prisonId: String = "MDI",
     visitRoom: String = "A1",
-    visitStart: LocalDateTime = LocalDateTime.of(2021, 11, 1, 12, 30, 44),
+    visitStart: LocalDateTime = LocalDateTime.now().plusDays(2),
     visitEnd: LocalDateTime = visitStart.plusHours(1),
     visitType: VisitType = VisitType.SOCIAL,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -18,6 +18,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.temporal.ChronoUnit
 
 @Component
 class VisitEntityHelper(
@@ -29,7 +30,7 @@ class VisitEntityHelper(
     prisonerId: String = "FF0000AA",
     prisonId: String = "MDI",
     visitRoom: String = "A1",
-    visitStart: LocalDateTime = LocalDateTime.now().plusDays(2),
+    visitStart: LocalDateTime = LocalDateTime.now().plusDays(2).truncatedTo(ChronoUnit.SECONDS),
     visitEnd: LocalDateTime = visitStart.plusHours(1),
     visitType: VisitType = VisitType.SOCIAL,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
@@ -273,7 +273,7 @@ class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integ
     // Then
     responseSpec.expectStatus().isBadRequest
       .expectBody()
-      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to cancel an expired visit")
+      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to change / cancel an expired visit")
       .jsonPath("$.developerMessage").isEqualTo("Visit with booking reference - ${expiredVisit.reference} is in the past, it cannot be cancelled")
 
     // And

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
+import java.time.LocalDateTime
 
 @DisplayName("Put /visits/{reference}/cancel")
 class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : IntegrationTestBase() {
@@ -252,8 +253,40 @@ class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integ
     responseSpec.expectStatus().isUnauthorized
   }
 
+  @Test
+  fun `cancel expired visit returns error`() {
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.CANCELLATION,
+      "No longer joining."
+    )
+    // Given
+    val visit = createExpiredVisitAndSave()
+
+    // When
+    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+      .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
+      .body(
+        BodyInserters.fromValue(outcomeDto)
+      )
+      .exchange()
+
+    // Then
+
+    responseSpec.expectStatus().isBadRequest
+      .expectBody()
+      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to cancel an expired visit")
+      .jsonPath("$.developerMessage").isEqualTo("Visit with booking reference - ${visit.reference} is in the past, it cannot be cancelled")
+
+    // And
+    verify(telemetryClient, times(1)).trackEvent(eq("visit-bad-request-error"), any(), isNull())
+    verify(telemetryClient, times(0)).trackEvent(eq("visit.cancelled-domain-event"), any(), isNull())
+  }
+
   private fun createVisitAndSave(): Visit {
-    val visit = visitEntityHelper.create(visitStatus = BOOKED)
-    return visit
+    return visitEntityHelper.create(visitStatus = BOOKED)
+  }
+
+  private fun createExpiredVisitAndSave(): Visit {
+    return visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(2))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @DisplayName("Put /visits/{reference}/cancel")
 class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : IntegrationTestBase() {
@@ -272,7 +271,6 @@ class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integ
       .exchange()
 
     // Then
-
     responseSpec.expectStatus().isBadRequest
       .expectBody()
       .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to cancel an expired visit")
@@ -288,6 +286,8 @@ class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integ
   }
 
   private fun createExpiredVisitAndSave(): Visit {
-    return visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(2).truncatedTo(ChronoUnit.SECONDS), reference = "expired-visit")
+    val visitStart = LocalDateTime.of((LocalDateTime.now().year - 1), 11, 1, 12, 30, 44)
+
+    return visitEntityHelper.create(visitStatus = BOOKED, visitStart = visitStart, reference = "expired-visit")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
@@ -243,7 +243,7 @@ class BookVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integra
     responseSpec
       .expectStatus().isBadRequest
       .expectBody()
-      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to change an expired visit")
+      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to change / cancel an expired visit")
       .jsonPath("$.developerMessage").isEqualTo("Visit with booking reference - $reference is in the past, it cannot be changed")
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.RESERVED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("PUT $VISIT_BOOK")
@@ -219,11 +220,11 @@ class BookVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integra
 
   @Test
   fun `Amend and book expired visit - returns bad request error `() {
+    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, reference = "expired-visit", visitStart = LocalDateTime.now().minusDays(2).truncatedTo(ChronoUnit.SECONDS))
+    val reservedVisit = visitEntityHelper.create(reference = expiredVisit.reference)
 
     // Given
-    val reference = reservedVisit.reference
-
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, reference = reference, visitStart = LocalDateTime.now().minusDays(2))
+    val reference = expiredVisit.reference
 
     visitEntityHelper.createNote(visit = expiredVisit, text = "Some text outcomes", type = VISIT_OUTCOMES)
     visitEntityHelper.createNote(visit = expiredVisit, text = "Some text concerns", type = VISITOR_CONCERN)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.RESERVED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("PUT $VISIT_BOOK")
@@ -220,7 +219,8 @@ class BookVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integra
 
   @Test
   fun `Amend and book expired visit - returns bad request error `() {
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, reference = "expired-visit", visitStart = LocalDateTime.now().minusDays(2).truncatedTo(ChronoUnit.SECONDS))
+    val visitStart = LocalDateTime.of((LocalDateTime.now().year - 1), 11, 1, 12, 30, 44)
+    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, reference = "expired-visit", visitStart = visitStart)
     val reservedVisit = visitEntityHelper.create(reference = expiredVisit.reference)
 
     // Given

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.BOOKED
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @DisplayName("Put $VISIT_CANCEL")
 class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : IntegrationTestBase() {
@@ -258,7 +259,7 @@ class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integ
 
   @Test
   fun `cancel expired visit returns bad request error`() {
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(2))
+    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(2).truncatedTo(ChronoUnit.SECONDS), reference = "expired-visit")
 
     val outcomeDto = OutcomeDto(
       OutcomeStatus.PRISONER_CANCELLED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
@@ -273,7 +273,7 @@ class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integ
     // Then
     responseSpec.expectStatus().isBadRequest
       .expectBody()
-      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to cancel an expired visit")
+      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to change / cancel an expired visit")
       .jsonPath("$.developerMessage").isEqualTo("Visit with booking reference - $reference is in the past, it cannot be cancelled")
 
     // And

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.BOOKED
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @DisplayName("Put $VISIT_CANCEL")
 class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : IntegrationTestBase() {
@@ -259,7 +258,8 @@ class CancelVisitTest(@Autowired private val objectMapper: ObjectMapper) : Integ
 
   @Test
   fun `cancel expired visit returns bad request error`() {
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(2).truncatedTo(ChronoUnit.SECONDS), reference = "expired-visit")
+    val visitStart = LocalDateTime.of((LocalDateTime.now().year - 1), 11, 1, 12, 30, 44)
+    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = visitStart, reference = "expired-visit")
 
     val outcomeDto = OutcomeDto(
       OutcomeStatus.PRISONER_CANCELLED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ChangeBookedVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ChangeBookedVisitTest.kt
@@ -39,7 +39,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("PUT $VISIT_CHANGE")
@@ -128,8 +127,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
           assertThat(it["visitType"]).isEqualTo(reservedVisit.visitType.name)
           assertThat(it["visitRoom"]).isEqualTo(reservedVisit.visitRoom)
           assertThat(it["visitRestriction"]).isEqualTo(reservedVisit.visitRestriction.name)
-          assertThat(it["visitStart"]).isNotEmpty
-          assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS)).isEqualTo(reservedVisit.visitStart.truncatedTo(ChronoUnit.SECONDS))
+          assertThat(it["visitStart"]).isEqualTo(reservedVisit.visitStart.toString())
           assertThat(it["visitStatus"]).isEqualTo(VisitStatus.CHANGING.name)
         },
         isNull()
@@ -182,8 +180,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isNotEmpty
-        assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS)).isEqualTo(visit.startTimestamp.truncatedTo(ChronoUnit.SECONDS))
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -219,8 +216,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isNotEmpty
-        assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS)).isEqualTo(visit.startTimestamp.truncatedTo(ChronoUnit.SECONDS))
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -256,8 +252,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isNotEmpty
-        assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS)).isEqualTo(visit.startTimestamp.truncatedTo(ChronoUnit.SECONDS))
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -292,8 +287,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isNotEmpty
-        assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS)).isEqualTo(visit.startTimestamp.truncatedTo(ChronoUnit.SECONDS))
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -364,26 +358,11 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
   }
 
   @Test
-  fun `change visit that has already expired a day back`() {
+  fun `change visit that has already expired returns bad request`() {
     // Given
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.SECONDS), reference = "expired-visit-1")
+    val visitStart = LocalDateTime.of((LocalDateTime.now().year - 1), 11, 1, 12, 30, 44)
+    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = visitStart, reference = "expired-visit-1")
 
-    val reserveVisitSlotDto = createReserveVisitSlotDto()
-
-    // When
-    val responseSpec = callVisitChange(webTestClient, roleVisitSchedulerHttpHeaders, reserveVisitSlotDto, expiredVisit.reference)
-
-    // Then
-    responseSpec.expectStatus().isBadRequest
-      .expectBody()
-      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to change an expired visit")
-      .jsonPath("$.developerMessage").isEqualTo("Visit with booking reference - ${expiredVisit.reference} is in the past, it cannot be changed")
-  }
-
-  @Test
-  fun `change visit that has already expired - 2 minutes back`() {
-    // Given
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusMinutes(2).truncatedTo(ChronoUnit.SECONDS), reference = "expired-visit-2")
     val reserveVisitSlotDto = createReserveVisitSlotDto()
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ChangeBookedVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ChangeBookedVisitTest.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("PUT $VISIT_CHANGE")
@@ -127,7 +128,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
           assertThat(it["visitType"]).isEqualTo(reservedVisit.visitType.name)
           assertThat(it["visitRoom"]).isEqualTo(reservedVisit.visitRoom)
           assertThat(it["visitRestriction"]).isEqualTo(reservedVisit.visitRestriction.name)
-          assertThat(it["visitStart"]).isEqualTo(reservedVisit.visitStart.toString())
+          assertThat(it["visitStart"]).isEqualTo(reservedVisit.visitStart.format(DateTimeFormatter.ISO_DATE_TIME))
           assertThat(it["visitStatus"]).isEqualTo(VisitStatus.CHANGING.name)
         },
         isNull()
@@ -143,7 +144,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
           assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
           assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
           assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-          assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
+          assertThat(it["visitStart"]).isEqualTo(reservedVisit.visitStart.format(DateTimeFormatter.ISO_DATE_TIME))
           assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
         },
         isNull()
@@ -180,7 +181,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -216,7 +217,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -252,7 +253,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -287,7 +288,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
         assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()
@@ -371,7 +372,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
     // Then
     responseSpec.expectStatus().isBadRequest
       .expectBody()
-      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to change an expired visit")
+      .jsonPath("$.userMessage").isEqualTo("Validation failure: trying to change / cancel an expired visit")
       .jsonPath("$.developerMessage").isEqualTo("Visit with booking reference - ${expiredVisit.reference} is in the past, it cannot be changed")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ChangeBookedVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ChangeBookedVisitTest.kt
@@ -366,7 +366,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
   @Test
   fun `change visit that has already expired a day back`() {
     // Given
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(1))
+    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.SECONDS), reference = "expired-visit-1")
 
     val reserveVisitSlotDto = createReserveVisitSlotDto()
 
@@ -383,7 +383,7 @@ class ChangeBookedVisitTest(@Autowired private val objectMapper: ObjectMapper) :
   @Test
   fun `change visit that has already expired - 2 minutes back`() {
     // Given
-    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusMinutes(2))
+    val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = LocalDateTime.now().minusMinutes(2).truncatedTo(ChronoUnit.SECONDS), reference = "expired-visit-2")
     val reserveVisitSlotDto = createReserveVisitSlotDto()
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
@@ -42,6 +42,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.LegacyDataRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 private const val TEST_END_POINT = "/migrate-visits"
 
@@ -159,7 +160,8 @@ class MigrateVisitTest : IntegrationTestBase() {
         assertThat(it["visitType"]).isEqualTo(SOCIAL.name)
         assertThat(it["visitRoom"]).isEqualTo("A1")
         assertThat(it["visitRestriction"]).isEqualTo(OPEN.name)
-        assertThat(it["visitStart"]).isEqualTo(visitTime.toString())
+        assertThat(it["visitStart"]).isNotEmpty
+        assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS)).isEqualTo(visitTime.truncatedTo(ChronoUnit.SECONDS))
         assertThat(it["visitStatus"]).isEqualTo(BOOKED.name)
         assertThat(it["outcomeStatus"]).isEqualTo(COMPLETED_NORMALLY.name)
       },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
@@ -42,7 +42,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.LegacyDataRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 private const val TEST_END_POINT = "/migrate-visits"
 
@@ -160,8 +159,7 @@ class MigrateVisitTest : IntegrationTestBase() {
         assertThat(it["visitType"]).isEqualTo(SOCIAL.name)
         assertThat(it["visitRoom"]).isEqualTo("A1")
         assertThat(it["visitRestriction"]).isEqualTo(OPEN.name)
-        assertThat(it["visitStart"]).isNotEmpty
-        assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS)).isEqualTo(visitTime.truncatedTo(ChronoUnit.SECONDS))
+        assertThat(it["visitStart"]).isEqualTo(visitTime.toString())
         assertThat(it["visitStatus"]).isEqualTo(BOOKED.name)
         assertThat(it["outcomeStatus"]).isEqualTo(COMPLETED_NORMALLY.name)
       },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
@@ -42,6 +42,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.LegacyDataRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 private const val TEST_END_POINT = "/migrate-visits"
 
@@ -159,7 +160,7 @@ class MigrateVisitTest : IntegrationTestBase() {
         assertThat(it["visitType"]).isEqualTo(SOCIAL.name)
         assertThat(it["visitRoom"]).isEqualTo("A1")
         assertThat(it["visitRestriction"]).isEqualTo(OPEN.name)
-        assertThat(it["visitStart"]).isEqualTo(visitTime.toString())
+        assertThat(it["visitStart"]).isEqualTo(visitTime.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitStatus"]).isEqualTo(BOOKED.name)
         assertThat(it["outcomeStatus"]).isEqualTo(COMPLETED_NORMALLY.name)
       },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ReserveSlotTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ReserveSlotTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.RESERVED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType.SOCIAL
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("POST $VISIT_RESERVE_SLOT")
@@ -114,7 +115,7 @@ class ReserveSlotTest(@Autowired private val objectMapper: ObjectMapper) : Integ
         Assertions.assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         Assertions.assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         Assertions.assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        Assertions.assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
+        Assertions.assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         Assertions.assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ReserveSlotTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ReserveSlotTest.kt
@@ -31,7 +31,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.RESERVED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType.SOCIAL
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("POST $VISIT_RESERVE_SLOT")
@@ -115,9 +114,7 @@ class ReserveSlotTest(@Autowired private val objectMapper: ObjectMapper) : Integ
         Assertions.assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         Assertions.assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         Assertions.assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        Assertions.assertThat(it["visitStart"]).isNotEmpty
-        Assertions.assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS))
-          .isEqualTo(visit.startTimestamp.truncatedTo(ChronoUnit.SECONDS))
+        Assertions.assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
         Assertions.assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ReserveSlotTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ReserveSlotTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.RESERVED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType.SOCIAL
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("POST $VISIT_RESERVE_SLOT")
@@ -114,7 +115,9 @@ class ReserveSlotTest(@Autowired private val objectMapper: ObjectMapper) : Integ
         Assertions.assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
         Assertions.assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
         Assertions.assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
-        Assertions.assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.toString())
+        Assertions.assertThat(it["visitStart"]).isNotEmpty
+        Assertions.assertThat(LocalDateTime.parse(it["visitStart"]).truncatedTo(ChronoUnit.SECONDS))
+          .isEqualTo(visit.startTimestamp.truncatedTo(ChronoUnit.SECONDS))
         Assertions.assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
       },
       isNull()


### PR DESCRIPTION
## What does this pull request do?
VB-1253 changes - do not allow a visit to be amended or cancelled if the visit has expired i.e. the visit start date is in the past. Checks added to the following API calls -

PUT /visits/{reference}/change
PUT /visits/{reference}/cancel
PATCH /visits/{reference}/cancel
PUT /visits/{applicationReference}/book (if updating an existing visit)

## What is the intent behind these changes?
Fix for VB-1253, to avoid expired visits from being amended.
