### PR TITLE
VB-1295 - interim fix to reduce time span to 10 minutes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -48,7 +48,7 @@ class VisitService(
   private val sessionTemplateService: SessionTemplateService,
   private val snsService: SnsService,
   private val prisonConfigService: PrisonConfigService,
-  @Value("\${task.expired-visit.validity-minutes:20}") private val expiredPeriodMinutes: Int,
+  @Value("\${task.expired-visit.validity-minutes:10}") private val expiredPeriodMinutes: Int,
   @Value("\${visit.cancel.day-limit:28}") private val visitCancellationDayLimit: Int,
 ) {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,8 +117,8 @@ policy:
 task:
   expired-visit:
     enabled: true
-    cron: 0 0/10 * * * *
-    validity-minutes: 10 # delete reserved visits older than validity-minutes
+    cron: 0 0/5 * * * * #frequency of delete expired reserved visits cron job - every 5 minutes
+    validity-minutes: 10 #delete reserved visits older than 10 minutes
   log-non-associations:
     enabled: true
     cron: "0 0 3 * * ?" #every day at 3 AM


### PR DESCRIPTION
VB-1295 - interim fix to reduce the time span from 20 minutes to 10 minutes. Any reserved visits older than 10 minutes will be deleted.

## What does this pull request do?

Deletes reserved visits older than 10 minutes instead of the current 20 minutes.
## What is the intent behind these changes?

Interim fix as call centre cannot book visits for same prisoner again for 20 minutes. So reducing the time to 10 minutes.