### PR TITLE
Update schedule for logging non association visits

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,7 +121,7 @@ task:
     validity-minutes: 20
   log-non-associations:
     enabled: true
-    cron: "0 0 3 * * ?" #every day at 3 AM
+    cron: "0 0 14 * * ?" #every day at 2 PM - to be changed post release to 3 AM again
     number-of-days-ahead: 30
 
 feature:


### PR DESCRIPTION

## What does this pull request do?

Moves the log non association run to 2 PM
## What is the intent behind these changes?

Log non association visits on Live