### PR TITLE
Improvement to sql generator to insert in session template tables in …

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionTemplateSQLGeneratorApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionTemplateSQLGeneratorApplication.kt
@@ -257,7 +257,7 @@ class SessionTemplateSQLGenerator {
     addLine("UPDATE tmp_session_template SET prison_id = prison.id FROM prison WHERE tmp_session_template.prison_code = prison.code;", sqlInsertBuilder)
     addLine(buffer = sqlInsertBuilder)
     addLine("INSERT INTO session_template(id,visit_room,visit_type,open_capacity,closed_capacity,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly)", sqlInsertBuilder)
-    addLine("   SELECT id,visit_room,visit_type,open_capacity,closed_capacity,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly FROM tmp_session_template;", sqlInsertBuilder)
+    addLine("   SELECT id,visit_room,visit_type,open_capacity,closed_capacity,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly FROM tmp_session_template order by id;", sqlInsertBuilder)
 
     addLine("ALTER SEQUENCE session_template_id_seq RESTART WITH ${sessionRecords.size + 1};", sqlInsertBuilder)
 
@@ -315,7 +315,7 @@ class SessionTemplateSQLGenerator {
     addLine("UPDATE tmp_permitted_session_location SET prison_id = prison.id FROM prison WHERE tmp_permitted_session_location.prison_code = prison.code;", sqlInsertBuilder)
     addLine(buffer = sqlInsertBuilder)
     addLine("INSERT INTO permitted_session_location(id,prison_id,level_one_code,level_two_code,level_three_code,level_four_code)", sqlInsertBuilder)
-    addLine("   SELECT id,prison_id,level_one_code,level_two_code,level_three_code,level_four_code FROM tmp_permitted_session_location;", sqlInsertBuilder)
+    addLine("   SELECT id,prison_id,level_one_code,level_two_code,level_three_code,level_four_code FROM tmp_permitted_session_location order by id;", sqlInsertBuilder)
 
     addLine(buffer = sqlInsertBuilder)
     addLine("ALTER SEQUENCE permitted_session_location_id_seq RESTART WITH ${sessionLocationItems.size + 1};", sqlInsertBuilder)


### PR DESCRIPTION
…correct order.

## What does this pull request do?

Tech debt, makes sure the Session templates are inserted into the table in a certain order

## What is the intent behind these changes?

To make DB natural order logical from a reading point of view!