### PR TITLE
Added support for bi weekly session mapping in migration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/MigrationSessiontTemplateMatcher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/MigrationSessiontTemplateMatcher.kt
@@ -27,6 +27,7 @@ class MigrationSessionTemplateMatcher(
   private val prisonerCategoryMatcher: PrisonerCategoryMatcher,
   private val prisonerIncentiveLevelMatcher: PrisonerIncentiveLevelMatcher,
   private val sessionValidator: PrisonerSessionValidator,
+  private val sessionDatesUtil: SessionDatesUtil,
 ) {
 
   companion object {
@@ -71,11 +72,15 @@ class MigrationSessionTemplateMatcher(
     sessionDate: LocalDate,
     restriction: VisitRestriction,
   ): List<SessionTemplate> {
-    val templates = sessionTemplateRepository.findValidSessionTemplatesBy(
+    var templates = sessionTemplateRepository.findValidSessionTemplatesBy(
       rangeStartDate = sessionDate,
       prisonCode = prisonCode,
       dayOfWeek = sessionDate.dayOfWeek,
     )
+
+    templates = templates.filter {
+      sessionDatesUtil.isBiWeeklySessionActiveForDate(sessionDate, it)
+    }
 
     return removeUnwantedRestrictionTypes(restriction, templates)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtil.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtil.kt
@@ -65,6 +65,6 @@ class SessionDatesUtil {
 
   fun isBiWeeklySkipDate(
     validFromDate: LocalDate,
-    firstBookableSessionDay: LocalDate,
-  ) = WEEKS.between(validFromDate, firstBookableSessionDay).toInt() % 2 != 0
+    sessionDate: LocalDate,
+  ) = WEEKS.between(validFromDate, sessionDate).toInt() % 2 != 0
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitSessionMatchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitSessionMatchTest.kt
@@ -864,4 +864,56 @@ class MigrateVisitSessionMatchTest : MigrationIntegrationTestBase() {
       assertThat(visit.sessionTemplateReference).isEqualTo(sessionTemplate.reference)
     }
   }
+
+  @Test
+  fun `Migrated session match - for Bi weekly session templates`() {
+    // Given
+    val migrateVisitRequestDto = createMigrateVisitRequestDto()
+    val startTime = migrateVisitRequestDto.startTimestamp.toLocalTime()
+    val endTime = migrateVisitRequestDto.endTimestamp.toLocalTime()
+    val dayOfWeek = migrateVisitRequestDto.startTimestamp.dayOfWeek
+
+    sessionTemplateEntityHelper.create(
+      validFromDate = LocalDate.now().minusDays(7),
+      prisonCode = migrateVisitRequestDto.prisonCode,
+      dayOfWeek = dayOfWeek,
+      visitRoom = migrateVisitRequestDto.visitRoom,
+      startTime = startTime,
+      endTime = endTime,
+      biWeekly = true,
+    )
+
+    val sessionTemplate = sessionTemplateEntityHelper.create(
+      validFromDate = LocalDate.now().minusDays(14),
+      prisonCode = migrateVisitRequestDto.prisonCode,
+      dayOfWeek = dayOfWeek,
+      visitRoom = migrateVisitRequestDto.visitRoom,
+      startTime = startTime,
+      endTime = endTime,
+      biWeekly = true,
+    )
+
+    sessionTemplateEntityHelper.create(
+      validFromDate = LocalDate.now().minusDays(21),
+      prisonCode = migrateVisitRequestDto.prisonCode,
+      dayOfWeek = dayOfWeek,
+      visitRoom = migrateVisitRequestDto.visitRoom,
+      startTime = startTime,
+      endTime = endTime,
+      biWeekly = true,
+    )
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, migrateVisitRequestDto)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+    val reference = getReference(responseSpec)
+
+    val visit = visitRepository.findByReference(reference)
+    assertThat(visit).isNotNull
+    visit?.let {
+      assertThat(visit.sessionTemplateReference).isEqualTo(sessionTemplate.reference)
+    }
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds support for Bi weekly mapping of sessions to migrated visits

## What is the intent behind these changes?

To fix a defect and therefore solving the issue with capacity counts with migrated data