### PR TITLE
VB-2005 Update VSiP Dependencies - change to CI JDK version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
   validate:
     executor:
       name: hmpps/java_localstack_postgres
-      jdk_tag: "17.0"
+      jdk_tag: "19.0"
       localstack_tag: "0.14.0"
       services: "sns,sqs"
       postgres_tag: "14"


### PR DESCRIPTION
## What does this pull request do?

makes sure code is compiled to the correct version of the JDK

## What is the intent behind these changes?

to get CI build working