### PR TITLE
Still had capacoty_group in temp table

### DIFF
--- a/src/main/resources/db.scripts.mvp/Simple_set__Session_Template_Data.sql
+++ b/src/main/resources/db.scripts.mvp/Simple_set__Session_Template_Data.sql
@@ -228,7 +228,7 @@
 
         -- insert data into real session template table from temporary one.
         INSERT INTO session_template(id,reference,visit_room,visit_type,open_capacity,closed_capacity,enhanced,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly,name)
-        SELECT id,CONCAT('-',REGEXP_REPLACE(to_hex((ROW_NUMBER () OVER (ORDER BY id))+2951597050), '(.{3})(?!$)', '\1.','g')) as reference,capacity_group,visit_type,open_capacity,closed_capacity,enhanced,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly,name FROM tmp_session_template order by id;
+        SELECT id,CONCAT('-',REGEXP_REPLACE(to_hex((ROW_NUMBER () OVER (ORDER BY id))+2951597050), '(.{3})(?!$)', '\1.','g')) as reference,visit_room,visit_type,open_capacity,closed_capacity,enhanced,start_time,end_time,valid_from_date,valid_to_date,day_of_week,prison_id,bi_weekly,name FROM tmp_session_template order by id;
 
         -- Sequence updated manually as id's were inserted from temp table
         ALTER SEQUENCE session_template_id_seq RESTART WITH  168;


### PR DESCRIPTION
## What does this pull request do?

Small error in sql script capacoty_group was still in sql script re verted back to visit_room

## What is the intent behind these changes?

Sql would not run in preprod other wise