### PR TITLE
VB-1312 - Update cron for deleteTask job to run every 10 minutes.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,7 +106,7 @@ policy:
 task:
   expired-visit:
     enabled: true
-    cron: 0 0 * * * *
+    cron: 0 0/10 * * * *
     validity-minutes: 20
 
 feature:


### PR DESCRIPTION


## What does this pull request do?

 Update to run job every 10 minutes instead of an hour to delete any expired visits more than 20 (set in validity-minutes) minutes old.


## What is the intent behind these changes?

Ensure expired visits are deleted at the earliest so that the slot is freed.