### PR TITLE
VB-3358 - remove associated notification events with cancellation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
@@ -111,4 +111,6 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
     nativeQuery = true,
   )
   fun getNotificationsTypesForBookingReference(@Param("bookingReference") bookingReference: String): List<NotificationEventType>
+
+  fun deleteByBookingReference(@Param("bookingReference") bookingReference: String): Int
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -563,6 +563,10 @@ class VisitNotificationEventHelper(
       ),
     )
   }
+
+  fun getVisitNotifications(
+    visitBookingReference: String,
+  ): List<VisitNotificationEvent> = visitNotificationEventRepository.findByBookingReference(visitBookingReference)
 }
 
 class AllowedSessionLocationHierarchy(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/TestVisitNotificationEventRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/TestVisitNotificationEventRepository.kt
@@ -16,4 +16,6 @@ interface TestVisitNotificationEventRepository : JpaRepository<VisitNotification
     nativeQuery = true,
   )
   fun getFutureVisitNotificationEvents(@Param("prisonCode") prisonCode: String): List<VisitNotificationEvent>
+
+  fun findByBookingReference(@Param("bookingReference") bookingReference: String): List<VisitNotificationEvent>
 }


### PR DESCRIPTION
## What does this pull request do?

Removes any notification events associated with a visit reference from the visit notification event table.

## What is the intent behind these changes?

VB-3358 requirements 