### PR TITLE
Migration was missing CANCELLED visits with a null outcome status. Al…

### DIFF
--- a/src/main/resources/db/migration/V3_03__insert_data_into_application_table.sql
+++ b/src/main/resources/db/migration/V3_03__insert_data_into_application_table.sql
@@ -61,7 +61,7 @@ INSERT INTO application (id,
             a.modify_timestamp
         FROM tmp_application a
             JOIN visit v on v.reference = a.booking_reference
-        WHERE v.visit_status  = 'BOOKED' or (v.visit_status  = 'CANCELLED' and v.outcome_status != 'SUPERSEDED_CANCELLATION')
+        WHERE v.visit_status  = 'BOOKED' or (v.visit_status  = 'CANCELLED' and (v.outcome_status is null or v.outcome_status != 'SUPERSEDED_CANCELLATION'))
         Order by a.id;
 
 ALTER TABLE tmp_visit   DROP application_reference;

--- a/src/main/resources/db/migration/V3_07__data_into_application_indexes.sql
+++ b/src/main/resources/db/migration/V3_07__data_into_application_indexes.sql
@@ -1,3 +1,7 @@
 -- may be change to serial4
 CREATE INDEX idx_application_reference ON application(reference);
 
+-- THESE WERE PREVENTING THE SYSTEM FROM DELETING THE CHILD OBJECTS
+-- ALTER TABLE application_contact  ADD CONSTRAINT fk_contact_to_application FOREIGN KEY (application_id) REFERENCES application(id);
+-- ALTER TABLE application_support  ADD CONSTRAINT fk_support_to_application FOREIGN KEY (application_id) REFERENCES application(id);
+-- ALTER TABLE application_visitor  ADD CONSTRAINT fk_visitor_to_application FOREIGN KEY (application_id) REFERENCES application(id);

--- a/src/main/resources/db/migration/V3_09__add_indexes_for_application_changes.sql
+++ b/src/main/resources/db/migration/V3_09__add_indexes_for_application_changes.sql
@@ -10,3 +10,18 @@ SELECT setval(pg_get_serial_sequence('application_contact', 'id'), max(id)) FROM
 SELECT setval(pg_get_serial_sequence('application_support', 'id'), max(id)) FROM application_support;
 SELECT setval(pg_get_serial_sequence('application_visitor', 'id'), max(id)) FROM application_visitor;
 
+-- These foreign keys exist on some DB's instance but they belong to the backup table so delete
+ALTER TABLE visit_contact DROP CONSTRAINT IF EXISTS fk_contact_to_visit;
+ALTER TABLE visit_notes DROP CONSTRAINT IF EXISTS fk_notes_to_visit;
+ALTER TABLE visit_support DROP CONSTRAINT IF EXISTS fk_support_to_visit;
+ALTER TABLE visit_visitor DROP CONSTRAINT IF EXISTS fk_visitor_to_visit;
+
+-- THESE WERE PREVENTING THE SYSTEM FROM DELETING THE CHILD OBJECTS
+-- Now re-create foreign keys tables
+-- ALTER TABLE visit_contact  ADD CONSTRAINT fk_contact_to_visit FOREIGN KEY (visit_id) REFERENCES visit(id);
+-- ALTER TABLE visit_notes  ADD CONSTRAINT fk_notes_to_visit FOREIGN KEY (visit_id) REFERENCES visit(id);
+-- ALTER TABLE visit_support  ADD CONSTRAINT fk_support_to_visit FOREIGN KEY (visit_id) REFERENCES visit(id);
+-- ALTER TABLE visit_visitor  ADD CONSTRAINT fk_visitor_to_visit FOREIGN KEY (visit_id) REFERENCES visit(id);
+
+
+

--- a/src/main/resources/db/migration/V3_10__remove_application_data_from_visits.sql
+++ b/src/main/resources/db/migration/V3_10__remove_application_data_from_visits.sql
@@ -1,5 +1,5 @@
 
--- Create
+-- Create table
 CREATE TEMP TABLE tmp_delete_applications_from_visits(visit_id int not null);
 
 INSERT INTO tmp_delete_applications_from_visits(visit_id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -508,6 +508,7 @@ class DeleteEntityHelper(
 
 ) {
 
+  @Transactional
   fun deleteAll() {
     println("Delete all")
     sessionRepository.deleteAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -16,6 +16,7 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationDto
@@ -126,6 +127,7 @@ abstract class IntegrationTestBase {
   }
 
   @AfterEach
+  @Transactional
   internal fun deleteAll() {
     deleteEntityHelper.deleteAll()
   }


### PR DESCRIPTION
Migration was missing CANCELLED visits with a null outcome status. Also removed FK indexes as they caused issues with deleting of child objects.