### PR TITLE
VB-2395 Block dates from Cardiff schedule in VSiP (CFI)

### DIFF
--- a/src/main/resources/db/migration/data/R__add_prison_codes.sql
+++ b/src/main/resources/db/migration/data/R__add_prison_codes.sql
@@ -48,6 +48,9 @@ INSERT INTO prison_exclude_date(prison_id, exclude_date) Select id,'2023-07-08' 
 
 -- HMP Cardiff (CFI)
 INSERT INTO prison_exclude_date(prison_id, exclude_date) Select id,'2023-07-26' from prison where code = 'CFI';
+INSERT INTO prison_exclude_date(prison_id, exclude_date) Select id,'2023-07-12' from prison where code = 'CFI';
+INSERT INTO prison_exclude_date(prison_id, exclude_date) Select id,'2023-07-19' from prison where code = 'CFI';
+
 
 -- HMP Wandsworth (WWI)
 INSERT INTO prison_exclude_date(prison_id, exclude_date) Select id,'2023-07-05' from prison where code = 'WWI';


### PR DESCRIPTION
Description

We need to remove the following dates from the social visits timetable for Cardiff:

12 7 2023 

19 7 2023 