### PR TITLE
VB-2096 - Reduce dependency logging on prod and preprod

### DIFF
--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -13,9 +13,6 @@
   "selfDiagnostics": {
     "destination": "console"
   },
-  "sampling": {
-    "percentage": 100
-  },
   "preview": {
     "sampling": {
       "overrides": [


### PR DESCRIPTION
removed the sampling as can still see the dependency logs o…n preprod.

## What does this pull request do?

Reduce dependency logging on prod and preprod

## What is the intent behind these changes?

Reduce dependency logging as logs are being cluttered