### PR TITLE
VB-1352 - Revert some changes made in VB-1296 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.ChangeVisitSlotRequestDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ReserveVisitSlotDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitFilter
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.service.VisitService
 import java.time.LocalDateTime
@@ -336,12 +337,14 @@ class VisitController(
     ) size: Int
   ): Page<VisitDto> {
     return visitService.findVisitsByFilterPageableDescending(
-      prisonerId = prisonerId?.trim(),
-      prisonId = prisonId.trim(),
-      startDateTime = startTimestamp,
-      endDateTime = endTimestamp,
-      nomisPersonId = nomisPersonId,
-      visitStatus = visitStatus,
+      VisitFilter(
+        prisonerId = prisonerId?.trim(),
+        prisonId = prisonId.trim(),
+        startDateTime = startTimestamp,
+        endDateTime = endTimestamp,
+        nomisPersonId = nomisPersonId,
+        visitStatus = visitStatus
+      ),
       page,
       size
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitControllerLegacy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitControllerLegacy.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitFilter
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.service.VisitService
 import java.time.LocalDateTime
@@ -99,12 +100,14 @@ class VisitControllerLegacy(
     ) visitStatus: VisitStatus?
   ): List<VisitDto> =
     visitService.findVisitsByFilter(
-      prisonerId = prisonerId?.trim(),
-      prisonId = prisonId.trim(),
-      startDateTime = startTimestamp,
-      endDateTime = endTimestamp,
-      nomisPersonId = nomisPersonId,
-      visitStatus = visitStatus
+      VisitFilter(
+        prisonerId = prisonerId?.trim(),
+        prisonId = prisonId.trim(),
+        startDateTime = startTimestamp,
+        endDateTime = endTimestamp,
+        nomisPersonId = nomisPersonId,
+        visitStatus = visitStatus
+      )
     )
 
   @Deprecated("This endpoint should be changed to :$VISIT_CANCEL", ReplaceWith(VISIT_CANCEL), WARNING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/VisitFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/VisitFilter.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.model
+
+import java.time.LocalDateTime
+
+data class VisitFilter(
+  val prisonerId: String? = null,
+  val prisonId: String? = null,
+  val visitRoom: String? = null,
+  val nomisPersonId: Long? = null,
+  val startDateTime: LocalDateTime? = null,
+  val endDateTime: LocalDateTime? = null,
+  val visitStatus: VisitStatus? = null,
+  val visitRestriction: VisitRestriction? = null,
+  val createTimestamp: LocalDateTime? = null,
+  val modifyTimestamp: LocalDateTime? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/specification/VisitSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/specification/VisitSpecification.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.model.specification
+
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitFilter
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitVisitor
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaQuery
+import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.Root
+
+class VisitSpecification(private val filter: VisitFilter) : Specification<Visit> {
+  override fun toPredicate(
+    root: Root<Visit>,
+    query: CriteriaQuery<*>,
+    criteriaBuilder: CriteriaBuilder
+  ): Predicate? {
+    val predicates = mutableListOf<Predicate>()
+
+    filter.prisonerId?.run {
+      predicates.add(criteriaBuilder.equal(root.get<String>(Visit::prisonerId.name), this))
+    }
+
+    filter.prisonId?.run {
+      predicates.add(criteriaBuilder.equal(root.get<String>(Visit::prisonId.name), this))
+    }
+
+    filter.startDateTime?.run {
+      predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get(Visit::visitStart.name), this))
+    }
+
+    filter.endDateTime?.run {
+      predicates.add(criteriaBuilder.lessThan(root.get(Visit::visitStart.name), this))
+    }
+
+    filter.visitRoom?.run {
+      predicates.add(criteriaBuilder.equal(root.get<String>(Visit::visitRoom.name), this))
+    }
+
+    filter.nomisPersonId?.run {
+      val innerJoinFromVisitToVisitors =
+        root.join<Visit, MutableList<VisitVisitor>>(Visit::visitors.name).get<VisitVisitor>(
+          VisitVisitor::nomisPersonId.name
+        )
+      predicates.add(criteriaBuilder.equal(innerJoinFromVisitToVisitors, this))
+    }
+
+    filter.visitStatus?.run {
+      predicates.add(criteriaBuilder.equal(root.get<String>(Visit::visitStatus.name), this))
+    }
+
+    filter.visitRestriction?.run {
+      predicates.add(criteriaBuilder.equal(root.get<String>(Visit::visitRestriction.name), this))
+    }
+
+    filter.createTimestamp?.run {
+      predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(Visit::createTimestamp.name), this))
+    }
+
+    filter.modifyTimestamp?.run {
+      predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(Visit::modifyTimestamp.name), this))
+    }
+
+    return criteriaBuilder.and(*predicates.toTypedArray())
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Lock
@@ -109,25 +107,6 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
     nativeQuery = true
   )
   fun updateCreateTimestamp(createTimestamp: LocalDateTime, id: Long): Int
