### PR TITLE
Fix to resolve issues with multiple events being created

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -49,6 +49,11 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
   fun findApplication(applicationReference: String): Visit?
 
   @Query(
+    "SELECT v.reference FROM Visit v WHERE v.applicationReference = :applicationReference AND (v.visitStatus = 'CHANGING' OR v.visitStatus = 'RESERVED') ",
+  )
+  fun getApplicationBookingReference(applicationReference: String): String?
+
+  @Query(
     "SELECT v FROM Visit v WHERE v.applicationReference = :applicationReference AND v.visitStatus = 'BOOKED' ",
   )
   fun findBookedApplication(applicationReference: String): Visit?
@@ -117,6 +122,11 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
     "SELECT v FROM Visit v WHERE v.reference = :reference AND v.visitStatus = 'BOOKED' ",
   )
   fun findBookedVisit(reference: String): Visit?
+
+  @Query(
+    "SELECT CASE WHEN (COUNT(v) > 0) THEN TRUE ELSE FALSE END FROM Visit v WHERE v.reference = :reference AND v.visitStatus = 'BOOKED' ",
+  )
+  fun doseBookedVisitExist(reference: String): Boolean
 
   @Transactional
   @Modifying

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/util/PersistVisitHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/util/PersistVisitHelper.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.service.util
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation.REQUIRES_NEW
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.exception.VisitNotFoundException
+import uk.gov.justice.digital.hmpps.visitscheduler.model.OutcomeStatus.SUPERSEDED_CANCELLATION
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitNoteType
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
+
+@Component
+@Transactional(propagation = REQUIRES_NEW)
+class PersistVisitHelper(
+  private val visitRepository: VisitRepository,
+) {
+
+  fun persistBooking(applicationReference: String): VisitDto {
+    val visitToBook = visitRepository.findApplication(applicationReference)
+      ?: throw VisitNotFoundException("Application (reference $applicationReference) not found")
+
+    visitRepository.findBookedVisit(visitToBook.reference)?.let { existingBooking ->
+      existingBooking.visitStatus = CANCELLED
+      existingBooking.outcomeStatus = SUPERSEDED_CANCELLATION
+      existingBooking.cancelledBy = visitToBook.createdBy
+      visitRepository.saveAndFlush(existingBooking)
+
+      // set the new bookings updated by to current username and set createdBy to existing booking username
+      visitToBook.updatedBy = visitToBook.createdBy
+      visitToBook.createdBy = existingBooking.createdBy
+    }
+
+    visitToBook.visitStatus = VisitStatus.BOOKED
+    return VisitDto(visitRepository.saveAndFlush(visitToBook))
+  }
+
+  fun persistCancel(reference: String, cancelVisitDto: CancelVisitDto): VisitDto {
+    val cancelOutcome = cancelVisitDto.cancelOutcome
+
+    val visitEntity = visitRepository.findBookedVisit(reference) ?: throw VisitNotFoundException("Visit $reference not found")
+
+    visitEntity.visitStatus = CANCELLED
+    visitEntity.outcomeStatus = cancelOutcome.outcomeStatus
+    visitEntity.cancelledBy = cancelVisitDto.actionedBy
+
+    cancelOutcome.text?.let {
+      visitEntity.visitNotes.add(createVisitNote(visitEntity, VisitNoteType.VISIT_OUTCOMES, cancelOutcome.text))
+    }
+
+    return VisitDto(visitRepository.saveAndFlush(visitEntity))
+  }
+
+  private fun createVisitNote(visit: Visit, type: VisitNoteType, text: String): VisitNote {
+    return VisitNote(
+      visitId = visit.id,
+      type = type,
+      text = text,
+      visit = visit,
+    )
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

This pull requests moves the update of the visit entity for booking and cancellation into a helper class, so the transaction can be complete before the domain events are sent (Domain events can take some time). Therefore other threads with the same action and details will use the latest persisted data. Hopefully duplicate requests will be caught by isApplicationBooked or isBookingCancelled and the existing details will be return with no additional process.   

## What is the intent behind these changes?

To prevent duplicate events from being sent to the domain events and down stream actions will not be actioned.


