### PR TITLE
VB-2074 cache support types and supported prisons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/VisitSchedulerApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/VisitSchedulerApplication.kt
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.security.SecurityScheme
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @SecurityScheme(name = "bearerAuth", scheme = "bearer", type = SecuritySchemeType.HTTP, bearerFormat = "JWT")
 @EnableScheduling
+@EnableCaching
 class VisitScheduler
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/PrisonConfigService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/PrisonConfigService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.service
 
 import jakarta.validation.ValidationException
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -18,6 +19,7 @@ class PrisonConfigService(
     return prisonRepository.findByCode(prisonCode) ?: throw ValidationException(messageService.getMessage("validation.prison.notfound", prisonCode))
   }
 
+  @Cacheable("supported-prisons")
   @Transactional(readOnly = true)
   fun getSupportedPrisons(): List<String> {
     return prisonRepository.getSupportedPrisons()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SupportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SupportService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.service
 
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.SupportTypeDto
@@ -11,6 +12,7 @@ class SupportService(
 ) {
 
   @Transactional(readOnly = true)
+  @Cacheable("support-types")
   fun getSupportTypes(): List<SupportTypeDto> {
     // Revisit externalising support types and content management
     return supportTypeRepository.findAll().sortedBy { it.code }.map { SupportTypeDto(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/task/ScheduledCacheEvictTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/task/ScheduledCacheEvictTask.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.task
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Scheduled task to evict cache to ensure cache is refreshed at regular intervals.
+ */
+@Component
+class ScheduledCacheEvictTask {
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Scheduled(cron = "\${cache.evict.support-types.cron:0 0 */12 * * ?}")
+  @CacheEvict(value = ["support-types"], allEntries = true)
+  fun evictSupportTypesCache() {
+    LOG.debug("Evicting support types cache.")
+  }
+
+  @Scheduled(cron = "\${cache.evict.supported-prisons.cron:0 0 */3 * * ?}")
+  @CacheEvict(value = ["supported-prisons"], allEntries = true)
+  fun evictSupportedPrisonsCache() {
+    LOG.debug("Evicting supported prisons cache.")
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -41,3 +41,10 @@ task:
     enabled: true
     cron: 0 0/10 * * * ?
     validity-minutes: 20
+
+cache:
+  evict:
+    support-types:
+      cron: "0 */15 * * * ?"
+    supported-prisons:
+      cron: "0 */15 * * * ?"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,3 +128,10 @@ feature:
 visit:
   cancel:
     day-limit: 28
+
+cache:
+  evict:
+    support-types:
+      cron: "0 0 */12 * * ?" #every 12 hours
+    supported-prisons:
+      cron: "0 0 0/3 * * ?" #every 3 hours

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/VisitSupportControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/VisitSupportControllerTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.integration
 
 import com.microsoft.applicationinsights.TelemetryClient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -8,8 +10,9 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.annotation.DirtiesContext
+import org.springframework.cache.CacheManager
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SupportTypeRepository
 
 @DisplayName("Get /visit-support")
@@ -21,8 +24,16 @@ class VisitSupportControllerTest : IntegrationTestBase() {
   @SpyBean
   private lateinit var supportTypeRepository: SupportTypeRepository
 
+  @Autowired
+  private lateinit var cacheManager: CacheManager
+
+  @BeforeEach
+  @AfterEach
+  fun clearCache() {
+    cacheManager.getCache("support-types")?.clear()
+  }
+
   @Test
-  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   fun `all available support is returned`() {
     // Give
     val requiredRole = listOf("ROLE_VISIT_SCHEDULER")
@@ -41,7 +52,6 @@ class VisitSupportControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   fun `when support is called twice cached values are returned the second time`() {
     // Give
     val requiredRole = listOf("ROLE_VISIT_SCHEDULER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/config/GetSupportedPrisonsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/config/GetSupportedPrisonsTest.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.integration.config
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.annotation.DirtiesContext
+import org.springframework.cache.CacheManager
 import org.springframework.test.web.reactive.server.WebTestClient.BodyContentSpec
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.SUPPORTED_PRISONS
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
@@ -18,10 +21,18 @@ class GetSupportedPrisonsTest : IntegrationTestBase() {
   @SpyBean
   private lateinit var prisonRepository: PrisonRepository
 
+  @Autowired
+  private lateinit var cacheManager: CacheManager
+
   private val requiredRole = listOf("ROLE_VISIT_SCHEDULER")
 
+  @BeforeEach
+  @AfterEach
+  fun clearCache() {
+    cacheManager.getCache("supported-prisons")?.clear()
+  }
+
   @Test
-  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   fun `all supported prisons are returned in correct order`() {
     // Given
     val today = LocalDate.now()
@@ -53,7 +64,6 @@ class GetSupportedPrisonsTest : IntegrationTestBase() {
   }
 
   @Test
-  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   fun `when supported prisons is called twice cached values are returned the second time`() {
     // Given
     val today = LocalDate.now()
@@ -90,7 +100,6 @@ class GetSupportedPrisonsTest : IntegrationTestBase() {
   }
 
   @Test
-  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   fun `sessions with inactive prisons are not returned`() {
     // Given
     sessionTemplateEntityHelper.create(prisonCode = "GRE", activePrison = false)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/config/GetSupportedPrisonsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/config/GetSupportedPrisonsTest.kt
@@ -3,17 +3,25 @@ package uk.gov.justice.digital.hmpps.visitscheduler.integration.config
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.reactive.server.WebTestClient.BodyContentSpec
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.SUPPORTED_PRISONS
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.PrisonRepository
 import java.time.LocalDate
 
 @DisplayName("Get $SUPPORTED_PRISONS")
 class GetSupportedPrisonsTest : IntegrationTestBase() {
+  @SpyBean
+  private lateinit var prisonRepository: PrisonRepository
 
   private val requiredRole = listOf("ROLE_VISIT_SCHEDULER")
 
   @Test
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   fun `all supported prisons are returned in correct order`() {
     // Given
     val today = LocalDate.now()
@@ -40,9 +48,49 @@ class GetSupportedPrisonsTest : IntegrationTestBase() {
     assertThat(results[2]).isEqualTo("CDE")
     assertThat(results[3]).isEqualTo("GRE")
     assertThat(results[4]).isEqualTo("WDE")
+
+    verify(prisonRepository, times(1)).getSupportedPrisons()
   }
 
   @Test
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  fun `when supported prisons is called twice cached values are returned the second time`() {
+    // Given
+    val today = LocalDate.now()
+
+    sessionTemplateEntityHelper.create(validFromDate = today, prisonCode = "AWE")
+    sessionTemplateEntityHelper.create(validFromDate = today, validToDate = today, prisonCode = "GRE")
+    sessionTemplateEntityHelper.create(validFromDate = today.minusDays(1), prisonCode = "CDE")
+    sessionTemplateEntityHelper.create(validFromDate = today.minusDays(1), validToDate = today, prisonCode = "BDE")
+    sessionTemplateEntityHelper.create(validFromDate = today.minusDays(2), validToDate = today.plusDays(1), prisonCode = "WDE")
+
+    // When
+    var responseSpec = webTestClient.get().uri(SUPPORTED_PRISONS)
+      .headers(setAuthorisation(roles = requiredRole))
+      .exchange()
+
+    // Then
+    var returnResult = responseSpec.expectStatus().isOk
+      .expectBody()
+    var results = getResults(returnResult)
+
+    assertThat(results.size).isEqualTo(5)
+
+    // When a call to supported prisons is made a 2nd time same values are returned but from cache
+    responseSpec = webTestClient.get().uri(SUPPORTED_PRISONS)
+      .headers(setAuthorisation(roles = requiredRole))
+      .exchange()
+
+    // Then
+    returnResult = responseSpec.expectStatus().isOk
+      .expectBody()
+    results = getResults(returnResult)
+    assertThat(results.size).isEqualTo(5)
+    verify(prisonRepository, times(1)).getSupportedPrisons()
+  }
+
+  @Test
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   fun `sessions with inactive prisons are not returned`() {
     // Given
     sessionTemplateEntityHelper.create(prisonCode = "GRE", activePrison = false)
@@ -59,6 +107,7 @@ class GetSupportedPrisonsTest : IntegrationTestBase() {
     val results = getResults(returnResult)
 
     assertThat(results.size).isEqualTo(0)
+    verify(prisonRepository, times(1)).getSupportedPrisons()
   }
 
   private fun getResults(returnResult: BodyContentSpec): Array<String> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/QuotableEncoderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/QuotableEncoderTest.kt
@@ -145,13 +145,13 @@ internal class QuotableEncoderTest {
   inner class EncoderCollisions {
 
     @Test
-    fun `Half a million hashes has no collisions`() {
+    fun `quarter a million hashes has no collisions`() {
       // Given
       // Not designed for testing extremely large values.
       val encoder = QuotableEncoder(minLength = 8)
 
       val hashes = mutableListOf<String>()
-      for (n in 0..500000) {
+      for (n in 0..250000) {
         // When
         val hash = encoder.encode(n.toLong())
         hashes.add(hash)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -71,3 +71,10 @@ feature:
 visit:
   cancel:
     day-limit: 28
+
+cache:
+  evict:
+    support-types:
+      cron: "0 0 */23 * * ?" #every 23 hours
+    supported-prisons:
+      cron: "0 0 0/23 * * ?" #every 23 hours


### PR DESCRIPTION
VB-2074 cache support types and supported prisons so that the data is not fetched from DB every time.

## What does this pull request do?

Caches support types and supported prisons and evicts the cache at regular intervals
## What is the intent behind these changes?

Performance improvements.