### PR TITLE
VB-3456 fix - allow session template reference as null.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -47,7 +47,7 @@ const val VISIT_CHANGE: String = "$VISIT_CONTROLLER_PATH/{reference}/change"
 const val VISIT_BOOK: String = "$VISIT_CONTROLLER_PATH/{applicationReference}/book"
 const val VISIT_CANCEL: String = "$VISIT_CONTROLLER_PATH/{reference}/cancel"
 const val GET_VISIT_BY_REFERENCE: String = "$VISIT_CONTROLLER_PATH/{reference}"
-const val GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE: String = "$VISIT_CONTROLLER_PATH/session-template"
+const val GET_VISITS_BY: String = "$VISIT_CONTROLLER_PATH/session-template"
 
 @RestController
 @Validated
@@ -459,14 +459,14 @@ class VisitController(
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")
-  @GetMapping(GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE)
+  @GetMapping(GET_VISITS_BY)
   @Operation(
-    summary = "Get visits by session template reference for a date or a range of dates",
-    description = "Retrieve visits by session template reference for a date or a range of dates",
+    summary = "Get visits for a date or a range of dates with / without a session template reference",
+    description = "Get visits for a date or a range of dates with a session template reference or visits without a session template reference when session template reference is not passed",
     responses = [
       ApiResponse(
         responseCode = "200",
-        description = "Returns visits for a session template",
+        description = "Returns visits for a session template or visits where session template reference is null if no session template reference parameter passed",
       ),
       ApiResponse(
         responseCode = "400",
@@ -485,8 +485,8 @@ class VisitController(
       ),
     ],
   )
-  fun getVisitsBySessionTemplateReference(
-    @Schema(name = "sessionTemplateReference", description = "Session template reference", example = "v9-d7-ed-7u", required = true)
+  fun getVisitsBy(
+    @Schema(name = "sessionTemplateReference", description = "Session template reference", example = "v9-d7-ed-7u", required = false)
     @RequestParam
     sessionTemplateReference: String?,
     @Schema(name = "fromDate", description = "Get visits from date", example = "2023-05-31", required = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -47,7 +47,7 @@ const val VISIT_CHANGE: String = "$VISIT_CONTROLLER_PATH/{reference}/change"
 const val VISIT_BOOK: String = "$VISIT_CONTROLLER_PATH/{applicationReference}/book"
 const val VISIT_CANCEL: String = "$VISIT_CONTROLLER_PATH/{reference}/cancel"
 const val GET_VISIT_BY_REFERENCE: String = "$VISIT_CONTROLLER_PATH/{reference}"
-const val GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE: String = "$VISIT_CONTROLLER_PATH/session-template/{sessionTemplateReference}"
+const val GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE: String = "$VISIT_CONTROLLER_PATH/session-template"
 
 @RestController
 @Validated
@@ -487,8 +487,8 @@ class VisitController(
   )
   fun getVisitsBySessionTemplateReference(
     @Schema(name = "sessionTemplateReference", description = "Session template reference", example = "v9-d7-ed-7u", required = true)
-    @PathVariable
-    sessionTemplateReference: String,
+    @RequestParam
+    sessionTemplateReference: String?,
     @Schema(name = "fromDate", description = "Get visits from date", example = "2023-05-31", required = true)
     @RequestParam
     fromDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/VisitsBySessionTemplateFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/VisitsBySessionTemplateFilter.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.model
 import java.time.LocalDate
 
 data class VisitsBySessionTemplateFilter(
-  val sessionTemplateReference: String,
+  val sessionTemplateReference: String?,
   val fromDate: LocalDate,
   val toDate: LocalDate,
   val visitStatusList: List<VisitStatus>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/specification/VisitsBySessionTemplateSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/specification/VisitsBySessionTemplateSpecification.kt
@@ -18,8 +18,10 @@ class VisitsBySessionTemplateSpecification(private val filter: VisitsBySessionTe
     val predicates = mutableListOf<Predicate>()
 
     with(filter) {
-      sessionTemplateReference.run {
+      if (!sessionTemplateReference.isNullOrEmpty()) {
         predicates.add(criteriaBuilder.equal(root.get<String>(Visit::sessionTemplateReference.name), sessionTemplateReference))
+      } else {
+        predicates.add(criteriaBuilder.isNull(root.get<String>(Visit::sessionTemplateReference.name)))
       }
 
       fromDate.run {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
@@ -15,9 +15,11 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_VISITS_BY_SESS
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.ArrayList
 
-@DisplayName("GET /visits/{sessionTemplateReference}")
+@DisplayName("GET /visits/session-template")
 class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
 
   private val visitTime: LocalDateTime = LocalDateTime.of(2023, 11, 1, 11, 30, 0)
@@ -30,11 +32,15 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     // visit 1 booked for session template reference - session-1
     visitEntityHelper.create(prisonCode = "MDI", visitStart = visitTime, prisonerId = "FF0000AA", sessionTemplateReference = "session-1", reference = "visit-booked-1", visitStatus = VisitStatus.BOOKED, visitRestriction = VisitRestriction.OPEN)
     // visit 2 reserved for session template reference - session-1
-    visitEntityHelper.create(prisonCode = "MDI", visitStart = visitTime, prisonerId = "FF0000AA", sessionTemplateReference = "session-1", reference = "visit-reserved-1", visitStatus = VisitStatus.RESERVED)
+    visitEntityHelper.create(prisonCode = "MDI", visitStart = visitTime, prisonerId = "FF0000AA", sessionTemplateReference = "session-1", reference = "visit-reserved-1", visitStatus = VisitStatus.CANCELLED)
     // visit 3 booked for session template reference - session-2
     visitEntityHelper.create(prisonCode = "MDI", visitStart = visitTime, prisonerId = "FF0000BB", sessionTemplateReference = "session-2", reference = "visit-booked-2", visitStatus = VisitStatus.BOOKED)
     // visit 4 booked for session template reference - session-1 but on next day
     visitEntityHelper.create(prisonCode = "MDI", visitStart = visitTime.plusDays(1), prisonerId = "FF0000BB", sessionTemplateReference = "session-1", reference = "visit-booked-3", visitStatus = VisitStatus.BOOKED, visitRestriction = VisitRestriction.CLOSED)
+    // session template reference is null and status is BOOKED
+    visitEntityHelper.create(prisonCode = "MDI", visitStart = visitTime.plusDays(1), prisonerId = "FF0000BB", sessionTemplateReference = null, reference = "visit-booked-sess-null", visitStatus = VisitStatus.BOOKED, visitRestriction = VisitRestriction.UNKNOWN)
+    // session template reference is null and status is CANCELLED
+    visitEntityHelper.create(prisonCode = "MDI", visitStart = visitTime.plusDays(2), prisonerId = "FF0000BB", sessionTemplateReference = null, reference = "visit-booked-sess-null2", visitStatus = VisitStatus.CANCELLED, visitRestriction = VisitRestriction.UNKNOWN)
   }
 
   @Test
@@ -44,7 +50,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val sessionDate = visitTime.toLocalDate()
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$sessionDate&toDate=$sessionDate&visitStatus=BOOKED")
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = sessionDate, toDate = sessionDate, visitStatus = listOf(VisitStatus.BOOKED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -60,10 +67,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val sessionDate = visitTime.toLocalDate()
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(
-      sessionTemplateReference,
-      "?fromDate=$sessionDate&toDate=$sessionDate&visitStatus=BOOKED,RESERVED",
-    )
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = sessionDate, toDate = sessionDate, visitStatus = listOf(VisitStatus.BOOKED, VisitStatus.CANCELLED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -84,7 +89,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val toDate = visitTime.toLocalDate().plusDays(1)
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$fromDate&toDate=$toDate&visitStatus=BOOKED")
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = fromDate, toDate = toDate, visitStatus = listOf(VisitStatus.BOOKED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -102,7 +108,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val toDate = visitTime.toLocalDate().plusDays(1)
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$fromDate&toDate=$toDate&visitStatus=BOOKED&visitRestrictions=OPEN")
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = fromDate, toDate = toDate, visitStatus = listOf(VisitStatus.BOOKED), visitRestrictions = listOf(VisitRestriction.OPEN)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -120,7 +127,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val toDate = visitTime.toLocalDate().plusDays(1)
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$fromDate&toDate=$toDate&visitStatus=BOOKED&visitRestrictions=OPEN,CLOSED")
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = fromDate, toDate = toDate, visitStatus = listOf(VisitStatus.BOOKED), visitRestrictions = listOf(VisitRestriction.OPEN, VisitRestriction.CLOSED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -140,7 +148,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val toDate = visitTime.toLocalDate().plusDays(1)
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$fromDate&toDate=$toDate&visitStatus=BOOKED&visitRestrictions=CLOSED")
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = fromDate, toDate = toDate, visitStatus = listOf(VisitStatus.BOOKED), visitRestrictions = listOf(VisitRestriction.CLOSED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -158,7 +167,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val toDate = visitTime.toLocalDate().plusDays(1)
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$fromDate&toDate=$toDate&visitStatus=BOOKED,RESERVED")
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = fromDate, toDate = toDate, visitStatus = listOf(VisitStatus.BOOKED, VisitStatus.CANCELLED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -170,13 +180,49 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when session template reference passed is null only session template reference null records are returned`() {
+    // Given
+    val fromDate = visitTime.toLocalDate()
+    val toDate = visitTime.toLocalDate().plusDays(2)
+
+    // When
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference = null, fromDate = fromDate, toDate = toDate, visitStatus = listOf(VisitStatus.BOOKED, VisitStatus.CANCELLED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
+
+    // Then
+    responseSpec.expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.content.length()").isEqualTo(2)
+      .jsonPath("$.content[0].reference").isEqualTo("visit-booked-sess-null2")
+      .jsonPath("$.content[1].reference").isEqualTo("visit-booked-sess-null")
+  }
+
+  @Test
+  fun `when session template reference passed is null only session template reference null records matching status are returned`() {
+    // Given
+    val fromDate = visitTime.toLocalDate()
+    val toDate = visitTime.toLocalDate().plusDays(2)
+
+    // When
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference = null, fromDate = fromDate, toDate = toDate, visitStatus = listOf(VisitStatus.CANCELLED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
+
+    // Then
+    responseSpec.expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.content.length()").isEqualTo(1)
+      .jsonPath("$.content[0].reference").isEqualTo("visit-booked-sess-null2")
+  }
+
+  @Test
   fun `when session has no visits for a date no records are returned`() {
     // Given
     val sessionTemplateReference = "session-2"
     val sessionDate = visitTime.toLocalDate().plusDays(1)
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$sessionDate&toDate=$sessionDate&visitStatus=BOOKED,RESERVED")
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = sessionDate, toDate = sessionDate, visitStatus = listOf(VisitStatus.BOOKED, VisitStatus.CANCELLED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -190,7 +236,8 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val sessionDate = visitTime.toLocalDate()
 
     // When
-    val responseSpec = callVisitsBySessionEndPoint(sessionTemplateReference, "?fromDate=$sessionDate&toDate=$sessionDate&visitStatus=BOOKED", roles = listOf())
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = sessionDate, toDate = sessionDate, visitStatus = listOf(VisitStatus.BOOKED)).joinToString("&")
+    val responseSpec = callVisitsBySessionEndPoint(params, roles = listOf())
 
     // Then
     responseSpec.expectStatus().isForbidden
@@ -200,27 +247,53 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
   @Test
   fun `unauthorised when no token`() {
     // Given
-    val prisonerId = "FF0000AA"
-    val prisonId = "MDI"
+    val sessionTemplateReference = "FF0000AA"
+    val sessionDate = LocalDate.now()
 
     // When
-    val responseSpec = webTestClient.get().uri("prisonId=$prisonId&prisonerId=$prisonerId").exchange()
+    val params = getVisitsBySessionTemplateQueryParams(sessionTemplateReference, fromDate = sessionDate, toDate = sessionDate, visitStatus = listOf(VisitStatus.BOOKED)).joinToString("&")
+    val responseSpec = webTestClient.get().uri("/visits/session-template?$params").exchange()
 
     // Then
     responseSpec.expectStatus().isUnauthorized
   }
 
   fun callVisitsBySessionEndPoint(
-    sessionTemplateReference: String,
     params: String,
     page: Int = 0,
     pageSize: Int = 100,
     roles: List<String> = listOf("ROLE_VISIT_SCHEDULER"),
   ): ResponseSpec {
-    var uri = GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE.replace("{sessionTemplateReference}", sessionTemplateReference)
-    uri += "$params&page=$page&size=$pageSize"
+    val uri = "$GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE?$params"
     return webTestClient.get().uri(uri)
       .headers(setAuthorisation(roles = roles))
       .exchange()
+  }
+
+  private fun getVisitsBySessionTemplateQueryParams(
+    sessionTemplateReference: String?,
+    fromDate: LocalDate,
+    toDate: LocalDate,
+    visitStatus: List<VisitStatus>? = null,
+    visitRestrictions: List<VisitRestriction>? = null,
+    page: Int? = 0,
+    size: Int? = 100,
+  ): List<String> {
+    val queryParams = ArrayList<String>()
+    sessionTemplateReference?.let {
+      queryParams.add("sessionTemplateReference=$sessionTemplateReference")
+    }
+    queryParams.add("fromDate=$fromDate")
+    queryParams.add("toDate=$toDate")
+
+    visitStatus?.forEach {
+      queryParams.add("visitStatus=$it")
+    }
+    visitRestrictions?.forEach {
+      queryParams.add("visitRestrictions=$it")
+    }
+    queryParams.add("page=$page")
+    queryParams.add("size=$size")
+    return queryParams
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
@@ -11,7 +11,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
-import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE
+import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_VISITS_BY
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
@@ -264,7 +264,7 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     pageSize: Int = 100,
     roles: List<String> = listOf("ROLE_VISIT_SCHEDULER"),
   ): ResponseSpec {
-    val uri = "$GET_VISITS_BY_SESSION_TEMPLATE_REFERENCE?$params"
+    val uri = "$GET_VISITS_BY?$params"
     return webTestClient.get().uri(uri)
       .headers(setAuthorisation(roles = roles))
       .exchange()


### PR DESCRIPTION
## What does this pull request do?

Allow session template reference as null to retrieve visits that do not have a session template reference.
## What is the intent behind these changes?
To allow getting all visits by date.