### PR TITLE
Delet all DMI migrated visits in prod

### DIFF
--- a/src/main/resources/db.scripts/test/R__VB-2248_Delete_DMI_migrated_visits.sql
+++ b/src/main/resources/db.scripts/test/R__VB-2248_Delete_DMI_migrated_visits.sql
@@ -22,9 +22,7 @@ BEGIN;
     DELETE FROM legacy_data WHERE visit_id IN (SELECT visit_id FROM tmp_delete_migrated_visits);
 
     -- Drop temporary tables
-    DROP TABLE  tmp_visits_with_sessions;
-    DROP TABLE  tmp_visits_to_sessions;
-    DROP TABLE  tmp_visits_to_dup_sessions;
+    DROP TABLE  tmp_delete_migrated_visits;
 
 -- Commit the change
 END;

--- a/src/main/resources/db.scripts/test/R__VB-2248_Delete_DMI_migrated_visits.sql
+++ b/src/main/resources/db.scripts/test/R__VB-2248_Delete_DMI_migrated_visits.sql
@@ -26,4 +26,5 @@ BEGIN;
     DROP TABLE  tmp_visits_to_sessions;
     DROP TABLE  tmp_visits_to_dup_sessions;
 
-COMMIT;
+-- Commit the change
+END;

--- a/src/main/resources/db.scripts/test/R__VB-2248_Delete_DMI_migrated_visits.sql
+++ b/src/main/resources/db.scripts/test/R__VB-2248_Delete_DMI_migrated_visits.sql
@@ -1,0 +1,29 @@
+-- *** THIS SHOULD NEVER BE RUN IN LIVE ***
+-- Start a transaction
+BEGIN;
+
+    SET SCHEMA 'public';
+
+    -- Create
+    CREATE TEMP TABLE tmp_delete_migrated_visits(visit_id int not null);
+
+        -- Insert
+    INSERT INTO tmp_delete_migrated_visits(visit_id)
+        SELECT v.id FROM visit v
+                        JOIN legacy_data ld ON ld.visit_id = v.id
+                        JOIN prison p ON p.id = v.prison_id
+                        WHERE p.code = 'DMI'
+    -- Delete
+    DELETE FROM visit WHERE id IN (SELECT visit_id FROM tmp_delete_migrated_visits);
+    DELETE FROM visit_contact WHERE visit_id IN (SELECT visit_id FROM tmp_delete_migrated_visits);
+    DELETE FROM visit_notes WHERE visit_id IN (SELECT visit_id FROM tmp_delete_migrated_visits);
+    DELETE FROM visit_support WHERE visit_id IN (SELECT visit_id FROM tmp_delete_migrated_visits);
+    DELETE FROM visit_visitor WHERE visit_id IN (SELECT visit_id FROM tmp_delete_migrated_visits);
+    DELETE FROM legacy_data WHERE visit_id IN (SELECT visit_id FROM tmp_delete_migrated_visits);
+
+    -- Drop temporary tables
+    DROP TABLE  tmp_visits_with_sessions;
+    DROP TABLE  tmp_visits_to_sessions;
+    DROP TABLE  tmp_visits_to_dup_sessions;
+
+COMMIT;


### PR DESCRIPTION
## What does this pull request do?

Remove DMI migrated data from DB

## What is the intent behind these changes?

To allow us to re migrate all DMI visits in prod