### PR TITLE
Make actioned by feild optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/MigrateVisitRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/MigrateVisitRequestDto.kt
@@ -53,6 +53,6 @@ data class MigrateVisitRequestDto(
   val visitors: Set<@Valid VisitorDto>? = setOf(),
   @Schema(description = "Visit notes", required = false)
   val visitNotes: Set<@Valid VisitNoteDto>? = setOf(),
-  @Schema(description = "Username for user who actioned this request", required = true)
+  @Schema(description = "Username for user who actioned this request", required = false)
   val actionedBy: String? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
@@ -73,7 +73,7 @@ class MigrateVisitTest : IntegrationTestBase() {
     roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS"))
   }
 
-  private fun createMigrateVisitRequestDto(actionedBy : String ?= "Aled Evans",): MigrateVisitRequestDto {
+  private fun createMigrateVisitRequestDto(actionedBy: String ? = "Aled Evans"): MigrateVisitRequestDto {
     return MigrateVisitRequestDto(
       prisonCode = "MDI",
       prisonerId = "FF0000FF",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateVisitTest.kt
@@ -100,7 +100,7 @@ class MigrateVisitTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `migrate visit 1`() {
+  fun `migrate visit`() {
     // Given
 
     val migrateVisitRequestDto = createMigrateVisitRequestDto()


### PR DESCRIPTION
## What does this pull request do?

createdBy is now optional also added tests.

## What is the intent behind these changes?

Sync process will be temporarily using old api without the created by details.