### PR TITLE
VB-1479 Biweekly session for Bristol - Sunday uses the opposite week

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtil.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtil.kt
@@ -45,5 +45,5 @@ class SessionDatesUtil {
   private fun isSkipWeek(
     validFromDate: LocalDate,
     firstBookableSessionDay: LocalDate
-  ) = WEEKS.between(validFromDate, firstBookableSessionDay.plusDays(1)).toInt() % 2 != 0
+  ) = WEEKS.between(validFromDate, firstBookableSessionDay).toInt() % 2 != 0
 }


### PR DESCRIPTION
## What does this pull request do?

Fixes a defect that skipped the last day of week on bi-weekly

## What is the intent behind these changes?

fixes defect