### PR TITLE
Remove list of capacity objects from api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
@@ -180,7 +180,7 @@ class VisitSessionController(
       example = "14:30:00",
     )
     sessionEndTime: LocalTime,
-  ): List<SessionCapacityDto> {
+  ): SessionCapacityDto {
     return sessionService.getSessionCapacity(prisonCode, sessionDate, sessionStartTime, sessionEndTime)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionCapacityDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionCapacityDto.kt
@@ -9,17 +9,13 @@ data class SessionCapacityDto(
   val closed: Int,
   @Schema(description = "open capacity", example = "50", required = true)
   val open: Int,
-  @Schema(description = "Capacity group", example = "Main Group", required = false)
-  val capacityGroup: String? = null,
 ) {
   constructor(sessionTemplateEntity: SessionTemplate) : this(
     closed = sessionTemplateEntity.closedCapacity,
     open = sessionTemplateEntity.openCapacity,
-    capacityGroup = sessionTemplateEntity.capacityGroup,
   )
   constructor(capacityGroupOfSessionTemplates: List<SessionTemplate>) : this(
     closed = capacityGroupOfSessionTemplates.sumOf { it.closedCapacity },
     open = capacityGroupOfSessionTemplates.sumOf { it.openCapacity },
-    capacityGroup = capacityGroupOfSessionTemplates.first().capacityGroup,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -284,7 +284,7 @@ class SessionService(
   private fun isDateWithinRange(sessionDate: LocalDate, startDate: LocalDate, endDate: LocalDate? = null) =
     sessionDate >= startDate && (endDate == null || sessionDate <= endDate)
 
-  fun getSessionCapacity(prisonCode: String, sessionDate: LocalDate, sessionStartTime: LocalTime, sessionEndTime: LocalTime): List<SessionCapacityDto> {
+  fun getSessionCapacity(prisonCode: String, sessionDate: LocalDate, sessionStartTime: LocalTime, sessionEndTime: LocalTime): SessionCapacityDto {
     val dayOfWeek = sessionDate.dayOfWeek
 
     var sessionTemplates = sessionTemplateRepository.findValidSessionTemplatesForSession(
@@ -301,8 +301,7 @@ class SessionService(
       throw CapacityNotFoundException("Session capacity not found prisonCode:$prisonCode,session Date:$sessionDate, StartTime:$sessionStartTime, EndTime:$sessionEndTime, dayOfWeek:$dayOfWeek")
     }
 
-    val capacityGroups = sessionTemplates.groupBy { it.capacityGroup }
-    return capacityGroups.map { (capacityGroup, itemsInGroup) -> SessionCapacityDto(itemsInGroup) }
+    return SessionCapacityDto(sessionTemplates)
   }
 
   private fun filterSessionsTemplatesForDate(date: LocalDate, sessionTemplates: List<SessionTemplate>): List<SessionTemplate> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionCapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionCapacityTest.kt
@@ -37,8 +37,8 @@ class GetSessionCapacityTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
     val sessionCapacity = getResults(returnResult)
-    Assertions.assertThat(sessionCapacity[0].closed).isEqualTo(sessionTemplate.closedCapacity)
-    Assertions.assertThat(sessionCapacity[0].open).isEqualTo(sessionTemplate.openCapacity)
+    Assertions.assertThat(sessionCapacity.closed).isEqualTo(sessionTemplate.closedCapacity)
+    Assertions.assertThat(sessionCapacity.open).isEqualTo(sessionTemplate.openCapacity)
   }
 
   @Test
@@ -74,12 +74,12 @@ class GetSessionCapacityTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
     val sessionCapacity = getResults(returnResult)
-    Assertions.assertThat(sessionCapacity[0].closed).isEqualTo(sessionTemplate1.closedCapacity)
-    Assertions.assertThat(sessionCapacity[0].open).isEqualTo(sessionTemplate1.openCapacity)
+    Assertions.assertThat(sessionCapacity.closed).isEqualTo(sessionTemplate1.closedCapacity)
+    Assertions.assertThat(sessionCapacity.open).isEqualTo(sessionTemplate1.openCapacity)
   }
 
   @Test
-  fun `Capacity groups capacities are added up`() {
+  fun `Capacities are added up`() {
     // Given
 
     val nextAllowedDay = getNextAllowedDay()
@@ -124,11 +124,8 @@ class GetSessionCapacityTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
     val sessionCapacity = getResults(returnResult)
-    Assertions.assertThat(sessionCapacity.size).isEqualTo(2)
-    Assertions.assertThat(sessionCapacity[0].closed).isEqualTo(sessionTemplate1.closedCapacity)
-    Assertions.assertThat(sessionCapacity[0].open).isEqualTo(sessionTemplate1.openCapacity)
-    Assertions.assertThat(sessionCapacity[1].closed).isEqualTo(20)
-    Assertions.assertThat(sessionCapacity[1].open).isEqualTo(22)
+    Assertions.assertThat(sessionCapacity.closed).isEqualTo(21)
+    Assertions.assertThat(sessionCapacity.open).isEqualTo(23)
   }
 
   @Test
@@ -164,9 +161,8 @@ class GetSessionCapacityTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
     val sessionCapacity = getResults(returnResult)
-    Assertions.assertThat(sessionCapacity.size).isEqualTo(1)
-    Assertions.assertThat(sessionCapacity[0].closed).isEqualTo(sessionTemplate1.closedCapacity + sessionTemplate2.closedCapacity)
-    Assertions.assertThat(sessionCapacity[0].open).isEqualTo(sessionTemplate1.openCapacity + sessionTemplate2.openCapacity)
+    Assertions.assertThat(sessionCapacity.closed).isEqualTo(sessionTemplate1.closedCapacity + sessionTemplate2.closedCapacity)
+    Assertions.assertThat(sessionCapacity.open).isEqualTo(sessionTemplate1.openCapacity + sessionTemplate2.openCapacity)
   }
 
   @Test
@@ -196,7 +192,7 @@ class GetSessionCapacityTest : IntegrationTestBase() {
     return LocalDate.now().plusDays(2)
   }
 
-  private fun getResults(returnResult: BodyContentSpec): Array<SessionCapacityDto> {
-    return objectMapper.readValue(returnResult.returnResult().responseBody, Array<SessionCapacityDto>::class.java)
+  private fun getResults(returnResult: BodyContentSpec): SessionCapacityDto {
+    return objectMapper.readValue(returnResult.returnResult().responseBody, SessionCapacityDto::class.java)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Removes multiple capacity dto's being returned when different capacity groups, it now adds them all up

## What is the intent behind these changes?

Reduce UI change