### PR TITLE
Vb 2028 create a new v 2 endpoint for cancel visits till syscon migrates cancel over to the new endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -34,12 +34,13 @@ import uk.gov.justice.digital.hmpps.visitscheduler.service.VisitService
 import java.time.LocalDateTime
 
 const val VISIT_CONTROLLER_PATH: String = "/visits"
+const val V2_VISIT_CONTROLLER_PATH: String = "/v2/visits"
 const val VISIT_CONTROLLER_SEARCH_PATH: String = "$VISIT_CONTROLLER_PATH/search"
 const val VISIT_RESERVE_SLOT: String = "$VISIT_CONTROLLER_PATH/slot/reserve"
 const val VISIT_RESERVED_SLOT_CHANGE: String = "$VISIT_CONTROLLER_PATH/{applicationReference}/slot/change"
 const val VISIT_CHANGE: String = "$VISIT_CONTROLLER_PATH/{reference}/change"
 const val VISIT_BOOK: String = "$VISIT_CONTROLLER_PATH/{applicationReference}/book"
-const val VISIT_CANCEL: String = "$VISIT_CONTROLLER_PATH/{reference}/cancel"
+const val VISIT_CANCEL: String = "$V2_VISIT_CONTROLLER_PATH/{reference}/cancel"
 const val GET_VISIT_BY_REFERENCE: String = "$VISIT_CONTROLLER_PATH/{reference}"
 
 @RestController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitControllerLegacy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitControllerLegacy.kt
