### PR TITLE
VB-1763 - script to update visits for Cardiff, Preston and Wandsworth

### DIFF
--- a/src/main/resources/db.scripts.mvp/fix_up_future_visits_for_cardiff_post_release.sql
+++ b/src/main/resources/db.scripts.mvp/fix_up_future_visits_for_cardiff_post_release.sql
@@ -1,0 +1,27 @@
+BEGIN;
+--update visits that have an incorrect end time of '19:00:00' instead of '18:45:00'
+--matching session timetable value is 18:00:00	18:45:00 on TUESDAY
+
+update visit set visit_end = visit_end - interval '15 minutes'
+where prison_id  in (
+    select prison_id from prison p where p.code = 'CFI'
+)
+  and 	visit_start >= TO_DATE('02/02/2023', 'DD/MM/YYYY')
+  and visit_start::time = '18:00:00'
+  and visit_end::time = '19:00:00'
+  and visit_status = 'BOOKED'
+  and UPPER(TRIM(To_Char(visit_start , 'DAY'))) = 'TUESDAY';
+
+--update visits that have an incorrect end time of '15:15:00' instead of '15:45:00'
+--matching session timetable value is 13:45:00 to 15:45:00 on all days
+
+update visit set visit_end = visit_end + interval '30 minutes'
+where prison_id  in (
+    select prison_id from prison p where p.code = 'CFI'
+)
+  and 	visit_start >= TO_DATE('02/02/2023', 'DD/MM/YYYY')
+  and visit_start::time = '13:45:00'
+  and visit_end::time = '15:15:00'
+  and visit_status = 'BOOKED';
+
+END;

--- a/src/main/resources/db.scripts.mvp/fix_up_future_visits_for_preston_post_release.sql
+++ b/src/main/resources/db.scripts.mvp/fix_up_future_visits_for_preston_post_release.sql
@@ -1,0 +1,27 @@
+BEGIN;
+--update visits that have an incorrect end time of '14:59:00' instead of '15:00:00'
+--matching session timetable value is 14:00:00	15:00:00
+
+update visit set visit_end = visit_end + interval '1 minutes'
+where prison_id  in (
+    select prison_id from prison p where p.code = 'PNI'
+)
+  and 	visit_start >= TO_DATE('02/02/2023', 'DD/MM/YYYY')
+  and (visit_start::time = '14:00:00')
+  and (visit_end::time = '14:59:00')
+  and visit_status = 'BOOKED';
+
+
+--update visits that have an incorrect end time of '16:29:00' instead of '16:30:00'
+--matching session timetable value is 15:30:00	16:30:00
+
+update visit set visit_end = visit_end + interval '1 minutes'
+where prison_id  in (
+    select prison_id from prison p where p.code = 'PNI'
+)
+  and 	visit_start >= TO_DATE('02/02/2023', 'DD/MM/YYYY')
+  and (visit_start::time = '15:30:00')
+  and (visit_end::time = '16:29:00')
+  and visit_status = 'BOOKED';
+
+END;

--- a/src/main/resources/db.scripts.mvp/fix_up_future_visits_for_wandsworth_post_release.sql
+++ b/src/main/resources/db.scripts.mvp/fix_up_future_visits_for_wandsworth_post_release.sql
@@ -1,0 +1,16 @@
+BEGIN;
+--update visits that have an incorrect start time of '15:15:00' and end time of '16:15:00' instead of start time of '15:30:00' and end time of '16:30:00'
+--matching session timetable value is 15:30:00	16:30:00 on Saturday and Sunday
+
+update visit set visit_start = visit_start + interval '15 minutes',
+visit_end = visit_end + interval '15 minutes'
+where prison_id  in (
+    select prison_id from prison p where p.code = 'WWI'
+)
+  and 	visit_start >= TO_DATE('02/02/2023', 'DD/MM/YYYY')
+  and (visit_start::time = '15:15:00')
+  and (visit_end::time = '16:15:00')
+  and visit_status = 'BOOKED'
+  and UPPER(TRIM(To_Char(visit_start , 'DAY'))) in ('SATURDAY', 'SUNDAY');
+
+END;


### PR DESCRIPTION
VB-1763 - script to update visits for Cardiff, Preston and Wandsworth to ensure visit times to match the timetables provided by each prison.

## What does this pull request do?

Updates visits migrated for the 3 new prisons to be onboarded to update the visit timings with the data in the session templates.

## What is the intent behind these changes?
Keep visit data in sync with session templates to allow these visits to be updated.