### PR TITLE
VB-2470 add validation around updates of valid to date to allow updates if visits are cancelled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -79,11 +79,13 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
   @Query(
     "SELECT count(v) > 0 FROM Visit v " +
       "WHERE v.sessionTemplateReference = :sessionTemplateReference AND " +
-      "(cast(:visitsFromDate as date)  is null or cast(v.visitStart as date) >= :visitsFromDate) ",
+      "(cast(:visitsFromDate as date)  is null or cast(v.visitStart as date) >= :visitsFromDate) AND " +
+      "((:#{#visitStatuses == null} = true) OR v.visitStatus IN (:visitStatuses))",
   )
   fun hasVisitsForSessionTemplate(
     sessionTemplateReference: String,
     visitsFromDate: LocalDate? = null,
+    visitStatuses: List<VisitStatus>? = null,
   ): Boolean
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -79,13 +79,22 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
   @Query(
     "SELECT count(v) > 0 FROM Visit v " +
       "WHERE v.sessionTemplateReference = :sessionTemplateReference AND " +
-      "(cast(:visitsFromDate as date)  is null or cast(v.visitStart as date) >= :visitsFromDate) AND " +
-      "((:#{#visitStatuses == null} = true) OR v.visitStatus IN (:visitStatuses))",
+      "(cast(:visitsFromDate as date)  is null or cast(v.visitStart as date) >= :visitsFromDate) ",
   )
   fun hasVisitsForSessionTemplate(
     sessionTemplateReference: String,
     visitsFromDate: LocalDate? = null,
-    visitStatuses: List<VisitStatus>? = null,
+  ): Boolean
+
+  @Query(
+    "SELECT count(v) > 0 FROM Visit v " +
+      "WHERE v.sessionTemplateReference = :sessionTemplateReference AND " +
+      "(cast(:visitsFromDate as date)  is null or cast(v.visitStart as date) >= :visitsFromDate) AND " +
+      "(v.visitStatus IN ('BOOKED','RESERVED','CHANGING'))",
+  )
+  fun hasBookedVisitsForSessionTemplate(
+    sessionTemplateReference: String,
+    visitsFromDate: LocalDate? = null,
   ): Boolean
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/UpdateSessionTemplateValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/UpdateSessionTemplateValidator.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.UpdateSessionTemplateDto
+import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionTemplateRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDate
@@ -64,9 +65,10 @@ class UpdateSessionTemplateValidator(
       if (newValidToDate != existingValidToDate) {
         // if the new validToDate is not null or before existing validToDate
         if ((newValidToDate != null && existingValidToDate == null) || (newValidToDate != null && newValidToDate.isBefore(existingValidToDate))) {
-          // check if there are any visits (any visit status) after the new valid to date
-          if (visitRepository.hasVisitsForSessionTemplate(existingSessionTemplate.reference, newValidToDate.plusDays(1))) {
-            return "Cannot update session valid to date to $newValidToDate for session template - ${existingSessionTemplate.reference} as there are visits associated with this session template after $newValidToDate."
+          // check if there are any booked or reserved visits (any visit status) after the new valid to date
+          val visitStatues = listOf<VisitStatus>(VisitStatus.BOOKED, VisitStatus.RESERVED, VisitStatus.CHANGING)
+          if (visitRepository.hasVisitsForSessionTemplate(existingSessionTemplate.reference, newValidToDate.plusDays(1), visitStatues)) {
+            return "Cannot update session valid to date to $newValidToDate for session template - ${existingSessionTemplate.reference} as there are booked or reserved visits associated with this session template after $newValidToDate."
           }
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/UpdateSessionTemplateValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/UpdateSessionTemplateValidator.kt
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.UpdateSessionTemplateDto
-import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionTemplateRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import java.time.LocalDate
@@ -66,8 +65,7 @@ class UpdateSessionTemplateValidator(
         // if the new validToDate is not null or before existing validToDate
         if ((newValidToDate != null && existingValidToDate == null) || (newValidToDate != null && newValidToDate.isBefore(existingValidToDate))) {
           // check if there are any booked or reserved visits (any visit status) after the new valid to date
-          val visitStatues = listOf<VisitStatus>(VisitStatus.BOOKED, VisitStatus.RESERVED, VisitStatus.CHANGING)
-          if (visitRepository.hasVisitsForSessionTemplate(existingSessionTemplate.reference, newValidToDate.plusDays(1), visitStatues)) {
+          if (visitRepository.hasBookedVisitsForSessionTemplate(existingSessionTemplate.reference, newValidToDate.plusDays(1))) {
             return "Cannot update session valid to date to $newValidToDate for session template - ${existingSessionTemplate.reference} as there are booked or reserved visits associated with this session template after $newValidToDate."
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminUpdateSessionTemplateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminUpdateSessionTemplateTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.boot.test.mock.mockito.SpyBean
@@ -372,7 +371,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validFromDate).isEqualTo(dto.sessionDateRange?.validFromDate)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validToDate).isEqualTo(dto.sessionDateRange?.validToDate)
-    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any(), any())
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
   }
 
   @Test
@@ -398,7 +397,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validFromDate).isEqualTo(dto.sessionDateRange?.validFromDate)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validToDate).isEqualTo(dto.sessionDateRange?.validToDate)
-    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any(), any())
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
   }
 
   @Test
