### PR TITLE
VB-2096 - update the applicationinsights.json to reduce logging

### DIFF
--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -28,22 +28,6 @@
             }
           ],
           "percentage": 10
-        },
-        {
-          "telemetryType": "dependency",
-          "attributes": [
-            {
-              "key": "job.system",
-              "value": "spring_scheduling",
-              "matchType": "strict"
-            },
-            {
-              "key": "code.namespace",
-              "value": "io.awspring.cloud.sqs.listener.acknowledgement.BatchingAcknowledgementProcessor.*",
-              "matchType": "regexp"
-            }
-          ],
-          "percentage": 0
         }
       ]
     }


### PR DESCRIPTION
update the applicationinsights.json to reduce logging on PreProd and Prod as it is logging all trace logs from dependencies as well.

## What does this pull request do?

updates the applicationinsights.json to reduce logging

## What is the intent behind these changes?
 Too much trace logs being logged in application insights especially for dependencies like JPA, Hibernate etc.