### PR TITLE
VB-1658 Upcoming visits search: Booked and Cancelled visits with same reference

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/specification/VisitSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/specification/VisitSpecification.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.model.specification
 
 import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitFilter
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
@@ -51,7 +52,18 @@ class VisitSpecification(private val filter: VisitFilter) : Specification<Visit>
         val visitStatusPath = root.get<String>(Visit::visitStatus.name)
         predicates.add(visitStatusPath.`in`(visitStatusList))
       }
+
+      val outcomeStatusPath = root.get<String>(Visit::outcomeStatus.name)
+      predicates.add(
+        criteriaBuilder.and(
+          criteriaBuilder.or(
+            criteriaBuilder.isNull(outcomeStatusPath),
+            criteriaBuilder.notEqual(outcomeStatusPath, OutcomeStatus.SUPERSEDED_CANCELLATION)
+          ),
+        )
+      )
     }
+
     return criteriaBuilder.and(*predicates.toTypedArray())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.helper
 
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
@@ -57,7 +58,8 @@ class VisitEntityHelper(
     visitType: VisitType = VisitType.SOCIAL,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,
     reference: String = "",
-    activePrison: Boolean = true
+    activePrison: Boolean = true,
+    outcomeStatus: OutcomeStatus? = null,
   ): Visit {
 
     val prison = prisonEntityHelper.create(prisonCode, activePrison)
@@ -73,7 +75,8 @@ class VisitEntityHelper(
         visitEnd = visitEnd,
         visitType = visitType,
         visitRestriction = visitRestriction,
-        _reference = reference
+        _reference = reference,
+        outcomeStatus = outcomeStatus
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByFilterTest.kt
@@ -15,6 +15,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_CONTROLLER_SEARCH_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus.SUPERSEDED_CANCELLATION
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.STATUS_CHANGED_REASON
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.VISITOR_CONCERN
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.VISIT_COMMENT
@@ -77,6 +78,9 @@ class VisitsByFilterTest : IntegrationTestBase() {
     visitEntityHelper.create(prisonerId = "GG0000BB", visitStart = visitTime.plusHours(1), visitStatus = RESERVED)
     visitEntityHelper.create(prisonerId = "GG0000BB", visitStart = visitTime.plusDays(1).plusHours(1), visitStatus = BOOKED)
     visitEntityHelper.create(prisonerId = "GG0000BB", visitStart = visitTime.plusDays(2).plusHours(1), visitStatus = CANCELLED)
+
+    visitEntityHelper.create(prisonerId = "GG0000BAA", visitStart = visitTime.plusDays(2).plusHours(1), visitStatus = BOOKED)
+    visitEntityHelper.create(prisonerId = "GG0000BAA", visitStart = visitTime.plusDays(2).plusHours(1), visitStatus = CANCELLED, outcomeStatus = SUPERSEDED_CANCELLATION)
   }
 
   @Test
@@ -192,6 +196,22 @@ class VisitsByFilterTest : IntegrationTestBase() {
           "LEI"
         )
       )
+  }
+
+  @Test
+  fun `gets only one visit when visit has been superseded`() {
+    // Given
+    val prisonId = "MDI"
+    val prisonerId = "GG0000BAA"
+
+    // When
+    val responseSpec = callVisitGetEndPoint("/visits?prisonId=$prisonId&prisonerId=$prisonerId&visitStatus=BOOKED,CANCELLED")
+
+    // Then
+    responseSpec.expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.length()").isEqualTo(1)
+      .jsonPath("$[0].visitStatus").isEqualTo("BOOKED")
   }
 
   @Test


### PR DESCRIPTION
Upcoming visits search: Booked and Cancelled visits with same reference

## What does this pull request do?

Prevents visits with outcome status of SUPERSEDED_CANCELLATION from being returned

## What is the intent behind these changes?

to fix the defect.