### PR TITLE
VB-3197 Remove video call visits for AYI from database

### DIFF
--- a/src/main/resources/db.scripts.mvp/Remove_migrated_video_cal_ visits_for_AYI.sql
+++ b/src/main/resources/db.scripts.mvp/Remove_migrated_video_cal_ visits_for_AYI.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+    SET SCHEMA 'public';
+
+
+    CREATE TEMP TABLE tmp_visit_ids_to_be_deleted(
+        visit_id         int,
+        booking_reference text
+    );
+
+    --selection criteria for visits to be deleted
+    INSERT INTO tmp_visit_ids_to_be_deleted (visit_id,booking_reference) (
+        SELECT v.id, v.reference  from visit v
+                              join legacy_data ld on ld.visit_id = v.id
+                              join prison p on p.id=v.prison_id and p.code = 'AYI'
+        where ((EXTRACT(EPOCH FROM v.visit_end::time)-EXTRACT(EPOCH FROM v.visit_start::time))/60) < 45 and  ld.id is not null
+    );
+
+
+    DELETE FROM visit_contact WHERE visit_id in (select visit_id FROM tmp_visit_ids_to_be_deleted);
+    DELETE FROM visit_notes WHERE visit_id in (select visit_id FROM tmp_visit_ids_to_be_deleted);
+    DELETE FROM visit_support WHERE visit_id in (select visit_id FROM tmp_visit_ids_to_be_deleted);
+    DELETE FROM visit_visitor WHERE visit_id in (select visit_id FROM tmp_visit_ids_to_be_deleted);
+    DELETE FROM visit WHERE id in (select visit_id FROM tmp_visit_ids_to_be_deleted);
+    DELETE FROM legacy_data d where visit_id in (select visit_id FROM tmp_visit_ids_to_be_deleted);
+    DELETE FROM event_audit ev where booking_reference in (select booking_reference FROM tmp_visit_ids_to_be_deleted);
+
+    -- Drop temporary tables
+    DROP TABLE tmp_visit_ids_to_be_deleted;
+
+END;


### PR DESCRIPTION
As part of the migrations for onboarding AYI, we included some video call visits that the establishment had put into the wrong NOMIS room.

We need toe remove these from the database so they do not appear incorrectly as SOCIAL visits.