### PR TITLE
VB-3291-Move-Bristol-(BSI)-sessions-to-new-timetable

### DIFF
--- a/src/main/resources/db.scripts.mvp/BRI_xmas_move_visits_to_new_st.sql
+++ b/src/main/resources/db.scripts.mvp/BRI_xmas_move_visits_to_new_st.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+    CREATE TEMP TABLE tmp_visits(visit_id int not null);
+
+    INSERT INTO tmp_visits(visit_id)
+    SELECT v.id from visit v, prison p
+    WHERE v.prison_id = p.id
+      AND p.code = 'BLI'
+      AND reference in (
+                        'do-vo-ea-ca',
+                        'rv-jo-ea-hz',
+                        'ar-on-pa-uy',
+                        'bv-so-ea-fd',
+                        've-go-ea-hb',
+                        'jr-zd-ea-cm',
+                        'xz-jo-ea-ir',
+                        'eq-so-ea-hz',
+                        'yb-vo-ea-ua'
+        );
+
+
+    UPDATE visit SET session_template_reference = 'xva.imp.ewp'
+        FROM tmp_visits tmp WHERE visit.id = tmp.visit_id;
+
+    -- drop temporary tables
+    DROP TABLE  tmp_visits;
+
+
+END;


### PR DESCRIPTION
Bristol (BSI) have asked for a significant change to their timetable over Christmas. There are some existing bookings from the ‘old’ deactivated session templates that need to be moved to the appropriate new session templates.