### PR TITLE
Vb 3620 unflag events to be sent to application insights to help improve reporting

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/UnFlagEventReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/UnFlagEventReason.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.enums
+
+enum class UnFlagEventReason(val desc: String) {
+  VISIT_CANCELLED("visit-cancelled"),
+  VISIT_DATE_UPDATED("visit-date-updated"),
+  PRISON_EXCLUDE_DATE_REMOVED("prison-exclude-date-removed"),
+  NON_ASSOCIATION_REMOVED("non-association-removed"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
@@ -153,6 +153,21 @@ class TelemetryClientService(
     return flagEventDataMap
   }
 
+  fun createUnFlagEventForVisit(
+    visitReference: String,
+    notificationEventType: NotificationEventType?,
+  ): MutableMap<String, String> {
+    val unFlagEventDataMap = mutableMapOf(
+      "reference" to visitReference,
+    )
+
+    notificationEventType?.let {
+      unFlagEventDataMap["reviewType"] = it.reviewType
+    }
+
+    return unFlagEventDataMap
+  }
+
   fun trackEvent(visitEvent: TelemetryVisitEvents, properties: Map<String, String>) {
     try {
       telemetryClient.trackEvent(visitEvent.eventName, properties, null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationDt
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.builder.ApplicationDtoBuilder
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.builder.VisitDtoBuilder
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.model.ApplicationMethodType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Application
@@ -156,9 +157,11 @@ class TelemetryClientService(
   fun createUnFlagEventForVisit(
     visitReference: String,
     notificationEventType: NotificationEventType?,
+    reason: UnFlagEventReason,
   ): MutableMap<String, String> {
     val unFlagEventDataMap = mutableMapOf(
       "reference" to visitReference,
+      "reason" to reason.desc,
     )
 
     notificationEventType?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryVisitEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryVisitEvents.kt
@@ -14,6 +14,7 @@ enum class TelemetryVisitEvents(val eventName: String) {
   BAD_REQUEST_ERROR_EVENT("visit-bad-request-error"),
   PUBLISH_ERROR_EVENT("visit-publish-event-error"),
   FLAGGED_VISIT_EVENT("flagged-visit-event"),
+  UNFLAGGED_VISIT_EVENT("unflagged-visit-event"),
 
   // reporting
   VISIT_COUNTS_REPORT("visit-counts-report"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -29,7 +29,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.service.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.service.NotificationEventType.PRISONER_RELEASED_EVENT
 import uk.gov.justice.digital.hmpps.visitscheduler.service.NotificationEventType.PRISONER_RESTRICTION_CHANGE_EVENT
 import uk.gov.justice.digital.hmpps.visitscheduler.service.NotificationEventType.PRISON_VISITS_BLOCKED_FOR_DATE
-import uk.gov.justice.digital.hmpps.visitscheduler.service.TelemetryVisitEvents.FLAGGED_VISIT_EVENT
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -37,9 +36,9 @@ import java.time.LocalTime
 @Service
 class VisitNotificationEventService(
   private val visitService: VisitService,
-  private val telemetryClientService: TelemetryClientService,
   private val visitNotificationEventRepository: VisitNotificationEventRepository,
   private val prisonerService: PrisonerService,
+  private val visitNotificationFlaggingService: VisitNotificationFlaggingService,
 ) {
 
   @Autowired
@@ -84,7 +83,7 @@ class VisitNotificationEventService(
       prisonDateBlockedDto.visitDate,
       PRISON_VISITS_BLOCKED_FOR_DATE,
     )
-    deleteNotificationsThatAreNoLongerValid(affectedNotifications)
+    deleteNotificationsThatAreNoLongerValid(affectedNotifications, PRISON_VISITS_BLOCKED_FOR_DATE)
   }
 
   fun handlePrisonerReleasedNotification(notificationDto: PrisonerReleasedNotificationDto) {
@@ -123,7 +122,11 @@ class VisitNotificationEventService(
 
   private fun processVisitsWithNotifications(affectedVisits: List<VisitDto>, type: NotificationEventType) {
     val affectedVisitsNoDuplicate = affectedVisits.filter { !visitNotificationEventRepository.isEventARecentDuplicate(it.reference, type) }
-    flagTrackEvents(affectedVisitsNoDuplicate, type)
+
+    affectedVisitsNoDuplicate.forEach {
+      val bookingEventAudit = visitService.getLastEventForBooking(it.reference)
+      visitNotificationFlaggingService.flagTrackEvents(it, bookingEventAudit, type)
+    }
 
     if (isPairGroupRequired(type)) {
       val affectedPairedVisits = pairWithEachOther(affectedVisits)
@@ -179,19 +182,10 @@ class VisitNotificationEventService(
     }
   }
 
-  private fun flagTrackEvents(
-    visits: List<VisitDto>,
-    type: NotificationEventType,
-  ) {
-    visits.forEach {
-      LOG.info("Flagging visit with reference {} for ${type.reviewType}", it.reference)
-      val bookingEventAudit = visitService.getLastEventForBooking(it.reference)
-      val data = telemetryClientService.createFlagEventFromVisitDto(it, bookingEventAudit, type)
-      telemetryClientService.trackEvent(FLAGGED_VISIT_EVENT, data)
+  private fun deleteNotificationsThatAreNoLongerValid(visitNotificationEvents: List<VisitNotificationEvent>, notificationEventType: NotificationEventType? = null) {
+    visitNotificationEvents.forEach {
+      visitNotificationFlaggingService.unFlagTrackEvents(it.bookingReference, notificationEventType)
     }
-  }
-
-  private fun deleteNotificationsThatAreNoLongerValid(visitNotificationEvents: List<VisitNotificationEvent>) {
     visitNotificationEventRepository.deleteAll(visitNotificationEvents)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationFlaggingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationFlaggingService.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
+import uk.gov.justice.digital.hmpps.visitscheduler.service.TelemetryVisitEvents.FLAGGED_VISIT_EVENT
+import uk.gov.justice.digital.hmpps.visitscheduler.service.TelemetryVisitEvents.UNFLAGGED_VISIT_EVENT
+
+@Service
+class VisitNotificationFlaggingService(
+  private val telemetryClientService: TelemetryClientService,
+) {
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun flagTrackEvents(
+    visit: VisitDto,
+    bookingEventAudit: EventAuditDto?,
+    type: NotificationEventType,
+  ) {
+    LOG.info("Flagging visit with reference {} for ${type.reviewType}", visit.reference)
+    val data = telemetryClientService.createFlagEventFromVisitDto(visit, bookingEventAudit, type)
+    telemetryClientService.trackEvent(FLAGGED_VISIT_EVENT, data)
+  }
+
+  fun unFlagTrackEvents(
+    visitReference: String,
+    type: NotificationEventType?,
+  ) {
+    LOG.info("Unflagging visit with reference {} , review type(s) - {}", visitReference, type?.reviewType ?: "ALL")
+    val data = telemetryClientService.createUnFlagEventForVisit(visitReference, type)
+    telemetryClientService.trackEvent(UNFLAGGED_VISIT_EVENT, data)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationFlaggingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationFlaggingService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.service.TelemetryVisitEvents.FLAGGED_VISIT_EVENT
 import uk.gov.justice.digital.hmpps.visitscheduler.service.TelemetryVisitEvents.UNFLAGGED_VISIT_EVENT
 
@@ -29,9 +30,10 @@ class VisitNotificationFlaggingService(
   fun unFlagTrackEvents(
     visitReference: String,
     type: NotificationEventType?,
+    reason: UnFlagEventReason,
   ) {
-    LOG.info("Unflagging visit with reference {} , review type(s) - {}", visitReference, type?.reviewType ?: "ALL")
-    val data = telemetryClientService.createUnFlagEventForVisit(visitReference, type)
+    LOG.info("Unflagging visit with reference {} , review type(s) - {}, reason - {} ", visitReference, type?.reviewType ?: "ALL", reason.desc)
+    val data = telemetryClientService.createUnFlagEventForVisit(visitReference, type, reason)
     telemetryClientService.trackEvent(UNFLAGGED_VISIT_EVENT, data)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitorDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.CreateApplicationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.CreateApplicationRestriction
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitNotificationEventHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callApplicationForVisitChange
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callCancelVisit
@@ -567,6 +568,7 @@ class CancelVisitTest : IntegrationTestBase() {
       eq("unflagged-visit-event"),
       org.mockito.kotlin.check {
         Assertions.assertThat(it["reference"]).isEqualTo(cancelledVisit.reference)
+        Assertions.assertThat(it["reason"]).isEqualTo(UnFlagEventReason.VISIT_CANCELLED.desc)
       },
       isNull(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
@@ -544,6 +544,7 @@ class CancelVisitTest : IntegrationTestBase() {
     verify(visitNotificationEventRepository, times(1)).deleteByBookingReference(eq(visit.reference))
 
     Assertions.assertThat(visitNotifications.size).isEqualTo(0)
+    assertUnFlagEvent(visitCancelled)
   }
 
   fun assertCancelledDomainEvent(
@@ -557,5 +558,18 @@ class CancelVisitTest : IntegrationTestBase() {
       isNull(),
     )
     verify(telemetryClient, times(1)).trackEvent(eq("prison-visit.cancelled-domain-event"), any(), isNull())
+  }
+
+  fun assertUnFlagEvent(
+    cancelledVisit: VisitDto,
+  ) {
+    verify(telemetryClient).trackEvent(
+      eq("unflagged-visit-event"),
+      org.mockito.kotlin.check {
+        Assertions.assertThat(it["reference"]).isEqualTo(cancelledVisit.reference)
+      },
+      isNull(),
+    )
+    verify(telemetryClient, times(1)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventServiceTest.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.service.NonAssociationDomainE
 class VisitNotificationEventServiceTest {
 
   private val visitService = mock<VisitService>()
-  private val telemetryClientService = mock<TelemetryClientService>()
+  private val visitNotificationFlaggingService = mock<VisitNotificationFlaggingService>()
   private val visitNotificationEventRepository = mock<VisitNotificationEventRepository>()
   private val prisonerService = mock<PrisonerService>()
 
@@ -34,7 +34,7 @@ class VisitNotificationEventServiceTest {
 
   @BeforeEach
   fun beforeEachTestSetup() {
-    visitNotificationEventService = VisitNotificationEventService(visitService, telemetryClientService, visitNotificationEventRepository, prisonerService)
+    visitNotificationEventService = VisitNotificationEventService(visitService, visitNotificationEventRepository, prisonerService, visitNotificationFlaggingService)
 
     whenever(prisonerService.getPrisoner(primaryNonAssociationNumber)).thenReturn(
       PrisonerDto(
@@ -83,7 +83,7 @@ class VisitNotificationEventServiceTest {
 
     // Then
     Mockito.verify(visitService, times(2)).getBookedVisits(any(), any(), any())
-    Mockito.verify(telemetryClientService, times(0)).trackEvent(any(), any())
+    Mockito.verify(visitNotificationFlaggingService, times(0)).flagTrackEvents(any(), any(), any())
     Mockito.verify(visitNotificationEventRepository, times(0)).saveAndFlush(any<VisitNotificationEvent>())
   }
 }


### PR DESCRIPTION
## What does this pull request do?
Creates unflag events when a notification event is removed.

## What is the intent behind these changes?

Better AppInsights reporting.