### PR TITLE
VB-2715 added end point with dummy response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitNotificationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitNotificationController.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NonAssociationChangedNotificationDto
+
+const val VISIT_NOTIFICATION_CONTROLLER_PATH: String = "/visits/notification"
+const val VISIT_NOTIFICATION_NONASSOCIATION_CHANGE_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/nonAssociation/changed"
+
+@RestController
+@Validated
+@Tag(name = "Visit notification controller $VISIT_NOTIFICATION_CONTROLLER_PATH")
+@RequestMapping(name = "Visit notification Resource", produces = [MediaType.APPLICATION_JSON_VALUE])
+class VisitNotificationController {
+
+  private companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @PreAuthorize("hasRole('VISIT_SCHEDULER')")
+  @PostMapping(VISIT_NOTIFICATION_NONASSOCIATION_CHANGE_PATH)
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "To notify VSiP that non association between two prisoners has changed",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "notification has completed successfully",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to notify VSiP of change",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to notify VSiP of change",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun notifyVSiPThatNonAssociationHasChanged(
+    @RequestBody @Valid
+    nonAssociationChangedNotificationDto: NonAssociationChangedNotificationDto,
+  ): ResponseEntity<HttpStatus> {
+    LOG.debug("Entered notifyVSiPOfNonAssociationHasChanged $nonAssociationChangedNotificationDto")
+    return ResponseEntity(HttpStatus.OK)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/NonAssociationChangedNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/NonAssociationChangedNotificationDto.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
+
+import java.time.LocalDate
+
+data class NonAssociationChangedNotificationDto(
+  val prisonerNumber: String,
+  val nonAssociationPrisonerNumber: String,
+  val validFromDate: LocalDate,
+  val validToDate: LocalDate? = null,
+)


### PR DESCRIPTION
Implement non-association for SQS - create listener in orchestration, added endpoint to allow orchestration work to be complete

## What does this pull request do?

It adds an end point with dummy response.

## What is the intent behind these changes?

to allow use to continue separate threads of coding work..