### PR TITLE
VB-1403 GET /visits - prisonId shouldn't be a required parameter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -298,11 +298,11 @@ class VisitController(
       description = "Filter results by prisoner id",
       example = "A12345DC"
     ) prisonerId: String?,
-    @RequestParam(value = "prisonId", required = true)
+    @RequestParam(value = "prisonId", required = false)
     @Parameter(
       description = "Filter results by prison id",
       example = "MDI"
-    ) prisonId: String,
+    ) prisonId: String?,
     @RequestParam(value = "startTimestamp", required = false)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @Parameter(
@@ -339,7 +339,7 @@ class VisitController(
     return visitService.findVisitsByFilterPageableDescending(
       VisitFilter(
         prisonerId = prisonerId?.trim(),
-        prisonId = prisonId.trim(),
+        prisonId = prisonId?.trim(),
         startDateTime = startTimestamp,
         endDateTime = endTimestamp,
         nomisPersonId = nomisPersonId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitControllerLegacy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitControllerLegacy.kt
@@ -71,11 +71,11 @@ class VisitControllerLegacy(
       description = "Filter results by prisoner id",
       example = "A12345DC"
     ) prisonerId: String?,
-    @RequestParam(value = "prisonId", required = true)
+    @RequestParam(value = "prisonId", required = false)
     @Parameter(
       description = "Filter results by prison id",
       example = "MDI"
-    ) prisonId: String,
+    ) prisonId: String?,
     @RequestParam(value = "startTimestamp", required = false)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @Parameter(
@@ -98,17 +98,18 @@ class VisitControllerLegacy(
       description = "Filter results by visit status",
       example = "BOOKED"
     ) visitStatus: VisitStatus?
-  ): List<VisitDto> =
-    visitService.findVisitsByFilter(
+  ): List<VisitDto> {
+    return visitService.findVisitsByFilter(
       VisitFilter(
         prisonerId = prisonerId?.trim(),
-        prisonId = prisonId.trim(),
+        prisonId = prisonId?.trim(),
         startDateTime = startTimestamp,
         endDateTime = endTimestamp,
         nomisPersonId = nomisPersonId,
         visitStatus = visitStatus
       )
     )
+  }
 
   @Deprecated("This endpoint should be changed to :$VISIT_CANCEL", ReplaceWith(VISIT_CANCEL), WARNING)
   @Suppress("KotlinDeprecation")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -184,6 +184,11 @@ class VisitService(
 
   @Transactional(readOnly = true)
   fun findVisitsByFilterPageableDescending(visitFilter: VisitFilter, pageablePage: Int? = null, pageableSize: Int? = null): Page<VisitDto> {
+
+    if (visitFilter.prisonId == null && visitFilter.prisonerId == null) {
+      throw ValidationException("Must have prisonId or prisonerId")
+    }
+
     val page: Pageable = PageRequest.of(pageablePage ?: 0, pageableSize ?: MAX_RECORDS, Sort.by(Visit::visitStart.name).descending())
     return visitRepository.findAll(VisitSpecification(visitFilter), page).map { VisitDto(it) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByFilterTest.kt
@@ -86,11 +86,10 @@ class VisitsByFilterTest : IntegrationTestBase() {
   fun `get visit by prisoner ID with no visitors`() {
 
     // Given
-    val prisonId = "LEI"
     val prisonerId = "FF0000BB"
 
     // When
-    val responseSpec = callVisitGetEndPoint("/visits?prisonId=$prisonId&prisonerId=$prisonerId")
+    val responseSpec = callVisitGetEndPoint("/visits?prisonerId=$prisonerId")
 
     // Then
     responseSpec
@@ -107,6 +106,19 @@ class VisitsByFilterTest : IntegrationTestBase() {
       .jsonPath("$[0].visitors.length()").isEqualTo(0)
       .jsonPath("$[0].visitContact").doesNotExist()
       .jsonPath("$[0].visitorSupport.length()").isEqualTo(0)
+  }
+
+  @Test
+  fun `get visit without prisoner ID or prison ID is not allowed`() {
+
+    // Given
+
+    // When
+    val responseSpec = callVisitGetEndPoint("/visits")
+
+    // Then
+    responseSpec
+      .expectStatus().isBadRequest
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

it changes prison id to not required, however if a prison Id not present then a prisoner id must be, this is to prevent the hole DB from being downloaded 

## What is the intent behind these changes?

To allow the consumer of the API to download all visits for a prisoners