### PR TITLE
VB-3172 - update visitsToDate to be null so that all visits will be returned

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/RequestSessionTemplateVisitStatsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/RequestSessionTemplateVisitStatsDto.kt
@@ -5,7 +5,10 @@ import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class RequestSessionTemplateVisitStatsDto(
-  @Schema(description = "Visits from date stats", example = "2019-11-02", required = true)
+  @Schema(description = "Visits from date - for stats", example = "2019-11-02", required = true)
   @field:NotNull
   val visitsFromDate: LocalDate,
+
+  @Schema(description = "Visits to date - for stats", example = "2019-11-30", required = false)
+  val visitsToDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionTemplateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionTemplateRepository.kt
@@ -23,7 +23,9 @@ interface SessionTemplateRepository : JpaRepository<SessionTemplate, Long> {
       "(SELECT  COUNT(CASE WHEN v.visit_restriction = 'OPEN' THEN 1 END) AS open, " +
       " COUNT(CASE WHEN v.visit_restriction = 'CLOSED' THEN 1 END) AS closed  FROM visit v " +
       " JOIN session_template st ON st.reference = v.session_template_reference " +
-      " WHERE st.reference = :reference AND v.visit_start > :visitsFromDate AND v.visit_start < :visitsToDate " +
+      " WHERE st.reference = :reference" +
+      " AND v.visit_start > :visitsFromDate" +
+      " AND (cast(:visitsToDate as date) is null OR v.visit_start < :visitsToDate)" +
       " AND visit_status IN ('BOOKED','RESERVED','CHANGING')" +
       " GROUP BY v.visit_start ) AS tmp ",
     nativeQuery = true,
@@ -31,26 +33,30 @@ interface SessionTemplateRepository : JpaRepository<SessionTemplate, Long> {
   fun findSessionTemplateMinCapacityBy(
     @Param("reference") reference: String,
     @Param("visitsFromDate") visitsFromDate: LocalDate,
-    @Param("visitsToDate") visitsToDate: LocalDate,
+    @Param("visitsToDate") visitsToDate: LocalDate?,
   ): Tuple
 
   @Query(
     "select count(*) from visit v " +
       " JOIN session_template st ON st.reference = v.session_template_reference " +
-      " WHERE st.reference = :reference AND v.visit_start > :visitsFromDate AND v.visit_start < :visitsToDate " +
+      " WHERE st.reference = :reference" +
+      " AND v.visit_start > :visitsFromDate" +
+      " AND (cast(:visitsToDate as date) is null OR v.visit_start < :visitsToDate)" +
       " AND visit_status IN ('BOOKED','RESERVED','CHANGING')",
     nativeQuery = true,
   )
   fun getVisitCount(
     @Param("reference") reference: String,
     @Param("visitsFromDate") visitsFromDate: LocalDate,
-    @Param("visitsToDate") visitsToDate: LocalDate,
+    @Param("visitsToDate") visitsToDate: LocalDate?,
   ): Int
 
   @Query(
     "select cast(v.visit_start as date) as visitDate, v.visit_restriction as visitRestriction, count(*) as visitCount from visit v " +
       " JOIN session_template st ON st.reference = v.session_template_reference " +
-      " WHERE st.reference = :reference AND v.visit_start > :visitsFromDate AND v.visit_start < :visitsToDate " +
+      " WHERE st.reference = :reference" +
+      " AND v.visit_start > :visitsFromDate" +
+      " AND (cast(:visitsToDate as date) is null OR v.visit_start < :visitsToDate)" +
       " AND visit_status IN ('BOOKED','RESERVED','CHANGING')" +
       " GROUP BY v.visit_start, v.visit_restriction" +
       " ORDER BY v.visit_start",
@@ -59,7 +65,7 @@ interface SessionTemplateRepository : JpaRepository<SessionTemplate, Long> {
   fun getVisitCountsByDate(
     @Param("reference") reference: String,
     @Param("visitsFromDate") visitsFromDate: LocalDate,
-    @Param("visitsToDate") visitsToDate: LocalDate,
+    @Param("visitsToDate") visitsToDate: LocalDate?,
   ): List<VisitCountsByDate>
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.visitscheduler.service
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.admin.SessionTemplateRangeType
@@ -65,8 +64,6 @@ class SessionTemplateService(
   private val sessionTemplateMapper: SessionTemplateMapper,
   private val sessionTemplateUtil: SessionTemplateUtil,
   private val visitMoveValidator: SessionTemplateVisitMoveValidator,
-  @Value("\${policy.session.booking-notice-period.maximum-days:28}")
-  private val policyNoticeDaysMax: Long,
 ) {
 
   companion object {
@@ -450,7 +447,7 @@ class SessionTemplateService(
     reference: String,
     requestSessionTemplateVisitStatsDto: RequestSessionTemplateVisitStatsDto,
   ): SessionTemplateVisitStatsDto {
-    val visitsToDate = LocalDate.now().plusDays(policyNoticeDaysMax)
+    val visitsToDate = requestSessionTemplateVisitStatsDto.visitsToDate
 
     val minimumCapacityTuple = this.sessionTemplateRepository.findSessionTemplateMinCapacityBy(reference, requestSessionTemplateVisitStatsDto.visitsFromDate, visitsToDate)
     val sessionCapacity = sessionTemplateUtil.getMinimumSessionCapacity(minimumCapacityTuple)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
@@ -460,14 +460,14 @@ fun callUpdateLocationSessionGroupByReference(
   )
 }
 
-fun callGetActivateSessionTemplate(
+fun callGetVisitStats(
   webTestClient: WebTestClient,
   sessionTemplateReference: String,
-  visitsFromDate: LocalDate,
+  requestSessionTemplateVisitStatsDto: RequestSessionTemplateVisitStatsDto,
   authHttpHeaders: (HttpHeaders) -> Unit,
 ): ResponseSpec {
   return callPost(
-    RequestSessionTemplateVisitStatsDto(visitsFromDate),
+    requestSessionTemplateVisitStatsDto,
     webTestClient,
     getReferenceUrl(SESSION_TEMPLATE_VISIT_STATS, sessionTemplateReference),
     authHttpHeaders,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
@@ -312,18 +312,18 @@ class AdminMoveTemplateVisitsTest : IntegrationTestBase() {
   fun `when to session template has higher weekly frequency than current but all visits can be moved are successful`() {
     // Given
     val today = LocalDate.now()
-    val fromSession = sessionTemplateEntityHelper.create(weeklyFrequency = 1, dayOfWeek = today.dayOfWeek)
-    val toSession = sessionTemplateEntityHelper.create(weeklyFrequency = 3, dayOfWeek = today.dayOfWeek, startTime = fromSession.startTime.minusMinutes(30), endTime = fromSession.endTime)
+    val fromSession = sessionTemplateEntityHelper.create(weeklyFrequency = 1, dayOfWeek = today.dayOfWeek, validFromDate = today)
+    val toSession = sessionTemplateEntityHelper.create(weeklyFrequency = 3, dayOfWeek = today.dayOfWeek, validFromDate = today, startTime = fromSession.startTime.minusMinutes(30), endTime = fromSession.endTime)
 
     // visit date falls after 3 weeks
-    val visit1Date = LocalDate.now().plusWeeks(4)
+    val visit1Date = today.plusWeeks(3)
     val visit1 = visitEntityHelper.create(
       sessionTemplateReference = fromSession.reference,
       visitStart = visit1Date.atTime(fromSession.startTime),
       visitEnd = visit1Date.atTime(fromSession.endTime),
     )
 
-    val visit2Date = LocalDate.now().plusWeeks(7)
+    val visit2Date = today.plusWeeks(6)
     val visit2 = visitEntityHelper.create(
       sessionTemplateReference = fromSession.reference,
       visitStart = visit2Date.atTime(fromSession.startTime),


### PR DESCRIPTION

## What does this pull request do?

Updates visits stats to not have an end date.

## What is the intent behind these changes?

VB-3172 fix