### PR TITLE
VB-3839 Update migration script so that session template start and en…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.service
 
 import com.microsoft.applicationinsights.TelemetryClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -30,11 +32,11 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Appl
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.ApplicationContact
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.ApplicationVisitor
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionSlot
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.ApplicationRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.EventAuditRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.LegacyDataRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
-import uk.gov.justice.digital.hmpps.visitscheduler.service.VisitService.Companion
 import uk.gov.justice.digital.hmpps.visitscheduler.utils.MigrationSessionTemplateMatcher
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -58,6 +60,10 @@ class MigrateVisitService(
   private val migrateMaxMonthsInFuture: Long,
 ) {
 
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
   @Autowired
   private lateinit var visitDtoBuilder: VisitDtoBuilder
 
@@ -76,24 +82,17 @@ class MigrateVisitService(
     // Deserialization kotlin data class issue when OutcomeStatus = json type of null defaults do not get set hence below code
     val outcomeStatus = migrateVisitRequest.outcomeStatus ?: OutcomeStatus.NOT_RECORDED
 
-    val shouldMigrateWithSessionTemplate = shouldMigrateWithSessionMapping(migrateVisitRequest)
     val prison: Prison
     val visitRoom: String
     val sessionSlot: SessionSlot
 
+    val shouldMigrateWithSessionTemplate = shouldMigrateWithSessionMapping(migrateVisitRequest)
     if (shouldMigrateWithSessionTemplate) {
       val sessionTemplate = migrationSessionTemplateMatcher.getMatchingSessionTemplate(migrateVisitRequest)
-
       prison = sessionTemplate.prison
-      val sessionTemplateReference = sessionTemplate.reference
       visitRoom = sessionTemplate.visitRoom
 
-      sessionSlot = sessionSlotService.getSessionSlot(
-        startTimeDate = migrateVisitRequest.startTimestamp,
-        endTimeAndDate = migrateVisitRequest.endTimestamp,
-        sessionTemplateReference,
-        prison,
-      )
+      sessionSlot = getSessionSlotFromSessionTemplate(migrateVisitRequest, sessionTemplate, prison)
     } else {
       prison = prisonsService.findPrisonByCode(migrateVisitRequest.prisonCode)
       visitRoom = migrateVisitRequest.visitRoom
@@ -139,6 +138,39 @@ class MigrateVisitService(
     }
 
     return visitEntity.reference
+  }
+
+  private fun getSessionSlotFromSessionTemplate(
+    migrateVisitRequest: MigrateVisitRequestDto,
+    sessionTemplate: SessionTemplate,
+    prison: Prison,
+  ): SessionSlot {
+    val startTimeDate: LocalDateTime
+    val endTimeAndDate: LocalDateTime
+
+    if (migrationSessionTemplateMatcher.isThereASessionTimeMisMatch(migrateVisitRequest, sessionTemplate)) {
+      startTimeDate = migrateVisitRequest.startTimestamp.toLocalDate().atTime(sessionTemplate.startTime)
+      endTimeAndDate = migrateVisitRequest.endTimestamp.toLocalDate().atTime(sessionTemplate.endTime)
+
+      LOG.debug(
+        "getSessionSlotFromSessionTemplate session miss match: session migrated '{}' to '{}' = '{}' to '{}' session template : {}",
+        migrateVisitRequest.startTimestamp.toLocalTime(),
+        migrateVisitRequest.endTimestamp.toLocalTime(),
+        sessionTemplate.startTime,
+        sessionTemplate.endTime,
+        sessionTemplate.reference,
+      )
+    } else {
+      startTimeDate = migrateVisitRequest.startTimestamp
+      endTimeAndDate = migrateVisitRequest.endTimestamp
+    }
+
+    return sessionSlotService.getSessionSlot(
+      startTimeDate = startTimeDate,
+      endTimeAndDate = endTimeAndDate,
+      sessionTemplate.reference,
+      prison,
+    )
   }
 
   private fun createApplication(
@@ -314,7 +346,7 @@ class MigrateVisitService(
     try {
       telemetryClient.trackEvent(eventName, properties, null)
     } catch (e: RuntimeException) {
-      Companion.LOG.error("Error occurred in call to telemetry client to log event - $e.toString()")
+      LOG.error("Error occurred in call to telemetry client to log event - $e.toString()")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/MigrationSessiontTemplateMatcher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/MigrationSessiontTemplateMatcher.kt
@@ -117,6 +117,12 @@ class MigrationSessionTemplateMatcher(
     }
   }
 
+  fun isThereASessionTimeMisMatch(
+    migrateVisitRequest: MigrateVisitRequestDto,
+    sessionTemplate: SessionTemplate,
+  ) = migrateVisitRequest.startTimestamp.toLocalTime() != sessionTemplate.startTime ||
+    migrateVisitRequest.endTimestamp.toLocalTime() != sessionTemplate.endTime
+
   fun getNearestSessionTemplate(
     migrateVisitRequest: MigrateVisitRequestDto,
     sessionTemplates: List<SessionTemplate>,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitTest.kt
@@ -121,6 +121,91 @@ class MigrateVisitTest : MigrationIntegrationTestBase() {
   }
 
   @Test
+  fun `migrate visit when start migrated session slot mismatch with session template - should use session template start date`() {
+    // Given
+
+    val migrateVisitRequestDto = createMigrateVisitRequestDto(modifyDateTime = LocalDateTime.of(2022, 9, 11, 12, 30))
+    val sessionTemplate = createSessionTemplateFrom(migrateVisitRequestDto, startTime = migrateVisitRequestDto.startTimestamp.plusHours(1).toLocalTime())
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, migrateVisitRequestDto)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+    val reference = getReference(responseSpec)
+
+    assertThat(migrateVisitRequestDto.startTimestamp.toLocalTime()).isNotEqualTo(sessionTemplate.startTime)
+    assertThat(migrateVisitRequestDto.endTimestamp.toLocalTime()).isEqualTo(sessionTemplate.endTime)
+
+    val visit = visitRepository.findByReference(reference)
+    assertThat(visit).isNotNull
+    visit?.let {
+      assertThat(visit.sessionSlot.slotDate).isEqualTo(migrateVisitRequestDto.endTimestamp.toLocalDate())
+      assertThat(visit.sessionSlot.slotStart.toLocalTime()).isEqualTo(sessionTemplate.startTime)
+      assertThat(visit.sessionSlot.slotEnd.toLocalTime()).isEqualTo(sessionTemplate.endTime)
+      assertVisitMatchesApplication(visit, visit.getLastApplication()!!)
+    }
+  }
+
+  @Test
+  fun `migrate visit when end migrated session slot mismatch with session template - should use session template end date`() {
+    // Given
+
+    val migrateVisitRequestDto = createMigrateVisitRequestDto(modifyDateTime = LocalDateTime.of(2022, 9, 11, 12, 30))
+    val sessionTemplate = createSessionTemplateFrom(migrateVisitRequestDto, endTime = migrateVisitRequestDto.endTimestamp.minusHours(1).toLocalTime())
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, migrateVisitRequestDto)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+    val reference = getReference(responseSpec)
+
+    assertThat(migrateVisitRequestDto.startTimestamp.toLocalTime()).isEqualTo(sessionTemplate.startTime)
+    assertThat(migrateVisitRequestDto.endTimestamp.toLocalTime()).isNotEqualTo(sessionTemplate.endTime)
+
+    val visit = visitRepository.findByReference(reference)
+    assertThat(visit).isNotNull
+    visit?.let {
+      assertThat(visit.sessionSlot.slotDate).isEqualTo(migrateVisitRequestDto.endTimestamp.toLocalDate())
+      assertThat(visit.sessionSlot.slotStart.toLocalTime()).isEqualTo(sessionTemplate.startTime)
+      assertThat(visit.sessionSlot.slotEnd.toLocalTime()).isEqualTo(sessionTemplate.endTime)
+      assertVisitMatchesApplication(visit, visit.getLastApplication()!!)
+    }
+  }
+
+  @Test
+  fun `migrate visit when end and start migrated session slot mismatch with session template - should use session template start and end date`() {
+    // Given
+
+    val migrateVisitRequestDto = createMigrateVisitRequestDto(modifyDateTime = LocalDateTime.of(2022, 9, 11, 12, 30))
+    val sessionTemplate = createSessionTemplateFrom(
+      migrateVisitRequestDto,
+      startTime = migrateVisitRequestDto.startTimestamp.minusHours(1).toLocalTime(),
+      endTime = migrateVisitRequestDto.endTimestamp.plusHours(1).toLocalTime(),
+    )
+
+    // When
+    val responseSpec = callMigrateVisit(roleVisitSchedulerHttpHeaders, migrateVisitRequestDto)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+    val reference = getReference(responseSpec)
+
+    assertThat(migrateVisitRequestDto.startTimestamp.toLocalTime()).isNotEqualTo(sessionTemplate.startTime)
+    assertThat(migrateVisitRequestDto.endTimestamp.toLocalTime()).isNotEqualTo(sessionTemplate.endTime)
+
+    val visit = visitRepository.findByReference(reference)
+    assertThat(visit).isNotNull
+    visit?.let {
+      assertThat(visit.sessionSlot.slotDate).isEqualTo(migrateVisitRequestDto.endTimestamp.toLocalDate())
+      assertThat(visit.sessionSlot.slotStart.toLocalTime()).isEqualTo(sessionTemplate.startTime)
+      assertThat(visit.sessionSlot.slotEnd.toLocalTime()).isEqualTo(sessionTemplate.endTime)
+      assertVisitMatchesApplication(visit, visit.getLastApplication()!!)
+    }
+  }
+
+  @Test
   fun `Migrate cancelled visit`() {
     // Given
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/MigrateVisitSessionMatchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/MigrateVisitSessionMatchTest.kt
@@ -1,0 +1,137 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.MigrateVisitRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionTemplateRepository
+import uk.gov.justice.digital.hmpps.visitscheduler.service.PrisonerService
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class MigrateVisitSessionMatchTest {
+
+  private val prisonerService: PrisonerService = Mockito.mock(PrisonerService::class.java)
+  private val sessionTemplateRepository: SessionTemplateRepository = Mockito.mock(SessionTemplateRepository::class.java)
+  private val prisonerCategoryMatcher: PrisonerCategoryMatcher = Mockito.mock(PrisonerCategoryMatcher::class.java)
+  private val prisonerIncentiveLevelMatcher: PrisonerIncentiveLevelMatcher = Mockito.mock(PrisonerIncentiveLevelMatcher::class.java)
+  private val sessionValidator: PrisonerSessionValidator = Mockito.mock(PrisonerSessionValidator::class.java)
+  private val sessionDatesUtil: SessionDatesUtil = Mockito.mock(SessionDatesUtil::class.java)
+
+  @InjectMocks
+  private val migrationSessionTemplateMatcher = MigrationSessionTemplateMatcher(
+    prisonerService,
+    sessionTemplateRepository,
+    prisonerCategoryMatcher,
+    prisonerIncentiveLevelMatcher,
+    sessionValidator,
+    sessionDatesUtil,
+  )
+
+  @Test
+  fun `When session start date is before migrated visit start date`() {
+    // Given
+    val (migrateVisitRequest, sessionTemplate) = setUpTest(-1)
+
+    // When
+    val result = doTest(migrateVisitRequest, sessionTemplate)
+
+    // Then
+    assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `When session start date is after migrated visit start date`() {
+    // Given
+    val (migrateVisitRequest, sessionTemplate) = setUpTest(1)
+
+    // When
+    val result = doTest(migrateVisitRequest, sessionTemplate)
+
+    // Then
+    assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `When session start date is same as migrated visit start date`() {
+    // Given
+    val (migrateVisitRequest, sessionTemplate) = setUpTest(0, 0)
+
+    // When
+    val result = doTest(migrateVisitRequest, sessionTemplate)
+
+    // Then
+    assertThat(result).isFalse()
+  }
+
+  @Test
+  fun `When session end date is before migrated visit end date`() {
+    // Given
+    val (migrateVisitRequest, sessionTemplate) = setUpTest(0, -30)
+
+    // When
+    val result = doTest(migrateVisitRequest, sessionTemplate)
+
+    // Then
+    assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `When session end date is after migrated visit end date`() {
+    // Given
+    val (migrateVisitRequest, sessionTemplate) = setUpTest(0, 30)
+
+    // When
+    val result = doTest(migrateVisitRequest, sessionTemplate)
+
+    // Then
+    assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `When session end date is same as migrated visit end date`() {
+    // Given
+    val (migrateVisitRequest, sessionTemplate) = setUpTest(0, 0)
+
+    // When
+    val result = doTest(migrateVisitRequest, sessionTemplate)
+    // Then
+    assertThat(result).isFalse()
+  }
+
+  private fun setUpTest(
+    sessionTemplateStartMinDiff: Int,
+    sessionTemplateEndMinDiff: Int? = null,
+  ): Pair<MigrateVisitRequestDto, SessionTemplate> {
+    val migrateVisitRequest = Mockito.mock(MigrateVisitRequestDto::class.java)
+    val sessionTemplate = Mockito.mock(SessionTemplate::class.java)
+
+    val startLocalDateTime = LocalDateTime.now()
+    val endLocalDateTime = startLocalDateTime.plusHours(1)
+
+    Mockito.`when`(migrateVisitRequest.startTimestamp).thenReturn(startLocalDateTime)
+    Mockito.`when`(sessionTemplate.startTime).thenReturn(startLocalDateTime.toLocalTime().plusMinutes(sessionTemplateStartMinDiff.toLong()))
+
+    sessionTemplateEndMinDiff?.let {
+      Mockito.`when`(migrateVisitRequest.endTimestamp).thenReturn(endLocalDateTime)
+      Mockito.`when`(sessionTemplate.endTime).thenReturn(endLocalDateTime.toLocalTime().plusMinutes(it.toLong()))
+    }
+
+    return Pair(migrateVisitRequest, sessionTemplate)
+  }
+
+  private fun doTest(
+    migrateVisitRequest: MigrateVisitRequestDto,
+    sessionTemplate: SessionTemplate,
+  ): Boolean {
+    val result = migrationSessionTemplateMatcher.isThereASessionTimeMisMatch(
+      migrateVisitRequest = migrateVisitRequest,
+      sessionTemplate = sessionTemplate,
+    )
+    return result
+  }
+}


### PR DESCRIPTION
During migration of visits from NOMIS to VSIP, the start and end time of the sessions in NOMIS are preserved. The visits themselves are associated with the nearest matching visit session.

Sometimes, these visit start and end times do not match (for example NOMIS might have been 14:15 - 15:15 and VSIP has 14:00 - 15:00.

The service will think that the prisoner is already on another visit, and will not allow the visit  to be updated. 

In order to fix this we need to update the migration code so that the visit times of the migrated visits match the visit session they are assigned to. 