### PR TITLE
VB-3621 Migration bug - found with duplicate data on session slots

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionSlotRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionSlotRepository.kt
@@ -20,9 +20,10 @@ interface SessionSlotRepository : JpaRepository<SessionSlot, Long>, JpaSpecifica
   fun findSessionSlot(slotDates: List<LocalDate>, sessionTemplateReferences: List<String>): List<SessionSlot>
 
   @Query(
-    "SELECT s FROM SessionSlot s " +
-      "WHERE s.sessionTemplateReference = :sessionTemplateReference" +
-      " AND s.slotDate = :slotDate ",
+    "SELECT * FROM session_slot s " +
+      "WHERE s.session_template_reference = :sessionTemplateReference" +
+      " AND s.slot_date = :slotDate limit 1",
+    nativeQuery = true,
   )
   fun findSessionSlot(
     sessionTemplateReference: String,
@@ -30,9 +31,10 @@ interface SessionSlotRepository : JpaRepository<SessionSlot, Long>, JpaSpecifica
   ): SessionSlot?
 
   @Query(
-    "SELECT s.id FROM SessionSlot s " +
-      "WHERE s.sessionTemplateReference = :sessionTemplateReference" +
-      " AND s.slotDate = :slotDate ",
+    "SELECT s.id FROM session_slot s " +
+      "WHERE s.session_template_reference = :sessionTemplateReference" +
+      " AND s.slot_date = :slotDate limit 1",
+    nativeQuery = true,
   )
   fun findSessionSlotId(
     sessionTemplateReference: String,
@@ -40,11 +42,12 @@ interface SessionSlotRepository : JpaRepository<SessionSlot, Long>, JpaSpecifica
   ): Long?
 
   @Query(
-    "SELECT s FROM SessionSlot s " +
-      "WHERE s.prisonId = :prisonId AND " +
-      "s.slotStart = :slotStart AND " +
-      "s.slotEnd = :slotEnd AND " +
-      "s.sessionTemplateReference is null",
+    "SELECT * FROM session_slot s " +
+      "WHERE s.prison_id = :prisonId AND " +
+      "s.slot_start = :slotStart AND " +
+      "s.slot_end = :slotEnd AND " +
+      "s.session_template_reference is null limit 1",
+    nativeQuery = true,
   )
   fun findSessionSlotWithOutSessionReference(
     prisonId: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionSlotRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionSlotRepository.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.visitscheduler.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionSlot
@@ -54,33 +53,4 @@ interface SessionSlotRepository : JpaRepository<SessionSlot, Long>, JpaSpecifica
     slotStart: LocalDateTime,
     slotEnd: LocalDateTime,
   ): SessionSlot?
