### PR TITLE
VB-2569 return list of visit dates and counts as part of visit stats endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitCountsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitCountsDto.kt
@@ -6,11 +6,11 @@ import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class SessionTemplateVisitCountsDto(
-  @Schema(description = "Date when the visits are booked or reserved",example = "2023-07-01", required = true)
+  @Schema(description = "Date when the visits are booked or reserved", example = "2023-07-01", required = true)
   @field:NotNull
-  val visitDate: LocalDate?,
+  val visitDate: LocalDate,
 
   @Schema(description = "Count of booked or reserved visits for a date", example = "10", required = true)
   @field:Min(1)
-  val visitCount: Int?,
+  val visitCount: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitCountsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitCountsDto.kt
@@ -11,6 +11,7 @@ data class SessionTemplateVisitCountsDto(
   val visitDate: LocalDate,
 
   @Schema(description = "Count of booked or reserved visits for a date", example = "10", required = true)
+  @field:NotNull
   @field:Min(1)
   val visitCount: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitCountsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitCountsDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class SessionTemplateVisitCountsDto(
+  @Schema(description = "Date when the visits are booked or reserved",example = "2023-07-01", required = true)
+  @field:NotNull
+  val visitDate: LocalDate?,
+
+  @Schema(description = "Count of booked or reserved visits for a date", example = "10", required = true)
+  @field:Min(1)
+  val visitCount: Int?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitStatsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateVisitStatsDto.kt
@@ -13,4 +13,7 @@ data class SessionTemplateVisitStatsDto(
   @Schema(description = "visit count for given date", example = "10", required = true)
   @field:Min(0)
   val visitCount: Int,
+
+  @Schema(description = "count of visits by date", required = false)
+  val visitsByDate: List<SessionTemplateVisitCountsDto>?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/projections/VisitCountsByDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/projections/VisitCountsByDate.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.model.entity.projections
+
+import java.time.LocalDate
+
+interface VisitCountsByDate {
+  val visitDate: LocalDate
+  val visitCount: Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionTemplateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionTemplateRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionCapacityDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionDateRangeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTimeSlotDto
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.projections.VisitCountsByDate
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -45,6 +46,21 @@ interface SessionTemplateRepository : JpaRepository<SessionTemplate, Long> {
     @Param("visitsFromDate") visitsFromDate: LocalDate,
     @Param("visitsToDate") visitsToDate: LocalDate,
   ): Int
+
+  @Query(
+    "select cast(v.visit_start as date) as visitDate, count(*) as visitCount from visit v " +
+      " JOIN session_template st ON st.reference = v.session_template_reference " +
+      " WHERE st.reference = :reference AND v.visit_start > :visitsFromDate AND v.visit_start < :visitsToDate " +
+      " AND visit_status IN ('BOOKED','RESERVED','CHANGING')" +
+      " GROUP BY v.visit_start" +
+      " ORDER BY v.visit_start",
+    nativeQuery = true,
+  )
+  fun getVisitCountsByDate(
+    @Param("reference") reference: String,
+    @Param("visitsFromDate") visitsFromDate: LocalDate,
+    @Param("visitsToDate") visitsToDate: LocalDate,
+  ): List<VisitCountsByDate>
 
   @Query(
     "select u from SessionTemplate u " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.CreateSessionTem
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.RequestSessionTemplateVisitStatsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionCapacityDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateVisitCountsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateVisitStatsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.UpdateSessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.category.CreateCategoryGroupDto
@@ -442,8 +443,11 @@ class SessionTemplateService(
     val open = if (emptyResults) 0 else (minimumCapacityTuple.get(0) as Long).toInt()
     val closed = if (emptyResults) 0 else (minimumCapacityTuple.get(1) as Long).toInt()
 
+    val visitCountsByDate = this.sessionTemplateRepository.getVisitCountsByDate(reference, requestSessionTemplateVisitStatsDto.visitsFromDate, visitsToDate).map {
+      SessionTemplateVisitCountsDto(it.visitDate, it.visitCount)
+    }.toList()
     val visitCount = this.sessionTemplateRepository.getVisitCount(reference, requestSessionTemplateVisitStatsDto.visitsFromDate, visitsToDate)
-    return SessionTemplateVisitStatsDto(SessionCapacityDto(closed, open), visitCount)
+    return SessionTemplateVisitStatsDto(SessionCapacityDto(closed, open), visitCount, visitCountsByDate)
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminSessionTemplateVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminSessionTemplateVisitsTest.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.admin.ACTIVATE_SESSION_TEMPLATE
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.admin.DEACTIVATE_SESSION_TEMPLATE
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateVisitCountsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateVisitStatsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callGetActivateSessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
@@ -83,6 +84,13 @@ class AdminSessionTemplateVisitsTest(
     Assertions.assertThat(sessionTemplateVisitStatsDto.visitCount).isEqualTo(6)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.open).isEqualTo(2)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.closed).isEqualTo(1)
+    Assertions.assertThat(sessionTemplateVisitStatsDto.visitsByDate).size().isEqualTo(5)
+    val visitsByDate = sessionTemplateVisitStatsDto.visitsByDate
+    Assertions.assertThat(visitsByDate!![0]).isEqualTo(SessionTemplateVisitCountsDto(visitsFromDateTime.plusDays(1).toLocalDate(), 2))
+    Assertions.assertThat(visitsByDate[1]).isEqualTo(SessionTemplateVisitCountsDto(visitsFromDateTime.plusDays(2).toLocalDate(), 1))
+    Assertions.assertThat(visitsByDate[2]).isEqualTo(SessionTemplateVisitCountsDto(visitsFromDateTime.plusDays(3).toLocalDate(), 1))
+    Assertions.assertThat(visitsByDate[3]).isEqualTo(SessionTemplateVisitCountsDto(visitsFromDateTime.plusDays(4).toLocalDate(), 1))
+    Assertions.assertThat(visitsByDate[4]).isEqualTo(SessionTemplateVisitCountsDto(visitsFromDateTime.plusDays(policyNoticeDaysMax - 1).toLocalDate(), 1))
   }
 
   private fun getSessionTemplateVisitStatsDto(responseSpec: ResponseSpec) =
@@ -107,6 +115,7 @@ class AdminSessionTemplateVisitsTest(
     Assertions.assertThat(sessionTemplateVisitStatsDto.visitCount).isEqualTo(0)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.open).isEqualTo(0)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.closed).isEqualTo(0)
+    Assertions.assertThat(sessionTemplateVisitStatsDto.visitsByDate).size().isEqualTo(0)
   }
 
   @Test
@@ -128,6 +137,7 @@ class AdminSessionTemplateVisitsTest(
     Assertions.assertThat(sessionTemplateVisitStatsDto.visitCount).isEqualTo(0)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.open).isEqualTo(0)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.closed).isEqualTo(0)
+    Assertions.assertThat(sessionTemplateVisitStatsDto.visitsByDate).size().isEqualTo(0)
   }
 
   @Test
@@ -148,5 +158,6 @@ class AdminSessionTemplateVisitsTest(
     Assertions.assertThat(sessionTemplateVisitStatsDto.visitCount).isEqualTo(0)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.open).isEqualTo(0)
     Assertions.assertThat(sessionTemplateVisitStatsDto.minimumCapacity.closed).isEqualTo(0)
+    Assertions.assertThat(sessionTemplateVisitStatsDto.visitsByDate).size().isEqualTo(0)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Updates the session template stats endpoint to include a list of visit dates and counts

## What is the intent behind these changes?

Admin API improvements.