### PR TITLE
Updated visit booked/reserved count check

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -333,19 +333,21 @@ class SessionService(
   }
 
   private fun getVisitRestrictionStats(session: VisitSessionDto): List<VisitRestrictionStats> {
-    val restrictionReservedStats = visitRepository.getCountOfReservedSessionVisitsForOpenOrClosedRestriction(
-      prisonCode = session.prisonCode,
-      sessionTemplateReference = session.sessionTemplateReference,
-      startDateTime = session.startTimestamp,
-      endDateTime = session.endTimestamp,
-      expiredDateAndTime = visitService.getReservedExpiredDateAndTime(),
-    )
-
     val restrictionBookedStats = visitRepository.getCountOfBookedSessionVisitsForOpenOrClosedRestriction(
       prisonCode = session.prisonCode,
       sessionTemplateReference = session.sessionTemplateReference,
-      startDateTime = session.startTimestamp,
-      endDateTime = session.endTimestamp,
+      sessionDate = session.startTimestamp.toLocalDate(),
+      sessionStartTime = session.startTimestamp.toLocalTime(),
+      sessionEndTime = session.endTimestamp.toLocalTime(),
+    )
+
+    val restrictionReservedStats = visitRepository.getCountOfReservedSessionVisitsForOpenOrClosedRestriction(
+      prisonCode = session.prisonCode,
+      sessionTemplateReference = session.sessionTemplateReference,
+      sessionDate = session.startTimestamp.toLocalDate(),
+      sessionStartTime = session.startTimestamp.toLocalTime(),
+      sessionEndTime = session.endTimestamp.toLocalTime(),
+      expiredDateAndTime = visitService.getReservedExpiredDateAndTime(),
     )
 
     return restrictionReservedStats + restrictionBookedStats

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsTest.kt
@@ -1006,7 +1006,7 @@ class GetSessionsTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `visit sessions visit count includes only visits within session period`() {
+  fun `visit sessions visit count includes only visits within session template period`() {
     // Given
     val nextAllowedDay = this.getNextAllowedDay()
     val dateTime = nextAllowedDay.atTime(9, 0)
@@ -1069,11 +1069,23 @@ class GetSessionsTest : IntegrationTestBase() {
       sessionTemplateReference = sessionTemplate.reference,
     )
 
+    this.visitEntityHelper.create(
+      prisonerId = "AF12345G",
+      prisonCode = "MDI",
+      visitRoom = sessionTemplate.visitRoom,
+      visitStart = dateTime,
+      visitEnd = endTime,
+      visitType = SOCIAL,
+      visitStatus = BOOKED,
+      visitRestriction = OPEN,
+      sessionTemplateReference = sessionTemplate.reference + "other",
+    )
+
     // When
     val responseSpec = callGetSessions()
 
     // Then
-    assertBookCounts(responseSpec, openCount = 2, closeCount = 0)
+    assertBookCounts(responseSpec, openCount = 4, closeCount = 0)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceTest.kt
@@ -109,8 +109,9 @@ class SessionServiceTest {
       visitRepository.getCountOfBookedSessionVisitsForOpenOrClosedRestriction(
         sessionTemplate.prison.code,
         sessionTemplateReference = sessionTemplate.reference,
-        startDateTime,
-        endDateTime,
+        startDateTime.toLocalDate(),
+        startDateTime.toLocalTime(),
+        endDateTime.toLocalTime(),
       ),
     ).thenReturn(getVisitRestrictionStatsList(visits))
   }
@@ -352,6 +353,7 @@ class SessionServiceTest {
         prison = prison,
         visitStatus = RESERVED,
         visitRestriction = OPEN,
+        sessionTemplateReference = singleSession.reference,
         visitRoom = "1",
       )
 
@@ -364,6 +366,7 @@ class SessionServiceTest {
         prison = prison,
         visitStatus = RESERVED,
         visitRestriction = CLOSED,
+        sessionTemplateReference = singleSession.reference,
         visitRoom = "1",
       )
       mockVisitRepositoryCountResponse(listOf(openVisit, closedVisit), singleSession)


### PR DESCRIPTION
To fix a booking count issues, it now uses the session template start and end time to work out the booking count