-
-  @Query(
-    "SELECT v FROM Visit v LEFT JOIN v.visitors as vis " +
-      "WHERE (:visitStatus is null OR v.visitStatus = :visitStatus)  AND " +
-      "(:nomisPersonId is null OR vis.nomisPersonId = :nomisPersonId) AND " +
-      "(:prisonerId is null OR v.prisonerId = :prisonerId) AND " +
-      "(:prisonId is null OR v.prisonId = :prisonId) AND " +
-      "(cast(:startDateTime as date) is null OR v.visitStart >= :startDateTime) AND " +
-      "(cast(:endDateTime as date) is null OR v.visitStart < :endDateTime) "
-  )
-  fun findPageBy(
-    @Param("prisonerId") prisonerId: String? = null,
-    @Param("prisonId") prisonId: String,
-    @Param("startDateTime") startDateTime: LocalDateTime? = null,
-    @Param("endDateTime") endDateTime: LocalDateTime? = null,
-    @Param("visitStatus") visitStatus: VisitStatus? = null,
-    @Param("nomisPersonId") nomisPersonId: Long? = null,
-    page: Pageable
-  ): Page<Visit>
 
   @Query(
     "SELECT CASE WHEN (COUNT(v) > 0) THEN TRUE ELSE FALSE END FROM Visit v LEFT JOIN v.visitors as vis " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ReserveVisitSlotDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus.SUPERSEDED_CANCELLATION
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitFilter
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.CHANGING
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitContact
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitSupport
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitVisitor
+import uk.gov.justice.digital.hmpps.visitscheduler.model.specification.VisitSpecification
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SupportTypeRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDateTime
@@ -176,47 +178,14 @@ class VisitService(
   }
 
   @Deprecated("See find visits pageable", ReplaceWith("findVisitsByFilterPageableDescending(visitFilter).content"))
-  fun findVisitsByFilter(
-    prisonerId: String?,
-    prisonId: String,
-    startDateTime: LocalDateTime?,
-    endDateTime: LocalDateTime?,
-    nomisPersonId: Long?,
-    visitStatus: VisitStatus?
-  ): List<VisitDto> {
-    return findVisitsByFilterPageableDescending(
-      prisonerId = prisonerId,
-      prisonId = prisonId,
-      startDateTime = startDateTime,
-      endDateTime = endDateTime,
-      nomisPersonId = nomisPersonId,
-      visitStatus = visitStatus
-    ).content
+  fun findVisitsByFilter(visitFilter: VisitFilter): List<VisitDto> {
+    return findVisitsByFilterPageableDescending(visitFilter).content
   }
 
   @Transactional(readOnly = true)
-  fun findVisitsByFilterPageableDescending(
-    prisonerId: String?,
-    prisonId: String,
-    startDateTime: LocalDateTime?,
-    endDateTime: LocalDateTime?,
-    nomisPersonId: Long?,
-    visitStatus: VisitStatus?,
-    pageablePage: Int = 0,
-    pageableSize: Int = MAX_RECORDS
-  ): Page<VisitDto> {
-
-    val page: Pageable = PageRequest.of(pageablePage, pageableSize, Sort.by(Visit::visitStart.name).descending())
-
-    return visitRepository.findPageBy(
-      prisonerId = prisonerId,
-      prisonId = prisonId,
-      startDateTime = startDateTime,
-      endDateTime = endDateTime,
-      nomisPersonId = nomisPersonId,
-      visitStatus = visitStatus,
-      page = page
-    ).map { VisitDto(it) }
+  fun findVisitsByFilterPageableDescending(visitFilter: VisitFilter, pageablePage: Int? = null, pageableSize: Int? = null): Page<VisitDto> {
+    val page: Pageable = PageRequest.of(pageablePage ?: 0, pageableSize ?: MAX_RECORDS, Sort.by(Visit::visitStart.name).descending())
+    return visitRepository.findAll(VisitSpecification(visitFilter), page).map { VisitDto(it) }
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION

## What does this pull request do?

Revert some changes made in VB-1296 as multiple visits are being returned when there are more than 1 visitors for a visit. Reintroduce VisitFilter and VisitSpecification files and remove native query added in VisitRepository.

## What is the intent behind these changes?

Fixes issue where multiple visits are being returned if there are more than 1 visitor added to a visit.