@@ -425,7 +424,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validFromDate).isEqualTo(dto.sessionDateRange?.validFromDate)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validToDate).isEqualTo(dto.sessionDateRange?.validToDate)
-    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any(), any())
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
   }
 
   @Test
@@ -465,10 +464,10 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validFromDate).isEqualTo(dto.sessionDateRange?.validFromDate)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validToDate).isEqualTo(dto.sessionDateRange?.validToDate)
-    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
+    verify(visitRepository, times(1)).hasBookedVisitsForSessionTemplate(
       eq(sessionTemplateWithValidDates.reference),
       eq(newValidToDate.plusDays(1)),
-      eq(listOf(VisitStatus.BOOKED, VisitStatus.RESERVED, VisitStatus.CHANGING)),
     )
   }
 
@@ -505,10 +504,10 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validFromDate).isEqualTo(dto.sessionDateRange?.validFromDate)
     Assertions.assertThat(sessionTemplateDto.sessionDateRange.validToDate).isEqualTo(dto.sessionDateRange?.validToDate)
-    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
+    verify(visitRepository, times(1)).hasBookedVisitsForSessionTemplate(
       eq(sessionTemplateWithValidDates.reference),
       eq(newValidToDate.plusDays(1)),
-      eq(listOf(VisitStatus.BOOKED, VisitStatus.RESERVED, VisitStatus.CHANGING)),
     )
   }
 
@@ -541,7 +540,8 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isBadRequest
       .expectBody()
       .jsonPath("$.validationMessages[0]").value(Matchers.containsString("Cannot update session valid to date to $newValidToDate for session template - ${sessionTemplateWithValidDates.reference} as there are booked or reserved visits associated with this session template after $newValidToDate."))
-    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(eq(sessionTemplateWithValidDates.reference), eq(newValidToDate.plusDays(1)), eq(listOf(VisitStatus.BOOKED, VisitStatus.RESERVED, VisitStatus.CHANGING)))
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
+    verify(visitRepository, times(1)).hasBookedVisitsForSessionTemplate(eq(sessionTemplateWithValidDates.reference), eq(newValidToDate.plusDays(1)))
   }
 
   @Test
@@ -563,7 +563,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.weeklyFrequency).isEqualTo(newWeeklyFrequency)
-    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(eq(sessionTemplateDto.reference), eq(null), isNull())
+    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(eq(sessionTemplateDto.reference), eq(null))
   }
 
   @Test
@@ -585,7 +585,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.weeklyFrequency).isEqualTo(newWeeklyFrequency)
-    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(eq(sessionTemplateDto.reference), eq(null), isNull())
+    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(eq(sessionTemplateDto.reference), eq(null))
   }
 
   @Test
@@ -607,7 +607,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.weeklyFrequency).isEqualTo(newWeeklyFrequency)
-    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any(), any())
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
   }
 
   @Test
@@ -685,7 +685,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.weeklyFrequency).isEqualTo(newWeeklyFrequency)
-    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any(), any())
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
   }
 
   @Test
@@ -709,7 +709,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionCapacity).isEqualTo(newSessionCapacity)
-    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any(), any())
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
   }
 
   @Test
@@ -732,7 +732,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionCapacity).isEqualTo(newSessionCapacity)
-    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any(), any())
+    verify(visitRepository, times(0)).hasVisitsForSessionTemplate(any(), any())
   }
 
   @Test
@@ -755,7 +755,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionCapacity).isEqualTo(newSessionCapacity)
-    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(sessionTemplate.reference, null, null)
+    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(sessionTemplate.reference, null)
   }
 
   @Test
@@ -802,7 +802,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     val sessionTemplateDto = getSessionTemplate(responseSpec)
     Assertions.assertThat(sessionTemplateDto.name).isEqualTo(dto.name)
     Assertions.assertThat(sessionTemplateDto.sessionCapacity).isEqualTo(newSessionCapacity)
-    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(sessionTemplate.reference, null, null)
+    verify(visitRepository, times(1)).hasVisitsForSessionTemplate(sessionTemplate.reference, null)
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

Updates validation around valid to date to looked for booked or reserved visits.
## What is the intent behind these changes?

Admin API improvements.