### PR TITLE
Start Wiremock on a random port to avoid conflicts

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -81,7 +81,6 @@ abstract class IntegrationTestBase {
         registry.add("spring.flyway.url", pgContainer::getJdbcUrl)
         registry.add("spring.flyway.user", pgContainer::getUsername)
         registry.add("spring.flyway.password", pgContainer::getPassword)
-        registry.add("prison.api.url", prisonApiMockServer::baseUrl)
       }
 
       lsContainer?.run {
@@ -92,6 +91,8 @@ abstract class IntegrationTestBase {
             registry.add("hmpps.sqs.region") { it.second }
           }
       }
+
+      registry.add("prison.api.url", prisonApiMockServer::baseUrl)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -81,6 +81,7 @@ abstract class IntegrationTestBase {
         registry.add("spring.flyway.url", pgContainer::getJdbcUrl)
         registry.add("spring.flyway.user", pgContainer::getUsername)
         registry.add("spring.flyway.password", pgContainer::getPassword)
+        registry.add("prison.api.url", { -> "http://localhost:" + prisonApiMockServer.port() })
       }
 
       lsContainer?.run {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -81,7 +81,7 @@ abstract class IntegrationTestBase {
         registry.add("spring.flyway.url", pgContainer::getJdbcUrl)
         registry.add("spring.flyway.user", pgContainer::getUsername)
         registry.add("spring.flyway.password", pgContainer::getPassword)
-        registry.add("prison.api.url", { -> "http://localhost:" + prisonApiMockServer.port() })
+        registry.add("prison.api.url", prisonApiMockServer::baseUrl)
       }
 
       lsContainer?.run {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/PrisonApiMockServer.kt
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import org.springframework.http.MediaType
 
-class PrisonApiMockServer : WireMockServer(8092) {
+class PrisonApiMockServer : WireMockServer(0) {
 
   fun stubGetOffenderNonAssociation(offenderNo: String, nonAssociationId: String, effectiveDate: String, expiryDate: String? = null) {
     stubFor(

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,7 +27,6 @@ hmpps.auth.url: http://localhost:8090/auth
 
 prison:
   api:
-    url: http://localhost:8092
     timeout: 5s
 
 policy:


### PR DESCRIPTION
## What does this pull request do?

This PR changes the test setup to use a random port when WireMock is started. Otherwise, the tests won't run if the machine that runs them already has something running on port `8092`.

## What is the intent behind these changes?

Your friend from the [Testcontainers](https://github.com/testcontainers/testcontainers-java) project was looking at how the library is used in the wild, tried running tests and discovered the static port usage :)