### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6.2
+  hmpps: ministryofjustice/hmpps@7
 
 parameters:
   alerts-slack-channel:
@@ -23,8 +23,7 @@ jobs:
     steps:
       - run:
           name: Checkout VSIP UI Tests
-          command:
-            git clone https://github.com/ministryofjustice/hmpps-vsip-ui-tests.git
+          command: git clone https://github.com/ministryofjustice/hmpps-vsip-ui-tests.git
       - run:
           name: get git status
           command: |
@@ -54,8 +53,7 @@ jobs:
     steps:
       - run:
           name: Checkout VSIP UI Tests
-          command:
-            git clone https://github.com/ministryofjustice/hmpps-vsip-ui-tests.git
+          command: git clone https://github.com/ministryofjustice/hmpps-vsip-ui-tests.git
       - run:
           name: get git status
           command: |
@@ -73,7 +71,6 @@ jobs:
           command: |
             cd hmpps-vsip-ui-tests
             mvn test -Dbrowser=remote-chrome -Denvironment="STAGING" -Dtest=suites.RunVSSmokeTest  
-
 
   validate:
     executor:

--- a/helm_deploy/visit-scheduler/Chart.yaml
+++ b/helm_deploy/visit-scheduler/Chart.yaml
@@ -5,7 +5,7 @@ name: visit-scheduler
 version: 0.2.1
 dependencies:
   - name: generic-service
-    version: 2.6.4
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.2

--- a/helm_deploy/visit-scheduler/values.yaml
+++ b/helm_deploy/visit-scheduler/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: visit-scheduler
   serviceAccountName: visit-someone-in-prison
@@ -7,12 +6,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/visit-scheduler
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: visit-scheduler-cert
     path: /
 
@@ -46,14 +45,8 @@ generic-service:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: visit-scheduler


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/visit-scheduler/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
