### PR TITLE
Vb 2040 defect sync cancel fails when visit is in the past

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/MigrateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/MigrateController.kt
@@ -10,25 +10,33 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.MigrateVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.service.MigrateVisitService
+
+const val MIGRATE_VISITS: String = "/migrate-visits"
+const val MIGRATE_CANCEL: String = "$MIGRATE_VISITS/{reference}/cancel"
 
 @RestController
 @Validated
 @Tag(name = "7. Visit migration rest controller")
-@RequestMapping(name = "Visit Migration Resource", path = ["/migrate-visits"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(name = "Visit Migration Resource", produces = [MediaType.APPLICATION_JSON_VALUE])
 class MigrateController(
   private val migrateVisitService: MigrateVisitService,
 ) {
 
   @PreAuthorize("hasAnyRole('MIGRATE_VISITS', 'MIGRATION_ADMIN')")
-  @PostMapping
+  @PostMapping(MIGRATE_VISITS)
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
     summary = "Migrate a visit",
@@ -67,5 +75,55 @@ class MigrateController(
     migrateVisitRequest: MigrateVisitRequestDto,
   ): String {
     return migrateVisitService.migrateVisit(migrateVisitRequest)
+  }
+
+  @PreAuthorize("hasAnyRole('MIGRATE_VISITS', 'MIGRATION_ADMIN')")
+  @PutMapping(MIGRATE_CANCEL)
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Migrate a canceled booked visit",
+    requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
+      content = [
+        Content(
+          mediaType = "application/json",
+          schema = Schema(implementation = OutcomeDto::class),
+        ),
+      ],
+    ),
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Cancelled visit migrated",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to cancelled visit migrated",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to cancelled visit migrated",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Visit not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun cancelVisit(
+    @Schema(description = "reference", example = "v9-d7-ed-7u", required = true)
+    @PathVariable
+    reference: String,
+    @RequestBody @Valid
+    cancelVisitDto: CancelVisitDto,
+  ): VisitDto {
+    return migrateVisitService.cancelVisit(reference.trim(), cancelVisitDto)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/MigrateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/MigrateController.kt
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.MigrateVisitRequestDto
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.service.MigrateVisitService
 
@@ -86,7 +85,7 @@ class MigrateController(
       content = [
         Content(
           mediaType = "application/json",
-          schema = Schema(implementation = OutcomeDto::class),
+          schema = Schema(implementation = CancelVisitDto::class),
         ),
       ],
     ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ChangeVisitSlotRequestDto
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ReserveVisitSlotDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitFilter
@@ -236,7 +235,7 @@ class VisitController(
       content = [
         Content(
           mediaType = "application/json",
-          schema = Schema(implementation = OutcomeDto::class),
+          schema = Schema(implementation = CancelVisitDto::class),
         ),
       ],
     ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/MigrateVisitRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/MigrateVisitRequestDto.kt
@@ -53,4 +53,6 @@ data class MigrateVisitRequestDto(
   val visitors: Set<@Valid VisitorDto>? = setOf(),
   @Schema(description = "Visit notes", required = false)
   val visitNotes: Set<@Valid VisitNoteDto>? = setOf(),
+  @Schema(description = "Username for user who actioned this request", required = false)
+  val actionedBy: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/MigrateVisitRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/MigrateVisitRequestDto.kt
@@ -53,6 +53,6 @@ data class MigrateVisitRequestDto(
   val visitors: Set<@Valid VisitorDto>? = setOf(),
   @Schema(description = "Visit notes", required = false)
   val visitNotes: Set<@Valid VisitNoteDto>? = setOf(),
-  @Schema(description = "Username for user who actioned this request", required = false)
+  @Schema(description = "Username for user who actioned this request", required = true)
   val actionedBy: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
@@ -3,10 +3,14 @@ package uk.gov.justice.digital.hmpps.visitscheduler.service
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateLegacyContactOnVisitRequestDto.Companion.UNKNOWN_TOKEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.MigrateVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.exception.VisitNotFoundException
 import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.CANCELLED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.LegacyData
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitContact
@@ -14,6 +18,8 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitVisitor
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.LegacyDataRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
+import uk.gov.justice.digital.hmpps.visitscheduler.service.VisitService.Companion
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Service
@@ -22,6 +28,7 @@ class MigrateVisitService(
   private val legacyDataRepository: LegacyDataRepository,
   private val visitRepository: VisitRepository,
   private val prisonConfigService: PrisonConfigService,
+  private val snsService: SnsService,
   private val authenticationHelperService: AuthenticationHelperService,
   private val telemetryClient: TelemetryClient,
 ) {
@@ -79,7 +86,7 @@ class MigrateVisitService(
       saveLegacyData(visitEntity, null)
     }
 
-    sendTelemetryData(visitEntity)
+    sendMigratedTrackEvent(visitEntity, TelemetryVisitEvents.VISIT_MIGRATED_EVENT)
 
     visitRepository.saveAndFlush(visitEntity)
 
@@ -95,22 +102,64 @@ class MigrateVisitService(
     return visitEntity.reference
   }
 
-  private fun sendTelemetryData(visitEntity: Visit) {
-    telemetryClient.trackEvent(
-      TelemetryVisitEvents.VISIT_MIGRATED_EVENT.eventName,
-      mapOf(
-        "reference" to visitEntity.reference,
-        "prisonerId" to visitEntity.prisonerId,
-        "prisonId" to visitEntity.prison.code,
-        "visitType" to visitEntity.visitType.name,
-        "visitRoom" to visitEntity.visitRoom,
-        "visitRestriction" to visitEntity.visitRestriction.name,
-        "visitStart" to visitEntity.visitStart.toString(),
-        "visitStatus" to visitEntity.visitStatus.name,
-        "outcomeStatus" to visitEntity.outcomeStatus?.name,
-      ),
-      null,
+  fun cancelVisit(reference: String, cancelVisitDto: CancelVisitDto): VisitDto {
+    val cancelOutcome = cancelVisitDto.cancelOutcome
+
+    if (visitRepository.isBookingCancelled(reference)) {
+      // If already canceled then just return object and do nothing more!
+      VisitService.LOG.debug("The visit $reference has already been canceled!")
+      val canceledVisit = visitRepository.findByReference(reference)!!
+      return VisitDto(canceledVisit)
+    }
+
+    val visitEntity = visitRepository.findBookedVisit(reference) ?: throw VisitNotFoundException("Canceled migrated visit $reference not found ")
+
+    visitEntity.visitStatus = CANCELLED
+    visitEntity.outcomeStatus = cancelOutcome.outcomeStatus
+    visitEntity.cancelledBy = cancelVisitDto.actionedBy
+
+    cancelOutcome.text?.let {
+      visitEntity.visitNotes.add(createVisitNote(visitEntity, VisitNoteType.VISIT_OUTCOMES, cancelOutcome.text))
+    }
+
+    sendMigratedTrackEvent(visitEntity, TelemetryVisitEvents.CANCELLED_VISIT_MIGRATED_EVENT)
+
+    val visit = VisitDto(visitRepository.saveAndFlush(visitEntity))
+    snsService.sendVisitCancelledEvent(visit)
+    return visit
+  }
+
+  private fun sendMigratedTrackEvent(visitEntity: Visit, type: TelemetryVisitEvents) {
+    val eventsMap = createVisitTrackEventFromVisitEntity(visitEntity)
+    visitEntity.outcomeStatus?.let {
+      eventsMap.put("outcomeStatus", it.name)
+    }
+    trackEvent(
+      type.eventName,
+      eventsMap,
     )
+  }
+
+  private fun createVisitTrackEventFromVisitEntity(visitEntity: Visit): MutableMap<String, String> {
+    return mutableMapOf(
+      "reference" to visitEntity.reference,
+      "prisonerId" to visitEntity.prisonerId,
+      "prisonId" to visitEntity.prison.code,
+      "visitType" to visitEntity.visitType.name,
+      "visitRoom" to visitEntity.visitRoom,
+      "visitRestriction" to visitEntity.visitRestriction.name,
+      "visitStart" to visitEntity.visitStart.format(DateTimeFormatter.ISO_DATE_TIME),
+      "visitStatus" to visitEntity.visitStatus.name,
+      "applicationReference" to visitEntity.applicationReference,
+    )
+  }
+
+  private fun trackEvent(eventName: String, properties: Map<String, String>) {
+    try {
+      telemetryClient.trackEvent(eventName, properties, null)
+    } catch (e: RuntimeException) {
+      Companion.LOG.error("Error occurred in call to telemetry client to log event - $e.toString()")
+    }
   }
 
   private fun capitalise(sentence: String): String =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
@@ -34,7 +34,7 @@ class MigrateVisitService(
 ) {
 
   fun migrateVisit(migrateVisitRequest: MigrateVisitRequestDto): String {
-    val actionedBy = authenticationHelperService.currentUserName
+    val actionedBy = migrateVisitRequest.actionedBy ?: authenticationHelperService.currentUserName
     // Deserialization kotlin data class issue when OutcomeStatus = json type of null defaults do not get set hence below code
     val outcomeStatus = migrateVisitRequest.outcomeStatus ?: OutcomeStatus.NOT_RECORDED
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryVisitEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryVisitEvents.kt
@@ -8,14 +8,7 @@ enum class TelemetryVisitEvents(val eventName: String) {
   VISIT_CANCELLED_EVENT("visit-cancelled"),
   VISIT_DELETED_EVENT("visit-expired-visits-deleted"),
   VISIT_MIGRATED_EVENT("visit-migrated"),
-
-  @Suppress("KotlinDeprecation")
-  @Deprecated("Legacy version - to be removed")
-  VISIT_UPDATED_EVENT("visit-updated"),
-
-  SESSION_TEMPLATE_CREATED("session-template-created"),
-  SESSION_TEMPLATE_DELETED("session-template-deleted"),
-
+  CANCELLED_VISIT_MIGRATED_EVENT("cancelled-visit-migrated"),
   ACCESS_DENIED_ERROR_EVENT("visit-access-denied-error"),
   INTERNAL_SERVER_ERROR_EVENT("visit-internal-server-error"),
   BAD_REQUEST_ERROR_EVENT("visit-bad-request-error"),

--- a/src/main/resources/db.scripts.mvp/R__Session_Template_Data.sql
+++ b/src/main/resources/db.scripts.mvp/R__Session_Template_Data.sql
@@ -1,367 +1,398 @@
--- This script clears certain tables and re-set auto id's to zero!
--- WARNING if the session template id's are used in other tables this script might have to change!
--- This is a temporary solution, and should be replaced by a JSON admin API!
--- Make sure prison table has the concerned prisons inserted before running this script!
--- See for instructions https://dsdmoj.atlassian.net/wiki/spaces/PSCH/pages/4239622317/SQL+SessionTemplate+Generator
-BEGIN;
+    -- This script clears certain tables and re-set auto id's to zero!
+    -- WARNING if the session template id's are used in other tables this script might have to change!
+    -- This is a temporary solution, and should be replaced by a JSON admin API!
+    -- Make sure prison table has the concerned prisons inserted before running this script!
+    -- See for instructions https://dsdmoj.atlassian.net/wiki/spaces/PSCH/pages/4239622317/SQL+SessionTemplate+Generator
+    BEGIN;
 
-	SET SCHEMA 'public';
+        SET SCHEMA 'public';
 
-	-- Use TRUNCATE rather than delete so indexes are re-set
-	TRUNCATE TABLE session_to_location_group RESTART IDENTITY CASCADE;
-	TRUNCATE TABLE session_location_group RESTART IDENTITY CASCADE;
-	TRUNCATE TABLE session_template  RESTART IDENTITY CASCADE;
-	TRUNCATE TABLE permitted_session_location  RESTART IDENTITY CASCADE;
+        -- Use TRUNCATE rather than delete so indexes are re-set
+        TRUNCATE TABLE session_to_location_group RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE session_location_group RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE session_template  RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE permitted_session_location  RESTART IDENTITY CASCADE;
+        TRUNCATE TABLE session_prisoner_category  RESTART IDENTITY CASCADE;
 
-	INSERT INTO prison(code, active) SELECT 'HEI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'HEI');
-	INSERT INTO prison(code, active) SELECT 'BLI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'BLI');
-	INSERT INTO prison(code, active) SELECT 'CFI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'CFI');
-	INSERT INTO prison(code, active) SELECT 'WWI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'WWI');
-	INSERT INTO prison(code, active) SELECT 'PNI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'PNI');
-	INSERT INTO prison(code, active) SELECT 'EWI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'EWI');
-	INSERT INTO prison(code, active) SELECT 'DHI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'DHI');
-	INSERT INTO prison(code, active) SELECT 'MHI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'MHI');
-	INSERT INTO prison(code, active) SELECT 'BNI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'BNI');
+            INSERT INTO prison(code, active) SELECT 'HEI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'HEI');
+        INSERT INTO prison(code, active) SELECT 'BLI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'BLI');
+        INSERT INTO prison(code, active) SELECT 'CFI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'CFI');
+        INSERT INTO prison(code, active) SELECT 'WWI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'WWI');
+        INSERT INTO prison(code, active) SELECT 'PNI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'PNI');
+        INSERT INTO prison(code, active) SELECT 'EWI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'EWI');
+        INSERT INTO prison(code, active) SELECT 'DHI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'DHI');
+        INSERT INTO prison(code, active) SELECT 'MHI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'MHI');
+        INSERT INTO prison(code, active) SELECT 'BNI', false WHERE NOT EXISTS ( SELECT id FROM prison WHERE code = 'BNI');
 
-	-- Creating session template data
-	CREATE TEMP TABLE tmp_session_template(
-		 id                serial        NOT NULL PRIMARY KEY,
-		 locationKeys      VARCHAR       ,
-		 prison_code       VARCHAR(6)    NOT NULL,
-		 prison_id         int    ,
-		 visit_room        VARCHAR(255)  NOT NULL,
-		 visit_type        VARCHAR(80)   NOT NULL,
-		 open_capacity     integer       NOT NULL,
-		 closed_capacity   integer       NOT NULL,
-		 enhanced          BOOLEAN       NOT NULL,
-		 start_time        time          NOT NULL,
-		 end_time          time          NOT NULL,
-		 valid_from_date   date          NOT NULL,
-		 valid_to_date     date          ,
-		 day_of_week       VARCHAR(40)   NOT NULL,
-		 bi_weekly         BOOLEAN       NOT NULL,
-         name              varchar(100)  NOT NULL
-		);
+        -- Creating session template data
+        CREATE TEMP TABLE tmp_session_template(
+             id                serial        NOT NULL PRIMARY KEY,
+             locationKeys      VARCHAR       ,
+             incCategories      VARCHAR       ,
+             excCategories      VARCHAR       ,
+             prison_code       VARCHAR(6)    NOT NULL,
+             prison_id         int    ,
+             visit_room        VARCHAR(255)  NOT NULL,
+             visit_type        VARCHAR(80)   NOT NULL,
+             open_capacity     integer       NOT NULL,
+             closed_capacity   integer       NOT NULL,
+             enhanced          BOOLEAN       NOT NULL,
+             start_time        time          NOT NULL,
+             end_time          time          NOT NULL,
+             valid_from_date   date          NOT NULL,
+             valid_to_date     date          ,
+             day_of_week       VARCHAR(40)   NOT NULL,
+             bi_weekly         BOOLEAN       NOT NULL,
+             name              varchar(100)  NOT NULL
+            );
 
-	INSERT INTO tmp_session_template (locationKeys,prison_code, visit_room, visit_type, open_capacity, closed_capacity,enhanced, start_time, end_time, valid_from_date, valid_to_date, day_of_week,bi_weekly,name)
-	VALUES
-		(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-05-30','2022-12-18','MONDAY',false,'MONDAY, 2022-05-30, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-06-01','2022-12-18','WEDNESDAY',false,'WEDNESDAY, 2022-06-01, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','10:00','2022-06-03','2022-12-18','FRIDAY',false,'FRIDAY, 2022-06-03, 09:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-06-04','2022-12-18','SATURDAY',false,'SATURDAY, 2022-06-04, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-06-05','2022-12-18','SUNDAY',false,'SUNDAY, 2022-06-05, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-19','2022-12-24','MONDAY',false,'MONDAY, 2022-12-19, 14:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-21','2022-12-24','WEDNESDAY',false,'WEDNESDAY, 2022-12-21, 14:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','11:00','2022-12-23','2022-12-24','FRIDAY',false,'FRIDAY, 2022-12-23, 09:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-24','2022-12-24','SATURDAY',false,'SATURDAY, 2022-12-24, 14:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-28','2023-01-02','WEDNESDAY',false,'WEDNESDAY, 2022-12-28, 14:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','11:00','2022-12-30','2023-01-02','FRIDAY',false,'FRIDAY, 2022-12-30, 09:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-31','2023-01-02','SATURDAY',false,'SATURDAY, 2022-12-31, 14:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2023-01-01','2023-01-02','SUNDAY',false,'SUNDAY, 2023-01-01, 14:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2023-01-02','2023-01-02','MONDAY',false,'MONDAY, 2023-01-02, 14:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-09','2023-03-20','MONDAY',false,'MONDAY, 2023-01-09, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-04','2023-03-20','WEDNESDAY',false,'WEDNESDAY, 2023-01-04, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','10:00','2023-01-06','2023-03-20','FRIDAY',false,'FRIDAY, 2023-01-06, 09:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-07','2023-03-20','SATURDAY',false,'SATURDAY, 2023-01-07, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-08','2023-03-20','SUNDAY',false,'SUNDAY, 2023-01-08, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'MONDAY',false,'MONDAY, 2023-03-21, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-21, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'09:00','10:00','2023-03-21',NULL,'FRIDAY',false,'FRIDAY, 2023-03-21, 09:00'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'SATURDAY',false,'SATURDAY, 2023-03-21, 13:45'),
-			(NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'SUNDAY',false,'SUNDAY, 2023-03-21, 13:45'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','TUESDAY',true,'TUESDAY, 2022-12-05, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','TUESDAY',true,'TUESDAY, 2022-12-05, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','WEDNESDAY',true,'WEDNESDAY, 2022-12-05, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','WEDNESDAY',true,'WEDNESDAY, 2022-12-05, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-05','2022-12-18','FRIDAY',true,'FRIDAY, 2022-12-05, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','SATURDAY',true,'SATURDAY, 2022-12-05, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','SATURDAY',true,'SATURDAY, 2022-12-05, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','SUNDAY',true,'SUNDAY, 2022-12-05, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','SUNDAY',true,'SUNDAY, 2022-12-05, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-11-28','2022-12-18','TUESDAY',true,'TUESDAY, 2022-11-28, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-11-28','2022-12-18','TUESDAY',true,'TUESDAY, 2022-11-28, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-11-28','2022-12-18','WEDNESDAY',true,'WEDNESDAY, 2022-11-28, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-11-28','2022-12-18','FRIDAY',true,'FRIDAY, 2022-11-28, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-11-28','2022-12-18','SATURDAY',true,'SATURDAY, 2022-11-28, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-11-28','2022-12-18','SATURDAY',true,'SATURDAY, 2022-11-28, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-11-28','2022-12-18','SUNDAY',true,'SUNDAY, 2022-11-28, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-11-28','2022-12-18','SUNDAY',true,'SUNDAY, 2022-11-28, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-20','2022-12-20','TUESDAY',false,'TUESDAY, 2022-12-20, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-20','2022-12-20','TUESDAY',false,'TUESDAY, 2022-12-20, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-21','2022-12-21','WEDNESDAY',false,'WEDNESDAY, 2022-12-21, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-21','2022-12-21','WEDNESDAY',false,'WEDNESDAY, 2022-12-21, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-23','2022-12-23','FRIDAY',false,'FRIDAY, 2022-12-23, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-24','2022-12-24','SATURDAY',false,'SATURDAY, 2022-12-24, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-24','2022-12-24','SATURDAY',false,'SATURDAY, 2022-12-24, 15:30'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-27','2022-12-27','TUESDAY',false,'TUESDAY, 2022-12-27, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-28','2022-12-28','WEDNESDAY',false,'WEDNESDAY, 2022-12-28, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-30','2022-12-30','FRIDAY',false,'FRIDAY, 2022-12-30, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'09:30','10:30','2022-12-31','2022-12-31','SATURDAY',false,'SATURDAY, 2022-12-31, 09:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-31','2022-12-31','SATURDAY',false,'SATURDAY, 2022-12-31, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-01','2023-01-01','SUNDAY',false,'SUNDAY, 2023-01-01, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-01','2023-01-01','SUNDAY',false,'SUNDAY, 2023-01-01, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-03','2023-01-03','TUESDAY',false,'TUESDAY, 2023-01-03, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-03','2023-01-03','TUESDAY',false,'TUESDAY, 2023-01-03, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'TUESDAY',true,'TUESDAY, 2023-01-04, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'TUESDAY',true,'TUESDAY, 2023-01-04, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'WEDNESDAY',true,'WEDNESDAY, 2023-01-04, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'WEDNESDAY',true,'WEDNESDAY, 2023-01-04, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2023-01-04',NULL,'FRIDAY',true,'FRIDAY, 2023-01-04, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'SATURDAY',true,'SATURDAY, 2023-01-04, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'SATURDAY',true,'SATURDAY, 2023-01-04, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'SUNDAY',true,'SUNDAY, 2023-01-04, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'SUNDAY',true,'SUNDAY, 2023-01-04, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-09',NULL,'TUESDAY',true,'TUESDAY, 2023-01-09, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-09',NULL,'TUESDAY',true,'TUESDAY, 2023-01-09, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2023-01-09',NULL,'WEDNESDAY',true,'WEDNESDAY, 2023-01-09, 14:00'),
-			('BLI_G2_WING:BLI_G2_C2','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2023-01-09',NULL,'FRIDAY',true,'FRIDAY, 2023-01-09, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-09',NULL,'SATURDAY',true,'SATURDAY, 2023-01-09, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-09',NULL,'SATURDAY',true,'SATURDAY, 2023-01-09, 15:30'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-09',NULL,'SUNDAY',true,'SUNDAY, 2023-01-09, 14:00'),
-			('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3','BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-09',NULL,'SUNDAY',true,'SUNDAY, 2023-01-09, 15:30'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',15,0,true,'18:00','18:45','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 18:00'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'09:30','11:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 09:30'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 13:45'),
-			(NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 13:45'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 09:00'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 10:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 13:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 15:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 09:00'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 10:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 13:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 15:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 09:00'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 10:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 09:00'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 10:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 13:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 15:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 09:00'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 10:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 13:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 15:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 09:00'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 10:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 13:30'),
-			(NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 15:30'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 14:00'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 15:30'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 14:00'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 15:30'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 14:00'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 15:30'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 14:00'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 15:30'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 14:00'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 15:30'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 14:00'),
-			(NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 15:30'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 14:00'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 15:30'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-10, 14:00'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-10, 15:30'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'FRIDAY',false,'FRIDAY, 2023-03-10, 14:00'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'FRIDAY',false,'FRIDAY, 2023-03-10, 15:30'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 14:00'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 15:30'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 14:00'),
-			(NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 15:30'),
-			(NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'13:30','15:45','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 13:30'),
-			(NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'09:30','11:30','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 09:30'),
-			(NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'13:30','15:45','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 13:30'),
-			(NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'13:30','15:45','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 13:30'),
-			(NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:15','16:00','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 13:15'),
-			(NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:15','16:00','2023-03-10',NULL,'THURSDAY',false,'THURSDAY, 2023-03-10, 13:15'),
-			(NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:30','16:15','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 13:30'),
-			(NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:30','16:15','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 13:30'),
-			(NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 14:15'),
-			(NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-10, 14:15'),
-			(NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'THURSDAY',false,'THURSDAY, 2023-03-10, 14:15'),
-			(NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 14:15'),
-			(NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 14:15')
-	;
+        INSERT INTO tmp_session_template (locationKeys, incCategories, excCategories, prison_code, visit_room, visit_type, open_capacity, closed_capacity,enhanced, start_time, end_time, valid_from_date, valid_to_date, day_of_week,bi_weekly,name)
+        VALUES
+            (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-05-30','2022-12-18','MONDAY',false,'MONDAY, 2022-05-30, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-06-01','2022-12-18','WEDNESDAY',false,'WEDNESDAY, 2022-06-01, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','10:00','2022-06-03','2022-12-18','FRIDAY',false,'FRIDAY, 2022-06-03, 09:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-06-04','2022-12-18','SATURDAY',false,'SATURDAY, 2022-06-04, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2022-06-05','2022-12-18','SUNDAY',false,'SUNDAY, 2022-06-05, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-19','2022-12-24','MONDAY',false,'MONDAY, 2022-12-19, 14:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-21','2022-12-24','WEDNESDAY',false,'WEDNESDAY, 2022-12-21, 14:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','11:00','2022-12-23','2022-12-24','FRIDAY',false,'FRIDAY, 2022-12-23, 09:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-24','2022-12-24','SATURDAY',false,'SATURDAY, 2022-12-24, 14:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-28','2023-01-02','WEDNESDAY',false,'WEDNESDAY, 2022-12-28, 14:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','11:00','2022-12-30','2023-01-02','FRIDAY',false,'FRIDAY, 2022-12-30, 09:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2022-12-31','2023-01-02','SATURDAY',false,'SATURDAY, 2022-12-31, 14:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2023-01-01','2023-01-02','SUNDAY',false,'SUNDAY, 2023-01-01, 14:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'14:00','16:00','2023-01-02','2023-01-02','MONDAY',false,'MONDAY, 2023-01-02, 14:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-09','2023-03-20','MONDAY',false,'MONDAY, 2023-01-09, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-04','2023-03-20','WEDNESDAY',false,'WEDNESDAY, 2023-01-04, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'09:00','10:00','2023-01-06','2023-03-20','FRIDAY',false,'FRIDAY, 2023-01-06, 09:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-07','2023-03-20','SATURDAY',false,'SATURDAY, 2023-01-07, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',30,2,false,'13:45','14:45','2023-01-08','2023-03-20','SUNDAY',false,'SUNDAY, 2023-01-08, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'MONDAY',false,'MONDAY, 2023-03-21, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-21, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'09:00','10:00','2023-03-21',NULL,'FRIDAY',false,'FRIDAY, 2023-03-21, 09:00'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'SATURDAY',false,'SATURDAY, 2023-03-21, 13:45'),
+                    (NULL,NULL,NULL,'HEI','Visits Main Room','SOCIAL',35,2,false,'13:45','14:45','2023-03-21',NULL,'SUNDAY',false,'SUNDAY, 2023-03-21, 13:45'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','TUESDAY',true,'TUESDAY, 2022-12-05, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','TUESDAY',true,'TUESDAY, 2022-12-05, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','WEDNESDAY',true,'WEDNESDAY, 2022-12-05, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','WEDNESDAY',true,'WEDNESDAY, 2022-12-05, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-05','2022-12-18','FRIDAY',true,'FRIDAY, 2022-12-05, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','SATURDAY',true,'SATURDAY, 2022-12-05, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','SATURDAY',true,'SATURDAY, 2022-12-05, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-05','2022-12-18','SUNDAY',true,'SUNDAY, 2022-12-05, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-05','2022-12-18','SUNDAY',true,'SUNDAY, 2022-12-05, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-11-28','2022-12-18','TUESDAY',true,'TUESDAY, 2022-11-28, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-11-28','2022-12-18','TUESDAY',true,'TUESDAY, 2022-11-28, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-11-28','2022-12-18','WEDNESDAY',true,'WEDNESDAY, 2022-11-28, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-11-28','2022-12-18','FRIDAY',true,'FRIDAY, 2022-11-28, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-11-28','2022-12-18','SATURDAY',true,'SATURDAY, 2022-11-28, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-11-28','2022-12-18','SATURDAY',true,'SATURDAY, 2022-11-28, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-11-28','2022-12-18','SUNDAY',true,'SUNDAY, 2022-11-28, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-11-28','2022-12-18','SUNDAY',true,'SUNDAY, 2022-11-28, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-20','2022-12-20','TUESDAY',false,'TUESDAY, 2022-12-20, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-20','2022-12-20','TUESDAY',false,'TUESDAY, 2022-12-20, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-21','2022-12-21','WEDNESDAY',false,'WEDNESDAY, 2022-12-21, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-21','2022-12-21','WEDNESDAY',false,'WEDNESDAY, 2022-12-21, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-23','2022-12-23','FRIDAY',false,'FRIDAY, 2022-12-23, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-24','2022-12-24','SATURDAY',false,'SATURDAY, 2022-12-24, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-24','2022-12-24','SATURDAY',false,'SATURDAY, 2022-12-24, 15:30'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2022-12-27','2022-12-27','TUESDAY',false,'TUESDAY, 2022-12-27, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-28','2022-12-28','WEDNESDAY',false,'WEDNESDAY, 2022-12-28, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2022-12-30','2022-12-30','FRIDAY',false,'FRIDAY, 2022-12-30, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'09:30','10:30','2022-12-31','2022-12-31','SATURDAY',false,'SATURDAY, 2022-12-31, 09:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2022-12-31','2022-12-31','SATURDAY',false,'SATURDAY, 2022-12-31, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-01','2023-01-01','SUNDAY',false,'SUNDAY, 2023-01-01, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-01','2023-01-01','SUNDAY',false,'SUNDAY, 2023-01-01, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-03','2023-01-03','TUESDAY',false,'TUESDAY, 2023-01-03, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-03','2023-01-03','TUESDAY',false,'TUESDAY, 2023-01-03, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'TUESDAY',true,'TUESDAY, 2023-01-04, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'TUESDAY',true,'TUESDAY, 2023-01-04, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'WEDNESDAY',true,'WEDNESDAY, 2023-01-04, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'WEDNESDAY',true,'WEDNESDAY, 2023-01-04, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2023-01-04',NULL,'FRIDAY',true,'FRIDAY, 2023-01-04, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'SATURDAY',true,'SATURDAY, 2023-01-04, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'SATURDAY',true,'SATURDAY, 2023-01-04, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-04',NULL,'SUNDAY',true,'SUNDAY, 2023-01-04, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-04',NULL,'SUNDAY',true,'SUNDAY, 2023-01-04, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-09',NULL,'TUESDAY',true,'TUESDAY, 2023-01-09, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-09',NULL,'TUESDAY',true,'TUESDAY, 2023-01-09, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2023-01-09',NULL,'WEDNESDAY',true,'WEDNESDAY, 2023-01-09, 14:00'),
+                    ('BLI_G2_WING:BLI_G2_C2',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','16:00','2023-01-09',NULL,'FRIDAY',true,'FRIDAY, 2023-01-09, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-09',NULL,'SATURDAY',true,'SATURDAY, 2023-01-09, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-09',NULL,'SATURDAY',true,'SATURDAY, 2023-01-09, 15:30'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'14:00','15:00','2023-01-09',NULL,'SUNDAY',true,'SUNDAY, 2023-01-09, 14:00'),
+                    ('BLI_G1_WING:BLI_G1_C1:BLI_G1_C2:BLI_G1_C3',NULL,NULL,'BLI','Visits Main Hall','SOCIAL',20,1,false,'15:30','16:30','2023-01-09',NULL,'SUNDAY',true,'SUNDAY, 2023-01-09, 15:30'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',15,0,true,'18:00','18:45','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 18:00'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',0,2,false,'13:45','14:45','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'09:30','11:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 09:30'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'CFI','Visits Main Hall','SOCIAL',40,0,false,'13:45','15:45','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 13:45'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 09:00'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 10:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 13:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 09:00'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 10:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 13:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 09:00'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-01-23, 10:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 09:00'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 10:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 13:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 09:00'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 10:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 13:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'09:00','10:00','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 09:00'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'10:30','11:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 10:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'13:30','14:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 13:30'),
+                    (NULL,NULL,NULL,'WWI','Visits Main Hall','SOCIAL',28,2,false,'15:30','16:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 14:00'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'MONDAY',false,'MONDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 14:00'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'TUESDAY',false,'TUESDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 14:00'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'THURSDAY',false,'THURSDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 14:00'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'FRIDAY',false,'FRIDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 14:00'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'SATURDAY',false,'SATURDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'14:00','15:00','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 14:00'),
+                    (NULL,NULL,NULL,'PNI','Visits Main Hall','SOCIAL',32,8,false,'15:30','16:30','2023-01-23',NULL,'SUNDAY',false,'SUNDAY, 2023-01-23, 15:30'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 14:00'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 15:30'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-10, 14:00'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-10, 15:30'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'FRIDAY',false,'FRIDAY, 2023-03-10, 14:00'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'FRIDAY',false,'FRIDAY, 2023-03-10, 15:30'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 14:00'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 15:30'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'14:00','15:00','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 14:00'),
+                    (NULL,NULL,NULL,'EWI','Visits Main Hall','SOCIAL',10,2,false,'15:30','16:30','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 15:30'),
+                    (NULL,NULL,NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'13:30','15:45','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 13:30'),
+                    (NULL,NULL,NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'09:30','11:30','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 09:30'),
+                    (NULL,NULL,NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'13:30','15:45','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 13:30'),
+                    (NULL,NULL,NULL,'DHI','Visits Main Hall','SOCIAL',24,3,false,'13:30','15:45','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 13:30'),
+                    (NULL,NULL,NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:15','16:00','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 13:15'),
+                    (NULL,NULL,NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:15','16:00','2023-03-10',NULL,'THURSDAY',false,'THURSDAY, 2023-03-10, 13:15'),
+                    (NULL,NULL,NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:30','16:15','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 13:30'),
+                    (NULL,NULL,NULL,'MHI','Visits Main Hall','SOCIAL',14,2,false,'13:30','16:15','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 13:30'),
+                    (NULL,NULL,NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'TUESDAY',false,'TUESDAY, 2023-03-10, 14:15'),
+                    (NULL,NULL,NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'WEDNESDAY',false,'WEDNESDAY, 2023-03-10, 14:15'),
+                    (NULL,NULL,NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'THURSDAY',false,'THURSDAY, 2023-03-10, 14:15'),
+                    (NULL,NULL,NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'SATURDAY',false,'SATURDAY, 2023-03-10, 14:15'),
+                    (NULL,NULL,NULL,'BNI','Visits Main Hall','SOCIAL',60,5,false,'14:15','15:45','2023-03-10',NULL,'SUNDAY',false,'SUNDAY, 2023-03-10, 14:15')
+        ;
 
-	-- update tmp session template table with correct prison id for given code.
-	UPDATE tmp_session_template SET prison_id = prison.id FROM prison WHERE tmp_session_template.prison_code = prison.code;
+        -- update tmp session template table with correct prison id for given code.
+        UPDATE tmp_session_template SET prison_id = prison.id FROM prison WHERE tmp_session_template.prison_code = prison.code;
 
-	-- insert data into real session template table from temporary one.
-	INSERT INTO session_template(id,reference,visit_room,visit_type,open_capacity,closed_capacity,enhanced,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly,name)
-	SELECT id,CONCAT('-',REGEXP_REPLACE(to_hex((ROW_NUMBER () OVER (ORDER BY id))+2951597050), '(.{3})(?!$)', '\1.','g')) as reference,visit_room,visit_type,open_capacity,closed_capacity,enhanced,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly,name FROM tmp_session_template order by id;
+        -- insert data into real session template table from temporary one.
+        INSERT INTO session_template(id,reference,visit_room,visit_type,open_capacity,closed_capacity,enhanced,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly,name)
+        SELECT id,CONCAT('-',REGEXP_REPLACE(to_hex((ROW_NUMBER () OVER (ORDER BY id))+2951597050), '(.{3})(?!$)', '\1.','g')) as reference,visit_room,visit_type,open_capacity,closed_capacity,enhanced,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly,name FROM tmp_session_template order by id;
 
-	-- Sequence updated manually as id's were inserted from temp table
-	ALTER SEQUENCE session_template_id_seq RESTART WITH  145;
+        -- Sequence updated manually as id's were inserted from temp table
+        ALTER SEQUENCE session_template_id_seq RESTART WITH  145;
 
-	-- Create temporary group table
-	CREATE TABLE tmp_session_location_group (
-		id                	serial        NOT NULL PRIMARY KEY,
-		prison_code       	VARCHAR(6)    NOT NULL,
-		prison_id         	int,
-		key          		VARCHAR(50)  NOT NULL,
-		name          	    VARCHAR(100)  NOT NULL
-	);
+        -- Create temporary group table
+        CREATE TABLE tmp_session_location_group (
+            id                	serial        NOT NULL PRIMARY KEY,
+            prison_code       	VARCHAR(6)    NOT NULL,
+            prison_id         	int,
+            key          		VARCHAR(50)  NOT NULL,
+            name          	    VARCHAR(100)  NOT NULL
+        );
 
-	-- Location group names are only descriptions they need to be updated when the group locations change
-	INSERT INTO tmp_session_location_group (prison_code,key,name)
-	VALUES
-		('BLI','BLI_G1_WING','Wings A, B, G, F, E and H'),
-			('BLI','BLI_G1_C1','Wing C - Landing 1 - Cells 1 to 32'),
-			('BLI','BLI_G1_C2','Wing C - Landing 2 - Cells 9 to 24'),
-			('BLI','BLI_G1_C3','Wing C - Landing 3 - Cells 1 to 24'),
-			('BLI','BLI_G2_WING','Wings D and F'),
-			('BLI','BLI_G2_C2','Wing C - Landing 2 - Cells 1 to 8 and 25 to 32')
-	;
+        -- Location group names are only descriptions they need to be updated when the group locations change
+        INSERT INTO tmp_session_location_group (prison_code,key,name)
+        VALUES
+            ('BLI','BLI_G1_WING','Wings A, B, G, F, E and H'),
+                    ('BLI','BLI_G1_C1','Wing C - Landing 1 - Cells 1 to 32'),
+                    ('BLI','BLI_G1_C2','Wing C - Landing 2 - Cells 9 to 24'),
+                    ('BLI','BLI_G1_C3','Wing C - Landing 3 - Cells 1 to 24'),
+                    ('BLI','BLI_G2_WING','Wings D and F'),
+                    ('BLI','BLI_G2_C2','Wing C - Landing 2 - Cells 1 to 8 and 25 to 32')
+        ;
 
-	-- update tmp location group table with correct prison id for given code.
-	UPDATE tmp_session_location_group SET prison_id = prison.id FROM prison WHERE tmp_session_location_group.prison_code = prison.code;
+        -- update tmp location group table with correct prison id for given code.
+        UPDATE tmp_session_location_group SET prison_id = prison.id FROM prison WHERE tmp_session_location_group.prison_code = prison.code;
 
-	-- insert data into real session location group table from temporary one.
-	INSERT INTO session_location_group(id,reference,prison_id,name)
-				SELECT id,CONCAT('-',REGEXP_REPLACE(to_hex((ROW_NUMBER () OVER (ORDER BY key))+2951597050), '(.{3})(?!$)', '\1~','g')) as reference,prison_id,name FROM tmp_session_location_group order by id;
+        -- insert data into real session location group table from temporary one.
+        INSERT INTO session_location_group(id,reference,prison_id,name)
+                    SELECT id,CONCAT('-',REGEXP_REPLACE(to_hex((ROW_NUMBER () OVER (ORDER BY key))+2951597050), '(.{3})(?!$)', '\1~','g')) as reference,prison_id,name FROM tmp_session_location_group order by id;
 
-	-- Sequence updated manually as id's were inserted from temp table
-	ALTER SEQUENCE session_location_group_id_seq RESTART WITH  7;
-
-
-	-- Create permitted session location data
-	CREATE TABLE tmp_permitted_session_location (
-		id                serial        NOT NULL PRIMARY KEY,
-		group_key        VARCHAR(100)  NOT NULL,
-		group_id          int,
-		level_one_code    VARCHAR(10) NOT NULL,
-		level_two_code    VARCHAR(10),
-		level_three_code  VARCHAR(10),
-		level_four_code   VARCHAR(10)
-	);
-
-	INSERT INTO tmp_permitted_session_location (group_key,level_one_code,level_two_code,level_three_code,level_four_code)
-	VALUES
-		('BLI_G1_WING','A',NULL,NULL, NULL),
-			('BLI_G1_WING','B',NULL,NULL, NULL),
-			('BLI_G1_WING','G',NULL,NULL, NULL),
-			('BLI_G1_WING','F',NULL,NULL, NULL),
-			('BLI_G1_WING','E',NULL,NULL, NULL),
-			('BLI_G1_WING','H',NULL,NULL, NULL),
-			('BLI_G1_C1','C','1','001', NULL),
-			('BLI_G1_C1','C','1','002', NULL),
-			('BLI_G1_C1','C','1','003', NULL),
-			('BLI_G1_C1','C','1','004', NULL),
-			('BLI_G1_C1','C','1','005', NULL),
-			('BLI_G1_C1','C','1','006', NULL),
-			('BLI_G1_C1','C','1','007', NULL),
-			('BLI_G1_C1','C','1','008', NULL),
-			('BLI_G1_C1','C','1','009', NULL),
-			('BLI_G1_C1','C','1','010', NULL),
-			('BLI_G1_C1','C','1','011', NULL),
-			('BLI_G1_C1','C','1','012', NULL),
-			('BLI_G1_C1','C','1','013', NULL),
-			('BLI_G1_C1','C','1','014', NULL),
-			('BLI_G1_C1','C','1','015', NULL),
-			('BLI_G1_C1','C','1','016', NULL),
-			('BLI_G1_C1','C','1','017', NULL),
-			('BLI_G1_C1','C','1','018', NULL),
-			('BLI_G1_C1','C','1','019', NULL),
-			('BLI_G1_C1','C','1','020', NULL),
-			('BLI_G1_C1','C','1','021', NULL),
-			('BLI_G1_C1','C','1','022', NULL),
-			('BLI_G1_C1','C','1','023', NULL),
-			('BLI_G1_C1','C','1','024', NULL),
-			('BLI_G1_C1','C','1','025', NULL),
-			('BLI_G1_C1','C','1','026', NULL),
-			('BLI_G1_C1','C','1','027', NULL),
-			('BLI_G1_C1','C','1','028', NULL),
-			('BLI_G1_C1','C','1','029', NULL),
-			('BLI_G1_C1','C','1','030', NULL),
-			('BLI_G1_C1','C','1','031', NULL),
-			('BLI_G1_C1','C','1','032', NULL),
-			('BLI_G1_C2','C','2','009', NULL),
-			('BLI_G1_C2','C','2','010', NULL),
-			('BLI_G1_C2','C','2','011', NULL),
-			('BLI_G1_C2','C','2','012', NULL),
-			('BLI_G1_C2','C','2','013', NULL),
-			('BLI_G1_C2','C','2','014', NULL),
-			('BLI_G1_C2','C','2','015', NULL),
-			('BLI_G1_C2','C','2','016', NULL),
-			('BLI_G1_C2','C','2','017', NULL),
-			('BLI_G1_C2','C','2','018', NULL),
-			('BLI_G1_C2','C','2','019', NULL),
-			('BLI_G1_C2','C','2','020', NULL),
-			('BLI_G1_C2','C','2','021', NULL),
-			('BLI_G1_C2','C','2','022', NULL),
-			('BLI_G1_C2','C','2','023', NULL),
-			('BLI_G1_C2','C','2','024', NULL),
-			('BLI_G1_C3','C','3','001', NULL),
-			('BLI_G1_C3','C','3','002', NULL),
-			('BLI_G1_C3','C','3','003', NULL),
-			('BLI_G1_C3','C','3','004', NULL),
-			('BLI_G1_C3','C','3','005', NULL),
-			('BLI_G1_C3','C','3','006', NULL),
-			('BLI_G1_C3','C','3','007', NULL),
-			('BLI_G1_C3','C','3','008', NULL),
-			('BLI_G1_C3','C','3','009', NULL),
-			('BLI_G1_C3','C','3','010', NULL),
-			('BLI_G1_C3','C','3','011', NULL),
-			('BLI_G1_C3','C','3','012', NULL),
-			('BLI_G1_C3','C','3','013', NULL),
-			('BLI_G1_C3','C','3','014', NULL),
-			('BLI_G1_C3','C','3','015', NULL),
-			('BLI_G1_C3','C','3','016', NULL),
-			('BLI_G1_C3','C','3','017', NULL),
-			('BLI_G1_C3','C','3','018', NULL),
-			('BLI_G1_C3','C','3','019', NULL),
-			('BLI_G1_C3','C','3','020', NULL),
-			('BLI_G1_C3','C','3','021', NULL),
-			('BLI_G1_C3','C','3','022', NULL),
-			('BLI_G1_C3','C','3','023', NULL),
-			('BLI_G1_C3','C','3','024', NULL),
-			('BLI_G2_WING','D',NULL,NULL, NULL),
-			('BLI_G2_WING','F',NULL,NULL, NULL),
-			('BLI_G2_C2','C','2','001', NULL),
-			('BLI_G2_C2','C','2','002', NULL),
-			('BLI_G2_C2','C','2','003', NULL),
-			('BLI_G2_C2','C','2','004', NULL),
-			('BLI_G2_C2','C','2','005', NULL),
-			('BLI_G2_C2','C','2','006', NULL),
-			('BLI_G2_C2','C','2','007', NULL),
-			('BLI_G2_C2','C','2','008', NULL),
-			('BLI_G2_C2','C','2','025', NULL),
-			('BLI_G2_C2','C','2','026', NULL),
-			('BLI_G2_C2','C','2','027', NULL),
-			('BLI_G2_C2','C','2','028', NULL),
-			('BLI_G2_C2','C','2','029', NULL),
-			('BLI_G2_C2','C','2','030', NULL),
-			('BLI_G2_C2','C','2','031', NULL),
-			('BLI_G2_C2','C','2','032', NULL)
-	;
-
-	-- update tmp location table with correct group_id.
-	UPDATE tmp_permitted_session_location SET group_id = tmp_session_location_group.id FROM tmp_session_location_group WHERE tmp_permitted_session_location.group_key = tmp_session_location_group.key;
+        -- Sequence updated manually as id's were inserted from temp table
+        ALTER SEQUENCE session_location_group_id_seq RESTART WITH  7;
 
 
-    -- insert data into real permitted session location table from temporary one.
-	INSERT INTO permitted_session_location(id,group_id,level_one_code,level_two_code,level_three_code,level_four_code)
-		SELECT id,group_id,level_one_code,level_two_code,level_three_code,level_four_code FROM tmp_permitted_session_location order by id;
+        -- Create permitted session location data
+        CREATE TABLE tmp_permitted_session_location (
+            id                serial        NOT NULL PRIMARY KEY,
+            group_key        VARCHAR(100)  NOT NULL,
+            group_id          int,
+            level_one_code    VARCHAR(10) NOT NULL,
+            level_two_code    VARCHAR(10),
+            level_three_code  VARCHAR(10),
+            level_four_code   VARCHAR(10)
+        );
 
-	ALTER SEQUENCE permitted_session_location_id_seq RESTART WITH 97;
+        INSERT INTO tmp_permitted_session_location (group_key,level_one_code,level_two_code,level_three_code,level_four_code)
+        VALUES
+            ('BLI_G1_WING','A',NULL,NULL, NULL),
+                    ('BLI_G1_WING','B',NULL,NULL, NULL),
+                    ('BLI_G1_WING','G',NULL,NULL, NULL),
+                    ('BLI_G1_WING','F',NULL,NULL, NULL),
+                    ('BLI_G1_WING','E',NULL,NULL, NULL),
+                    ('BLI_G1_WING','H',NULL,NULL, NULL),
+                    ('BLI_G1_C1','C','1','001', NULL),
+                    ('BLI_G1_C1','C','1','002', NULL),
+                    ('BLI_G1_C1','C','1','003', NULL),
+                    ('BLI_G1_C1','C','1','004', NULL),
+                    ('BLI_G1_C1','C','1','005', NULL),
+                    ('BLI_G1_C1','C','1','006', NULL),
+                    ('BLI_G1_C1','C','1','007', NULL),
+                    ('BLI_G1_C1','C','1','008', NULL),
+                    ('BLI_G1_C1','C','1','009', NULL),
+                    ('BLI_G1_C1','C','1','010', NULL),
+                    ('BLI_G1_C1','C','1','011', NULL),
+                    ('BLI_G1_C1','C','1','012', NULL),
+                    ('BLI_G1_C1','C','1','013', NULL),
+                    ('BLI_G1_C1','C','1','014', NULL),
+                    ('BLI_G1_C1','C','1','015', NULL),
+                    ('BLI_G1_C1','C','1','016', NULL),
+                    ('BLI_G1_C1','C','1','017', NULL),
+                    ('BLI_G1_C1','C','1','018', NULL),
+                    ('BLI_G1_C1','C','1','019', NULL),
+                    ('BLI_G1_C1','C','1','020', NULL),
+                    ('BLI_G1_C1','C','1','021', NULL),
+                    ('BLI_G1_C1','C','1','022', NULL),
+                    ('BLI_G1_C1','C','1','023', NULL),
+                    ('BLI_G1_C1','C','1','024', NULL),
+                    ('BLI_G1_C1','C','1','025', NULL),
+                    ('BLI_G1_C1','C','1','026', NULL),
+                    ('BLI_G1_C1','C','1','027', NULL),
+                    ('BLI_G1_C1','C','1','028', NULL),
+                    ('BLI_G1_C1','C','1','029', NULL),
+                    ('BLI_G1_C1','C','1','030', NULL),
+                    ('BLI_G1_C1','C','1','031', NULL),
+                    ('BLI_G1_C1','C','1','032', NULL),
+                    ('BLI_G1_C2','C','2','009', NULL),
+                    ('BLI_G1_C2','C','2','010', NULL),
+                    ('BLI_G1_C2','C','2','011', NULL),
+                    ('BLI_G1_C2','C','2','012', NULL),
+                    ('BLI_G1_C2','C','2','013', NULL),
+                    ('BLI_G1_C2','C','2','014', NULL),
+                    ('BLI_G1_C2','C','2','015', NULL),
+                    ('BLI_G1_C2','C','2','016', NULL),
+                    ('BLI_G1_C2','C','2','017', NULL),
+                    ('BLI_G1_C2','C','2','018', NULL),
+                    ('BLI_G1_C2','C','2','019', NULL),
+                    ('BLI_G1_C2','C','2','020', NULL),
+                    ('BLI_G1_C2','C','2','021', NULL),
+                    ('BLI_G1_C2','C','2','022', NULL),
+                    ('BLI_G1_C2','C','2','023', NULL),
+                    ('BLI_G1_C2','C','2','024', NULL),
+                    ('BLI_G1_C3','C','3','001', NULL),
+                    ('BLI_G1_C3','C','3','002', NULL),
+                    ('BLI_G1_C3','C','3','003', NULL),
+                    ('BLI_G1_C3','C','3','004', NULL),
+                    ('BLI_G1_C3','C','3','005', NULL),
+                    ('BLI_G1_C3','C','3','006', NULL),
+                    ('BLI_G1_C3','C','3','007', NULL),
+                    ('BLI_G1_C3','C','3','008', NULL),
+                    ('BLI_G1_C3','C','3','009', NULL),
+                    ('BLI_G1_C3','C','3','010', NULL),
+                    ('BLI_G1_C3','C','3','011', NULL),
+                    ('BLI_G1_C3','C','3','012', NULL),
+                    ('BLI_G1_C3','C','3','013', NULL),
+                    ('BLI_G1_C3','C','3','014', NULL),
+                    ('BLI_G1_C3','C','3','015', NULL),
+                    ('BLI_G1_C3','C','3','016', NULL),
+                    ('BLI_G1_C3','C','3','017', NULL),
+                    ('BLI_G1_C3','C','3','018', NULL),
+                    ('BLI_G1_C3','C','3','019', NULL),
+                    ('BLI_G1_C3','C','3','020', NULL),
+                    ('BLI_G1_C3','C','3','021', NULL),
+                    ('BLI_G1_C3','C','3','022', NULL),
+                    ('BLI_G1_C3','C','3','023', NULL),
+                    ('BLI_G1_C3','C','3','024', NULL),
+                    ('BLI_G2_WING','D',NULL,NULL, NULL),
+                    ('BLI_G2_WING','F',NULL,NULL, NULL),
+                    ('BLI_G2_C2','C','2','001', NULL),
+                    ('BLI_G2_C2','C','2','002', NULL),
+                    ('BLI_G2_C2','C','2','003', NULL),
+                    ('BLI_G2_C2','C','2','004', NULL),
+                    ('BLI_G2_C2','C','2','005', NULL),
+                    ('BLI_G2_C2','C','2','006', NULL),
+                    ('BLI_G2_C2','C','2','007', NULL),
+                    ('BLI_G2_C2','C','2','008', NULL),
+                    ('BLI_G2_C2','C','2','025', NULL),
+                    ('BLI_G2_C2','C','2','026', NULL),
+                    ('BLI_G2_C2','C','2','027', NULL),
+                    ('BLI_G2_C2','C','2','028', NULL),
+                    ('BLI_G2_C2','C','2','029', NULL),
+                    ('BLI_G2_C2','C','2','030', NULL),
+                    ('BLI_G2_C2','C','2','031', NULL),
+                    ('BLI_G2_C2','C','2','032', NULL)
+        ;
+
+        -- update tmp location table with correct group_id.
+        UPDATE tmp_permitted_session_location SET group_id = tmp_session_location_group.id FROM tmp_session_location_group WHERE tmp_permitted_session_location.group_key = tmp_session_location_group.key;
 
 
-	-- Create link table data
-	INSERT INTO session_to_location_group(session_template_id, group_id)
-	SELECT st.id, g.id FROM tmp_session_template st
-									   JOIN tmp_session_location_group g ON POSITION(g.key  IN st.locationKeys)<>0 ORDER BY st.id,g.id;
+        -- insert data into real permitted session location table from temporary one.
+        INSERT INTO permitted_session_location(id,group_id,level_one_code,level_two_code,level_three_code,level_four_code)
+            SELECT id,group_id,level_one_code,level_two_code,level_three_code,level_four_code FROM tmp_permitted_session_location order by id;
 
-	-- Drop temporary tables
-	DROP TABLE tmp_session_template;
-	DROP TABLE tmp_session_location_group;
-	DROP TABLE tmp_permitted_session_location;
+        ALTER SEQUENCE permitted_session_location_id_seq RESTART WITH 97;
 
-END;
+
+        -- Create link table data
+        INSERT INTO session_to_location_group(session_template_id, group_id)
+        SELECT st.id, g.id FROM tmp_session_template st
+                                           JOIN tmp_session_location_group g ON POSITION(g.key  IN st.locationKeys)<>0 ORDER BY st.id,g.id;
+
+        -- Location group names are only descriptions they need to be updated when the group locations change
+
+        -- Prisoner category
+
+        -- Create temporary group table
+            CREATE TABLE tmp_session_prisoner_category (
+                id                  serial          NOT NULL PRIMARY KEY,
+                code                varchar(100)    NOT NULL
+            );
+
+            -- No categories given
+
+        -- insert data into real permitted session location table from temporary one.
+        INSERT INTO session_prisoner_category(id,code)
+            SELECT id,code FROM tmp_session_prisoner_category order by id;
+
+        ALTER SEQUENCE session_prisoner_category_id_seq RESTART WITH 1;
+
+        -- Create inc link table data
+        INSERT INTO session_to_included_prisoner_category(session_template_id, prisoner_category_id)
+        SELECT st.id, c.id FROM tmp_session_template st
+        JOIN tmp_session_prisoner_category c ON POSITION(c.code  IN st.incCategories)<>0 ORDER BY st.id,c.id;
+
+        -- Create inc link table data
+        INSERT INTO session_to_excluded_prisoner_category(session_template_id, prisoner_category_id)
+        SELECT st.id, c.id FROM tmp_session_template st
+        JOIN tmp_session_prisoner_category c ON POSITION(c.code  IN st.excCategories)<>0 ORDER BY st.id,c.id;
+
+    -- Drop temporary tables
+        DROP TABLE tmp_session_template;
+        DROP TABLE tmp_session_location_group;
+        DROP TABLE tmp_permitted_session_location;
+        DROP TABLE tmp_session_prisoner_category;
+    END;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
@@ -6,6 +6,7 @@ import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_VISIT_BY_REFERENCE
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.LOCATION_GROUP_ADMIN_PATH
+import uk.gov.justice.digital.hmpps.visitscheduler.controller.MIGRATE_CANCEL
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.PRISON_LOCATION_GROUPS_ADMIN_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.REFERENCE_LOCATION_GROUP_ADMIN_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.REFERENCE_SESSION_TEMPLATE_PATH
@@ -39,6 +40,24 @@ fun callCancelVisit(
 
 fun getCancelVisitUrl(reference: String): String {
   return VISIT_CANCEL.replace("{reference}", reference)
+}
+
+fun callMigrateCancelVisit(
+  webTestClient: WebTestClient,
+  authHttpHeaders: (HttpHeaders) -> Unit,
+  reference: String,
+  cancelVisitDto: CancelVisitDto? = null,
+): ResponseSpec {
+  return callPut(
+    cancelVisitDto,
+    webTestClient,
+    getMigrateCancelVisitUrl(reference),
+    authHttpHeaders,
+  )
+}
+
+fun getMigrateCancelVisitUrl(reference: String): String {
+  return MIGRATE_CANCEL.replace("{reference}", reference)
 }
 
 fun callVisitReserveSlotChange(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
@@ -95,6 +95,7 @@ class MigrateVisitTest : IntegrationTestBase() {
       legacyData = CreateLegacyDataRequestDto(123),
       createDateTime = LocalDateTime.of(2022, 9, 11, 12, 30),
       modifyDateTime = LocalDateTime.of(2022, 10, 1, 12, 30),
+      actionedBy = "Aled Evans",
     )
   }
 
@@ -143,6 +144,7 @@ class MigrateVisitTest : IntegrationTestBase() {
           tuple(VISIT_COMMENT, "A visit comment"),
           tuple(STATUS_CHANGED_REASON, "Status has changed"),
         )
+      assertThat(visit.createdBy).isEqualTo("Aled Evans")
 
       val legacyData = legacyDataRepository.findByVisitId(visit.id)
       assertThat(legacyData).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
@@ -21,15 +21,20 @@ import org.springframework.transaction.annotation.Propagation.SUPPORTS
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.reactive.function.BodyInserter
 import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateLegacyContactOnVisitRequestDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateLegacyContactOnVisitRequestDto.Companion.UNKNOWN_TOKEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateLegacyDataRequestDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.MigrateVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.OutcomeDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitNoteDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitorDto
+import uk.gov.justice.digital.hmpps.visitscheduler.helper.callMigrateCancelVisit
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus.COMPLETED_NORMALLY
 import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus.NOT_RECORDED
+import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus.PRISONER_CANCELLED
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.STATUS_CHANGED_REASON
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.VISITOR_CONCERN
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType.VISIT_COMMENT
@@ -40,6 +45,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.LegacyDataRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
+import uk.gov.justice.digital.hmpps.visitscheduler.service.TelemetryVisitEvents
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -144,25 +150,8 @@ class MigrateVisitTest : IntegrationTestBase() {
         assertThat(legacyData.visitId).isEqualTo(visit.id)
         assertThat(legacyData.leadPersonId).isEqualTo(123)
       }
+      assertTelemetryClientEvents(VisitDto(visit), TelemetryVisitEvents.VISIT_MIGRATED_EVENT)
     }
-
-    // And
-    verify(telemetryClient).trackEvent(
-      eq("visit-migrated"),
-      org.mockito.kotlin.check {
-        assertThat(it["reference"]).isEqualTo(reference)
-        assertThat(it["prisonerId"]).isEqualTo("FF0000FF")
-        assertThat(it["prisonId"]).isEqualTo("MDI")
-        assertThat(it["visitType"]).isEqualTo(SOCIAL.name)
-        assertThat(it["visitRoom"]).isEqualTo("A1")
-        assertThat(it["visitRestriction"]).isEqualTo(OPEN.name)
-        assertThat(it["visitStart"]).isEqualTo(visitTime.format(DateTimeFormatter.ISO_DATE_TIME))
-        assertThat(it["visitStatus"]).isEqualTo(BOOKED.name)
-        assertThat(it["outcomeStatus"]).isEqualTo(COMPLETED_NORMALLY.name)
-      },
-      isNull(),
-    )
-    verify(telemetryClient, times(1)).trackEvent(eq("visit-migrated"), any(), isNull())
   }
 
   @Test
@@ -627,6 +616,40 @@ class MigrateVisitTest : IntegrationTestBase() {
     responseSpec.expectStatus().isUnauthorized
   }
 
+  @Test
+  fun `cancel visit migrated by reference -  with outcome and outcome text`() {
+    // Given
+    val visit = visitEntityHelper.create(visitStatus = BOOKED)
+
+    val cancelVisitDto = CancelVisitDto(
+      OutcomeDto(
+        PRISONER_CANCELLED,
+        "Prisoner got covid",
+      ),
+      CancelVisitTest.cancelledByByUser,
+    )
+    val reference = visit.reference
+
+    // When
+    val responseSpec = callMigrateCancelVisit(webTestClient, setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")), reference, cancelVisitDto)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk
+      .expectBody()
+      .returnResult()
+
+    // And
+    val visitCancelled = objectMapper.readValue(returnResult.responseBody, VisitDto::class.java)
+    CancelVisitTest.assertVisitCancellation(visitCancelled, PRISONER_CANCELLED, cancelVisitDto.actionedBy)
+    assertThat(visitCancelled.visitNotes.size).isEqualTo(1)
+    assertThat(visitCancelled.visitNotes[0].text).isEqualTo("Prisoner got covid")
+    assertThat(visitCancelled.createdBy).isEqualTo(visit.createdBy)
+    assertThat(visitCancelled.updatedBy).isEqualTo(visit.updatedBy)
+
+    assertTelemetryClientEvents(visitCancelled, TelemetryVisitEvents.CANCELLED_VISIT_MIGRATED_EVENT)
+    assertCancelledDomainEvent(visitCancelled)
+  }
+
   private fun getReference(responseSpec: ResponseSpec): String {
     var reference = ""
     responseSpec.expectBody()
@@ -659,5 +682,54 @@ class MigrateVisitTest : IntegrationTestBase() {
 
   companion object {
     val visitTime: LocalDateTime = LocalDateTime.of(LocalDate.now().year + 1, 11, 1, 12, 30, 44)
+  }
+
+  fun assertTelemetryClientEvents(
+    cancelledVisit: VisitDto,
+    type: TelemetryVisitEvents,
+  ) {
+    verify(telemetryClient).trackEvent(
+      eq(type.eventName),
+      org.mockito.kotlin.check {
+        assertThat(it["reference"]).isEqualTo(cancelledVisit.reference)
+        assertThat(it["applicationReference"]).isEqualTo(cancelledVisit.applicationReference)
+        assertThat(it["prisonerId"]).isEqualTo(cancelledVisit.prisonerId)
+        assertThat(it["prisonId"]).isEqualTo(cancelledVisit.prisonCode)
+        assertThat(it["visitType"]).isEqualTo(cancelledVisit.visitType.name)
+        assertThat(it["visitRoom"]).isEqualTo(cancelledVisit.visitRoom)
+        assertThat(it["visitRestriction"]).isEqualTo(cancelledVisit.visitRestriction.name)
+        assertThat(it["visitStart"]).isEqualTo(cancelledVisit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
+        assertThat(it["visitStatus"]).isEqualTo(cancelledVisit.visitStatus.name)
+        assertThat(it["outcomeStatus"]).isEqualTo(cancelledVisit.outcomeStatus!!.name)
+      },
+      isNull(),
+    )
+
+    val eventsMap = mutableMapOf(
+      "reference" to cancelledVisit.reference,
+      "applicationReference" to cancelledVisit.applicationReference,
+      "prisonerId" to cancelledVisit.prisonerId,
+      "prisonId" to cancelledVisit.prisonCode,
+      "visitType" to cancelledVisit.visitType.name,
+      "visitRoom" to cancelledVisit.visitRoom,
+      "visitRestriction" to cancelledVisit.visitRestriction.name,
+      "visitStart" to cancelledVisit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME),
+      "visitStatus" to cancelledVisit.visitStatus.name,
+      "outcomeStatus" to cancelledVisit.outcomeStatus!!.name,
+    )
+    verify(telemetryClient, times(1)).trackEvent(type.eventName, eventsMap, null)
+  }
+
+  fun assertCancelledDomainEvent(
+    cancelledVisit: VisitDto,
+  ) {
+    verify(telemetryClient).trackEvent(
+      eq("prison-visit.cancelled-domain-event"),
+      org.mockito.kotlin.check {
+        assertThat(it["reference"]).isEqualTo(cancelledVisit.reference)
+      },
+      isNull(),
+    )
+    verify(telemetryClient, times(1)).trackEvent(eq("prison-visit.cancelled-domain-event"), any(), isNull())
   }
 }


### PR DESCRIPTION
## What does this pull request do?

It prevents cancelation validation when migrated data from NOMIS

## What is the intent behind these changes?

To allow migrated cancelations to take place from nomis