### PR TITLE
Vb 2321 delete api function on session templates add validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -84,6 +84,14 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
   ): Boolean
 
   @Query(
+    "SELECT count(v) > 0 FROM Visit v " +
+      "WHERE v.sessionTemplateReference = :sessionTemplateReference",
+  )
+  fun hasVisitsForSessionTemplate(
+    sessionTemplateReference: String,
+  ): Boolean
+
+  @Query(
     "SELECT v.visitRestriction AS visitRestriction, COUNT(v) AS count  FROM Visit v " +
       "WHERE v.prison.code = :prisonCode AND " +
       "v.visitStart >= :startDateTime AND " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionCategoryGro
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionIncentiveLevelGroupRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionLocationGroupRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionTemplateRepository
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.util.function.Supplier
 
 @Service
@@ -43,6 +44,7 @@ class SessionTemplateService(
   private val sessionLocationGroupRepository: SessionLocationGroupRepository,
   private val sessionCategoryGroupRepository: SessionCategoryGroupRepository,
   private val sessionIncentiveLevelGroupRepository: SessionIncentiveLevelGroupRepository,
+  private val visitRepository: VisitRepository,
   private val prisonConfigService: PrisonConfigService,
 ) {
 
@@ -216,6 +218,10 @@ class SessionTemplateService(
   }
 
   fun deleteSessionTemplates(reference: String) {
+    if (visitRepository.hasVisitsForSessionTemplate(reference)) {
+      throw VSiPValidationException("Cannot delete session template $reference with existing visits!")
+    }
+
     val deleted = sessionTemplateRepository.deleteByReference(reference)
     if (deleted == 0) {
       throw ItemNotFoundException("Session template not found : $reference")


### PR DESCRIPTION
## What does this pull request do?

add's validation to delete end point, if session template has visits then it cannot be deleted.

## What is the intent behind these changes?

to make sure session templates can only be delete when there is no associated visits, to prevent live session templates being deleted