-
-  @Modifying
-  @Query(
-    "Update SessionSlot set sessionTemplateReference = :newSessionTemplateReference " +
-      "WHERE sessionTemplateReference = :existingSessionTemplateReference AND " +
-      "slotDate >= :fromDate ",
-  )
-  fun updateSessionTemplateReference(
-    existingSessionTemplateReference: String,
-    newSessionTemplateReference: String,
-    fromDate: LocalDate,
-  ): Int
-
-  @Modifying
-  @Query(
-    "Update SessionSlot set " +
-      "sessionTemplateReference = :newSessionTemplateReference, " +
-      "slotStart = :newStartTime, " +
-      "slotEnd = :newEndTime " +
-      "WHERE sessionTemplateReference = :existingSessionTemplateReference AND " +
-      "slotDate >= :fromDate ",
-  )
-  fun updateSessionTemplateReference(
-    existingSessionTemplateReference: String,
-    newSessionTemplateReference: String,
-    fromDate: LocalDate,
-    newStartTime: LocalDateTime,
-    newEndTime: LocalDateTime,
-  ): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -200,6 +200,20 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
 
   @Query(
     "SELECT v FROM Visit v WHERE " +
+      " (v.sessionSlot.sessionTemplateReference = :sessionTemplateReference)  AND " +
+      "v.sessionSlot.slotDate >= :fromDate AND " +
+      "v.visitStatus = 'BOOKED' AND " +
+      "(:#{#toDate} is null OR v.sessionSlot.slotDate <= :toDate) " +
+      " ORDER BY v.createTimestamp",
+  )
+  fun findBookedVisitsBySessionTemplateReference(
+    sessionTemplateReference: String,
+    fromDate: LocalDate,
+    toDate: LocalDate? = null,
+  ): List<Visit>
+
+  @Query(
+    "SELECT v FROM Visit v WHERE " +
       " (v.sessionSlot.sessionTemplateReference is NULL)  AND " +
       "(:#{#visitStatusList} is null OR v.visitStatus in :visitStatusList) AND " +
       "(:#{#visitRestrictions} is null OR v.visitRestriction in :visitRestrictions) AND " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
@@ -54,7 +54,7 @@ import java.util.function.Supplier
 
 @Service
 @Transactional
-class SessionTemplateService(
+open class SessionTemplateService(
   private val sessionTemplateRepository: SessionTemplateRepository,
   private val sessionLocationGroupRepository: SessionLocationGroupRepository,
   private val sessionCategoryGroupRepository: SessionCategoryGroupRepository,
@@ -74,7 +74,7 @@ class SessionTemplateService(
   }
 
   @Transactional(readOnly = true)
-  fun getSessionTemplates(prisonCode: String, rangeType: SessionTemplateRangeType): List<SessionTemplateDto> {
+  open fun getSessionTemplates(prisonCode: String, rangeType: SessionTemplateRangeType): List<SessionTemplateDto> {
     val sessionTemplates = when (rangeType) {
       ALL -> sessionTemplateRepository.findSessionTemplatesByPrisonCode(prisonCode)
       HISTORIC -> sessionTemplateRepository.findHistoricSessionTemplates(prisonCode)
@@ -84,17 +84,17 @@ class SessionTemplateService(
   }
 
   @Transactional(readOnly = true)
-  fun getSessionTemplates(reference: String): SessionTemplateDto {
+  open fun getSessionTemplates(reference: String): SessionTemplateDto {
     return SessionTemplateDto(getSessionTemplate(reference))
   }
 
   @Transactional(readOnly = true)
-  fun getSessionLocationGroup(reference: String): SessionLocationGroupDto {
+  open fun getSessionLocationGroup(reference: String): SessionLocationGroupDto {
     return SessionLocationGroupDto(getLocationGroupByReference(reference))
   }
 
   @Transactional(readOnly = true)
-  fun getSessionLocationGroups(prisonCode: String): List<SessionLocationGroupDto> {
+  open fun getSessionLocationGroups(prisonCode: String): List<SessionLocationGroupDto> {
     return sessionLocationGroupRepository.findByPrisonCode(prisonCode).map { SessionLocationGroupDto(it) }
   }
 
@@ -362,7 +362,7 @@ class SessionTemplateService(
   }
 
   @Transactional(readOnly = true)
-  fun getSessionCategoryGroup(reference: String): SessionCategoryGroupDto {
+  open fun getSessionCategoryGroup(reference: String): SessionCategoryGroupDto {
     return SessionCategoryGroupDto(getSessionCategoryGroupEntityByReference(reference))
   }
 
@@ -372,17 +372,17 @@ class SessionTemplateService(
   }
 
   @Transactional(readOnly = true)
-  fun getSessionCategoryGroups(prisonCode: String): List<SessionCategoryGroupDto> {
+  open fun getSessionCategoryGroups(prisonCode: String): List<SessionCategoryGroupDto> {
     return sessionCategoryGroupRepository.findByPrisonCode(prisonCode).map { SessionCategoryGroupDto(it) }
   }
 
   @Transactional(readOnly = true)
-  fun getSessionIncentiveGroups(prisonCode: String): List<SessionIncentiveLevelGroupDto> {
+  open fun getSessionIncentiveGroups(prisonCode: String): List<SessionIncentiveLevelGroupDto> {
     return sessionIncentiveLevelGroupRepository.findByPrisonCode(prisonCode).map { SessionIncentiveLevelGroupDto(it) }
   }
 
   @Transactional(readOnly = true)
-  fun getSessionIncentiveGroup(reference: String): SessionIncentiveLevelGroupDto {
+  open fun getSessionIncentiveGroup(reference: String): SessionIncentiveLevelGroupDto {
     return SessionIncentiveLevelGroupDto(getIncentiveLevelGroupByReference(reference))
   }
 
@@ -514,7 +514,7 @@ class SessionTemplateService(
   }
 
   @Transactional
-  fun moveSessionTemplateVisits(fromSessionTemplateReference: String, toSessionTemplateReference: String, fromDate: LocalDate): Int {
+  open fun moveSessionTemplateVisits(fromSessionTemplateReference: String, toSessionTemplateReference: String, fromDate: LocalDate): Int {
     val fromSessionTemplate = getSessionTemplate(fromSessionTemplateReference)
     val toSessionTemplate = getSessionTemplate(toSessionTemplateReference)
     // validate move before updating session template reference
@@ -523,7 +523,7 @@ class SessionTemplateService(
     val visits = visitRepository.findBookedVisitsBySessionTemplateReference(
       sessionTemplateReference = fromSessionTemplateReference,
       fromDate = fromDate,
-    ).toList().also {
+    ).also {
       val updatedVisits = updateSessionSlotId(it, toSessionTemplate)
       visitRepository.saveAllAndFlush(updatedVisits)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.exception.VSiPValidationExcep
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.VisitType
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.category.SessionCategoryGroup
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.category.SessionPrisonerCategory
@@ -41,7 +42,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.location
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionCategoryGroupRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionIncentiveLevelGroupRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionLocationGroupRepository
-import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionSlotRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionTemplateRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.utils.SessionTemplateComparator
@@ -59,7 +59,6 @@ class SessionTemplateService(
   private val sessionLocationGroupRepository: SessionLocationGroupRepository,
   private val sessionCategoryGroupRepository: SessionCategoryGroupRepository,
   private val sessionIncentiveLevelGroupRepository: SessionIncentiveLevelGroupRepository,
-  private val sessionSlotRepository: SessionSlotRepository,
   private val visitRepository: VisitRepository,
   private val prisonsService: PrisonsService,
   private val updateSessionTemplateValidator: UpdateSessionTemplateValidator,
@@ -67,6 +66,7 @@ class SessionTemplateService(
   private val sessionTemplateMapper: SessionTemplateMapper,
   private val sessionTemplateUtil: SessionTemplateUtil,
   private val visitMoveValidator: SessionTemplateVisitMoveValidator,
+  private val sessionSlotService: SessionSlotService,
 ) {
 
   companion object {
@@ -513,20 +513,32 @@ class SessionTemplateService(
     return overlappingSessions
   }
 
+  @Transactional
   fun moveSessionTemplateVisits(fromSessionTemplateReference: String, toSessionTemplateReference: String, fromDate: LocalDate): Int {
-    val fromSessionTemplate = SessionTemplateDto(getSessionTemplate(fromSessionTemplateReference))
-    val toSessionTemplate = SessionTemplateDto(getSessionTemplate(toSessionTemplateReference))
+    val fromSessionTemplate = getSessionTemplate(fromSessionTemplateReference)
+    val toSessionTemplate = getSessionTemplate(toSessionTemplateReference)
     // validate move before updating session template reference
-    validateMoveSessionTemplateVisits(fromSessionTemplate, toSessionTemplate, fromDate)
+    validateMoveSessionTemplateVisits(SessionTemplateDto(fromSessionTemplate), SessionTemplateDto(toSessionTemplate), fromDate)
 
-    return if (fromSessionTemplate.sessionTimeSlot == toSessionTemplate.sessionTimeSlot) {
-      sessionSlotRepository.updateSessionTemplateReference(existingSessionTemplateReference = fromSessionTemplateReference, newSessionTemplateReference = toSessionTemplateReference, fromDate)
-    } else {
-      val startSlot = fromDate.atTime(toSessionTemplate.sessionTimeSlot.startTime)
-      val endSlot = fromDate.atTime(toSessionTemplate.sessionTimeSlot.endTime)
-
-      sessionSlotRepository.updateSessionTemplateReference(existingSessionTemplateReference = fromSessionTemplateReference, newSessionTemplateReference = toSessionTemplateReference, fromDate, startSlot, endSlot)
+    val visits = visitRepository.findBookedVisitsBySessionTemplateReference(
+      sessionTemplateReference = fromSessionTemplateReference,
+      fromDate = fromDate,
+    ).toList().also {
+      val updatedVisits = updateSessionSlotId(it, toSessionTemplate)
+      visitRepository.saveAllAndFlush(updatedVisits)
     }
+
+    return visits.size
+  }
+
+  private fun updateSessionSlotId(visits: List<Visit>, toSessionTemplate: SessionTemplate): List<Visit> {
+    visits.forEach { visit ->
+      val sessionSlot = sessionSlotService.getSessionSlot(visit.sessionSlot.slotDate, SessionTemplateDto(toSessionTemplate), toSessionTemplate.prison)
+      visit.sessionSlot = sessionSlot
+      visit.sessionSlotId = sessionSlot.id
+    }
+
+    return visits
   }
 
   @Throws(VSiPValidationException::class)

--- a/src/main/resources/db/migration/V3_19__add_session_slot_constraints.sql
+++ b/src/main/resources/db/migration/V3_19__add_session_slot_constraints.sql
@@ -1,0 +1,2 @@
+-- UNIQUE constraint for session slot
+ALTER TABLE session_slot ADD UNIQUE NULLS NOT DISTINCT (session_template_reference,prison_id,slot_start,slot_end);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -51,6 +51,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Appl
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionSlot
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestEventAuditRepository
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestSessionSlotRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.utils.SessionDatesUtil
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -88,6 +89,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var eventAuditRepository: TestEventAuditRepository
+
+  @Autowired
+  protected lateinit var testSessionSlotRepository: TestSessionSlotRepository
 
   @Autowired
   protected lateinit var sessionPrisonerIncentiveLevelHelper: SessionPrisonerIncentiveLevelHelper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
@@ -312,10 +312,8 @@ class AdminMoveTemplateVisitsTest : IntegrationTestBase() {
     Assertions.assertThat(updatedVisit.sessionSlot.slotDate).isEqualTo(visitDate)
   }
 
-  // @Test
+  @Test
   fun `when to session template has higher weekly frequency than current but all visits can be moved are successful`() {
-    // TODO this is failing as it updating session slot and the values already exist
-
     // Given
     val today = LocalDate.now()
     val fromSession = sessionTemplateEntityHelper.create(weeklyFrequency = 1, dayOfWeek = today.dayOfWeek, validFromDate = today)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
@@ -312,8 +312,12 @@ class AdminMoveTemplateVisitsTest : IntegrationTestBase() {
     Assertions.assertThat(updatedVisit.sessionSlot.slotDate).isEqualTo(visitDate)
   }
 
-  @Test
+
+  //@Test
   fun `when to session template has higher weekly frequency than current but all visits can be moved are successful`() {
+
+    //TODO this is failing as it updating session slot and the values already exist
+
     // Given
     val today = LocalDate.now()
     val fromSession = sessionTemplateEntityHelper.create(weeklyFrequency = 1, dayOfWeek = today.dayOfWeek, validFromDate = today)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminMoveTemplateVisitsTest.kt
@@ -312,11 +312,9 @@ class AdminMoveTemplateVisitsTest : IntegrationTestBase() {
     Assertions.assertThat(updatedVisit.sessionSlot.slotDate).isEqualTo(visitDate)
   }
 
-
-  //@Test
+  // @Test
   fun `when to session template has higher weekly frequency than current but all visits can be moved are successful`() {
-
-    //TODO this is failing as it updating session slot and the values already exist
+    // TODO this is failing as it updating session slot and the values already exist
 
     // Given
     val today = LocalDate.now()


### PR DESCRIPTION
## What does this pull request do?

add's constraint and try catch code to return the correct value if issue occurs

## What is the intent behind these changes?

There is a race condition and in those cases a extra entry is entered into the DB, and all other visits for that slot then fail because the JPA query tries to return multiple results when only one is permitted.