@@ -10,14 +10,13 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.service.VisitService
@@ -31,14 +30,13 @@ import kotlin.DeprecationLevel.WARNING
 class VisitControllerLegacy(
   private val visitService: VisitService,
 ) {
-
   @Deprecated("This endpoint should be changed to :$VISIT_CANCEL", ReplaceWith(VISIT_CANCEL), WARNING)
   @Suppress("KotlinDeprecation")
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")
-  @PatchMapping("/{reference}/cancel")
+  @PutMapping("/{reference}/cancel")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
-    summary = "Cancel an existing visit",
+    summary = "Cancel an existing booked visit",
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(
@@ -79,8 +77,8 @@ class VisitControllerLegacy(
     @PathVariable
     reference: String,
     @RequestBody @Valid
-    cancelVisitDto: CancelVisitDto,
+    cancelOutcome: OutcomeDto,
   ): VisitDto {
-    return visitService.cancelVisit(reference.trim(), cancelVisitDto)
+    return visitService.cancelVisit(reference.trim(), cancelOutcome)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ChangeVisitSlotRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ReserveVisitSlotDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.ExpiredVisitAmendException
@@ -44,6 +45,7 @@ class VisitService(
   private val supportTypeRepository: SupportTypeRepository,
   private val telemetryClient: TelemetryClient,
   private val snsService: SnsService,
+  private val authenticationHelperService: AuthenticationHelperService,
   private val prisonConfigService: PrisonConfigService,
   @Value("\${task.expired-visit.validity-minutes:20}") private val expiredPeriodMinutes: Int,
   @Value("\${visit.cancel.day-limit:28}") private val visitCancellationDayLimit: Int,
@@ -264,6 +266,12 @@ class VisitService(
     }
 
     return visit
+  }
+
+  @Deprecated("This method has been deprecated.")
+  fun cancelVisit(reference: String, outcomeDto: OutcomeDto): VisitDto {
+    val cancelVisitDto = CancelVisitDto(outcomeDto, authenticationHelperService.currentUserName)
+    return cancelVisit(reference, cancelVisitDto)
   }
 
   fun cancelVisit(reference: String, cancelVisitDto: CancelVisitDto): VisitDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/legacy/CancelVisitTest.kt
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.context.TestPropertySource
 import org.springframework.web.reactive.function.BodyInserters
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
@@ -35,27 +34,22 @@ class CancelVisitTest : IntegrationTestBase() {
   @SpyBean
   private lateinit var telemetryClient: TelemetryClient
 
-  companion object {
-    const val cancelledByByUser = "user-1"
-  }
-
   @Test
   fun `cancel visit by reference with outcome and outcome text`() {
     // Given
     val visit = createVisitAndSave()
 
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.PRISONER_CANCELLED,
-        "Prisoner got covid",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.PRISONER_CANCELLED,
+      "Prisoner got covid",
     )
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${visit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
-      .body(BodyInserters.fromValue(cancelVisitDto))
+      .body(
+        BodyInserters.fromValue(outcomeDto),
+      )
       .exchange()
 
     // Then
@@ -76,18 +70,15 @@ class CancelVisitTest : IntegrationTestBase() {
     // Given
     val visit = createVisitAndSave()
 
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        outcomeStatus = OutcomeStatus.VISITOR_CANCELLED,
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      outcomeStatus = OutcomeStatus.VISITOR_CANCELLED,
     )
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${visit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .body(
-        BodyInserters.fromValue(cancelVisitDto),
+        BodyInserters.fromValue(outcomeDto),
       )
       .exchange()
 
@@ -109,7 +100,7 @@ class CancelVisitTest : IntegrationTestBase() {
     val visit = createVisitAndSave()
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${visit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .exchange()
 
@@ -126,19 +117,16 @@ class CancelVisitTest : IntegrationTestBase() {
     // Given
     val visit = createVisitAndSave()
 
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.SUPERSEDED_CANCELLATION,
-        "Prisoner has updated the existing booking",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.SUPERSEDED_CANCELLATION,
+      "Prisoner has updated the existing booking",
     )
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${visit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .body(
-        BodyInserters.fromValue(cancelVisitDto),
+        BodyInserters.fromValue(outcomeDto),
       )
       .exchange()
 
@@ -160,20 +148,17 @@ class CancelVisitTest : IntegrationTestBase() {
     // Given
     val reference = "12345"
 
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.ADMINISTRATIVE_CANCELLATION,
-        "Visit does not exist",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.ADMINISTRATIVE_CANCELLATION,
+      "Visit does not exist",
     )
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/$reference/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/$reference/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .body(
         BodyInserters.fromValue(
-          cancelVisitDto,
+          outcomeDto,
         ),
       )
       .exchange()
@@ -187,20 +172,17 @@ class CancelVisitTest : IntegrationTestBase() {
     // Given
     val reference = "12345"
 
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.ESTABLISHMENT_CANCELLED,
-        "Prisoner got covid",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.ESTABLISHMENT_CANCELLED,
+      "Prisoner got covid",
     )
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/$reference/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/$reference/cancel")
       .headers(setAuthorisation(roles = listOf()))
       .body(
         BodyInserters.fromValue(
-          cancelVisitDto,
+          outcomeDto,
         ),
       )
       .exchange()
@@ -217,19 +199,16 @@ class CancelVisitTest : IntegrationTestBase() {
     // Given
     val reference = "12345"
 
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.PRISONER_CANCELLED,
-        "Prisoner got covid",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.PRISONER_CANCELLED,
+      "Prisoner got covid",
     )
 
     // When
     val responseSpec = webTestClient.put().uri("/visits/$reference/cancel")
       .body(
         BodyInserters.fromValue(
-          cancelVisitDto,
+          outcomeDto,
         ),
       )
       .exchange()
@@ -240,22 +219,19 @@ class CancelVisitTest : IntegrationTestBase() {
 
   @Test
   fun `cancel expired visit before allowed days returns error`() {
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.CANCELLATION,
-        "No longer joining.",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.CANCELLATION,
+      "No longer joining.",
     )
     // Given
     val visitStart = LocalDateTime.now().minusDays(visitCancellationDayLimit + 1)
     val expiredVisit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = visitStart)
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${expiredVisit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${expiredVisit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .body(
-        BodyInserters.fromValue(cancelVisitDto),
+        BodyInserters.fromValue(outcomeDto),
       )
       .exchange()
 
@@ -275,22 +251,19 @@ class CancelVisitTest : IntegrationTestBase() {
    */
   @Test
   fun `cancel expired visit on same day as allowed day does not return error`() {
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.CANCELLATION,
-        "No longer joining.",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.CANCELLATION,
+      "No longer joining.",
     )
     // Given
     val visitStart = LocalDateTime.now().minusDays(visitCancellationDayLimit).truncatedTo(ChronoUnit.DAYS).withHour(1)
     val visit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = visitStart)
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${visit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .body(
-        BodyInserters.fromValue(cancelVisitDto),
+        BodyInserters.fromValue(outcomeDto),
       )
       .exchange()
 
@@ -306,22 +279,19 @@ class CancelVisitTest : IntegrationTestBase() {
 
   @Test
   fun `cancel expired visit today does not return error`() {
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.CANCELLATION,
-        "No longer joining.",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.CANCELLATION,
+      "No longer joining.",
     )
     // Given
     val visitStart = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).withHour(1)
     val visit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = visitStart)
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${visit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .body(
-        BodyInserters.fromValue(cancelVisitDto),
+        BodyInserters.fromValue(outcomeDto),
       )
       .exchange()
 
@@ -337,22 +307,19 @@ class CancelVisitTest : IntegrationTestBase() {
 
   @Test
   fun `cancel future visit does not return error`() {
-    val cancelVisitDto = CancelVisitDto(
-      OutcomeDto(
-        OutcomeStatus.CANCELLATION,
-        "No longer joining.",
-      ),
-      cancelledByByUser,
+    val outcomeDto = OutcomeDto(
+      OutcomeStatus.CANCELLATION,
+      "No longer joining.",
     )
     // Given
     val visitStart = LocalDateTime.now().plusDays(1)
     val visit = visitEntityHelper.create(visitStatus = BOOKED, visitStart = visitStart)
 
     // When
-    val responseSpec = webTestClient.patch().uri("/visits/${visit.reference}/cancel")
+    val responseSpec = webTestClient.put().uri("/visits/${visit.reference}/cancel")
       .headers(setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER")))
       .body(
-        BodyInserters.fromValue(cancelVisitDto),
+        BodyInserters.fromValue(outcomeDto),
       )
       .exchange()
 


### PR DESCRIPTION
## What does this pull request do?

move the existing cancel endpoint to VisitCotrollerLegacy

## What is the intent behind these changes?

Will ensure that the cancellations from NOMIS continue working till the new SYNC service endpoint is created.