### PR TITLE
VB-3877 Add UserType to Application/Visit and Cancel actions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/EventAudit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/EventAudit.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import java.time.LocalDateTime
 
 @Entity
@@ -43,6 +44,10 @@ class EventAudit(
 
   @Column(nullable = false)
   var actionedBy: String,
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "user_type", nullable = false)
+  val userType: UserType,
 
   @Column(nullable = true)
   var text: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationService.kt
@@ -312,6 +312,7 @@ class ApplicationService(
         type = if (application.reserved) RESERVED_VISIT else CHANGING_VISIT,
         applicationMethodType = applicationMethodType,
         text = null,
+        userType = application.userType,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/MigrateVisitService.kt
@@ -121,6 +121,7 @@ class MigrateVisitService(
         type = MIGRATED_VISIT,
         applicationMethodType = NOT_KNOWN,
         text = null,
+        userType = visitEntity.userType,
       ),
     )
 
@@ -306,6 +307,7 @@ class MigrateVisitService(
         type = CANCELLED_VISIT,
         applicationMethodType = NOT_KNOWN,
         text = null,
+        userType = STAFF,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -231,6 +231,7 @@ class VisitNotificationEventService(
         type = EventAuditType.valueOf(type.name),
         applicationMethodType = NOT_KNOWN,
         text = null,
+        userType = impactedVisit.userType,
       ),
     )
 

--- a/src/main/resources/db/migration/V3_25__add_user_type_to_event_audit_table.sql
+++ b/src/main/resources/db/migration/V3_25__add_user_type_to_event_audit_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE event_audit ADD user_type VARCHAR(80) DEFAULT 'STAFF' NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ApplicationEntityHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ApplicationEntityHelper.kt
@@ -28,7 +28,7 @@ class ApplicationEntityHelper(
   companion object {
 
     fun createApplication(visit: Visit): Application {
-      val application = Application(
+      return Application(
         prisonerId = visit.prisonerId,
         prisonId = visit.prisonId,
         prison = visit.prison,
@@ -41,7 +41,6 @@ class ApplicationEntityHelper(
         completed = true,
         userType = STAFF,
       )
-      return application
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -454,6 +454,7 @@ class EventAuditEntityHelper(
     applicationMethodType: ApplicationMethodType = ApplicationMethodType.PHONE,
     type: EventAuditType = EventAuditType.BOOKED_VISIT,
     text: String?,
+    userType: UserType = STAFF,
   ): EventAudit {
     return save(
       EventAudit(
@@ -464,6 +465,7 @@ class EventAuditEntityHelper(
         type = type,
         applicationMethodType = applicationMethodType,
         text = text,
+        userType = userType,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitTest.kt
@@ -113,6 +113,7 @@ class MigrateVisitTest : MigrationIntegrationTestBase() {
       assertThat(eventAuditList[0].actionedBy).isEqualTo("Aled Evans")
       assertThat(eventAuditList[0].type).isEqualTo(EventAuditType.MIGRATED_VISIT)
       assertThat(eventAuditList[0].createTimestamp).isEqualTo(migrateVisitRequestDto.createDateTime)
+      assertThat(eventAuditList[0].userType).isEqualTo(STAFF)
 
       assertThat(visit.getApplications().size).isEqualTo(1)
       val application = visit.getLastApplication()!!
@@ -625,6 +626,12 @@ class MigrateVisitTest : MigrationIntegrationTestBase() {
 
     assertTelemetryClientEvents(visitCancelled, TelemetryVisitEvents.CANCELLED_VISIT_MIGRATED_EVENT)
     assertCancelledDomainEvent(visitCancelled)
+
+    val eventAuditList = eventAuditRepository.findAllByBookingReference(visit.reference)
+    assertThat(eventAuditList).hasSize(1)
+    assertThat(eventAuditList[0].actionedBy).isEqualTo("user-2")
+    assertThat(eventAuditList[0].type).isEqualTo(EventAuditType.CANCELLED_VISIT)
+    assertThat(eventAuditList[0].userType).isEqualTo(STAFF)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/application/ChangeReservedSlotThatHasABookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/application/ChangeReservedSlotThatHasABookingTest.kt
@@ -93,7 +93,7 @@ class ChangeReservedSlotThatHasABookingTest : IntegrationTestBase() {
     val visit = getVisit(applicationDto.reference)
 
     Assertions.assertThat(visit).isNotNull
-    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, false)
+    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, false, oldBooking.reference)
 
     // And
     assertTelemetry(applicationDto, visit!!)
@@ -240,7 +240,7 @@ class ChangeReservedSlotThatHasABookingTest : IntegrationTestBase() {
     val visit = getVisit(applicationDto.reference)
 
     Assertions.assertThat(visit).isNotNull
-    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, true)
+    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, true, oldBooking.reference)
 
     // And
     assertTelemetry(applicationDto, visit!!)
@@ -266,7 +266,7 @@ class ChangeReservedSlotThatHasABookingTest : IntegrationTestBase() {
     val visit = getVisit(applicationDto.reference)
     Assertions.assertThat(visit).isNotNull
 
-    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, false)
+    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, false, oldBooking.reference)
 
     // And
     assertTelemetry(applicationDto, visit!!)
@@ -291,7 +291,7 @@ class ChangeReservedSlotThatHasABookingTest : IntegrationTestBase() {
     val visit = getVisit(applicationDto.reference)
     Assertions.assertThat(visit).isNotNull
 
-    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, true)
+    assertChangedApplicationDetails(initialChangeApplication, applicationDto, updateRequest, true, oldBooking.reference)
 
     // And
     assertTelemetry(applicationDto, visit!!)
@@ -302,6 +302,7 @@ class ChangeReservedSlotThatHasABookingTest : IntegrationTestBase() {
     applicationDto: ApplicationDto,
     changeApplicationRequest: ChangeApplicationDto,
     reserved: Boolean,
+    bookingReference: String,
   ) {
     val sessionTemplate = testSessionTemplateRepository.findByReference(changeApplicationRequest.sessionTemplateReference)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CreateNonAssociationVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CreateNonAssociationVisitNotificationControllerTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit.notifications
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.NON_
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.IncentiveLevel
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NonAssociationDomainEventType.NON_ASSOCIATION_CREATED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NonAssociationChangedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatNonAssociationHasChanged
@@ -81,26 +82,28 @@ class CreateNonAssociationVisitNotificationControllerTest : NotificationTestBase
     verify(visitNotificationEventRepository, times(2)).saveAndFlush(any<VisitNotificationEvent>())
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
-    Assertions.assertThat(visitNotifications).hasSize(2)
-    Assertions.assertThat(visitNotifications[1].reference).isEqualTo(visitNotifications[0].reference)
+    assertThat(visitNotifications).hasSize(2)
+    assertThat(visitNotifications[1].reference).isEqualTo(visitNotifications[0].reference)
 
-    val auditEvents = testEventAuditRepository.getAuditByType("NON_ASSOCIATION_EVENT")
-    Assertions.assertThat(auditEvents).hasSize(2)
+    val auditEvents = testEventAuditRepository.getAuditByType(NON_ASSOCIATION_EVENT)
+    assertThat(auditEvents).hasSize(2)
     with(auditEvents[0]) {
-      Assertions.assertThat(actionedBy).isEqualTo("NOT_KNOWN")
-      Assertions.assertThat(bookingReference).isEqualTo(primaryVisit.reference)
-      Assertions.assertThat(applicationReference).isEqualTo(primaryVisit.getLastApplication()?.reference)
-      Assertions.assertThat(sessionTemplateReference).isEqualTo(primaryVisit.sessionSlot.sessionTemplateReference)
-      Assertions.assertThat(type).isEqualTo(NON_ASSOCIATION_EVENT)
-      Assertions.assertThat(applicationMethodType).isEqualTo(NOT_KNOWN)
+      assertThat(actionedBy).isEqualTo("NOT_KNOWN")
+      assertThat(bookingReference).isEqualTo(primaryVisit.reference)
+      assertThat(applicationReference).isEqualTo(primaryVisit.getLastApplication()?.reference)
+      assertThat(sessionTemplateReference).isEqualTo(primaryVisit.sessionSlot.sessionTemplateReference)
+      assertThat(type).isEqualTo(NON_ASSOCIATION_EVENT)
+      assertThat(applicationMethodType).isEqualTo(NOT_KNOWN)
+      assertThat(userType).isEqualTo(UserType.STAFF)
     }
     with(auditEvents[1]) {
-      Assertions.assertThat(actionedBy).isEqualTo("NOT_KNOWN")
-      Assertions.assertThat(bookingReference).isEqualTo(secondaryVisit.reference)
-      Assertions.assertThat(applicationReference).isEqualTo(secondaryVisit.getLastApplication()?.reference)
-      Assertions.assertThat(sessionTemplateReference).isEqualTo(secondaryVisit.sessionSlot.sessionTemplateReference)
-      Assertions.assertThat(type).isEqualTo(NON_ASSOCIATION_EVENT)
-      Assertions.assertThat(applicationMethodType).isEqualTo(NOT_KNOWN)
+      assertThat(actionedBy).isEqualTo("NOT_KNOWN")
+      assertThat(bookingReference).isEqualTo(secondaryVisit.reference)
+      assertThat(applicationReference).isEqualTo(secondaryVisit.getLastApplication()?.reference)
+      assertThat(sessionTemplateReference).isEqualTo(secondaryVisit.sessionSlot.sessionTemplateReference)
+      assertThat(type).isEqualTo(NON_ASSOCIATION_EVENT)
+      assertThat(applicationMethodType).isEqualTo(NOT_KNOWN)
+      assertThat(userType).isEqualTo(UserType.STAFF)
     }
   }
 
@@ -145,22 +148,22 @@ class CreateNonAssociationVisitNotificationControllerTest : NotificationTestBase
     verify(visitNotificationEventRepository, times(4)).saveAndFlush(any<VisitNotificationEvent>())
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
-    Assertions.assertThat(visitNotifications).hasSize(4)
+    assertThat(visitNotifications).hasSize(4)
     with(visitNotifications[0]) {
-      Assertions.assertThat(bookingReference).isEqualTo(primaryVisit.reference)
+      assertThat(bookingReference).isEqualTo(primaryVisit.reference)
     }
     with(visitNotifications[1]) {
-      Assertions.assertThat(bookingReference).isEqualTo(secondaryVisit.reference)
+      assertThat(bookingReference).isEqualTo(secondaryVisit.reference)
       // Check group 1
-      Assertions.assertThat(reference).isEqualTo(visitNotifications[0].reference)
+      assertThat(reference).isEqualTo(visitNotifications[0].reference)
     }
     with(visitNotifications[2]) {
-      Assertions.assertThat(bookingReference).isEqualTo(primaryVisit2.reference)
+      assertThat(bookingReference).isEqualTo(primaryVisit2.reference)
     }
     with(visitNotifications[3]) {
-      Assertions.assertThat(bookingReference).isEqualTo(secondaryVisit.reference)
+      assertThat(bookingReference).isEqualTo(secondaryVisit.reference)
       // Check group 2
-      Assertions.assertThat(reference).isEqualTo(visitNotifications[2].reference)
+      assertThat(reference).isEqualTo(visitNotifications[2].reference)
     }
   }
 
@@ -227,13 +230,13 @@ class CreateNonAssociationVisitNotificationControllerTest : NotificationTestBase
     verify(visitNotificationEventRepository, times(8)).saveAndFlush(any<VisitNotificationEvent>())
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
-    Assertions.assertThat(visitNotifications).hasSize(8)
-    Assertions.assertThat(visitNotifications[1].reference).isEqualTo(visitNotifications[0].reference)
-    Assertions.assertThat(visitNotifications[2].reference).isEqualTo(visitNotifications[3].reference)
-    Assertions.assertThat(visitNotifications[4].reference).isEqualTo(visitNotifications[5].reference)
-    Assertions.assertThat(visitNotifications[6].reference).isEqualTo(visitNotifications[7].reference)
+    assertThat(visitNotifications).hasSize(8)
+    assertThat(visitNotifications[1].reference).isEqualTo(visitNotifications[0].reference)
+    assertThat(visitNotifications[2].reference).isEqualTo(visitNotifications[3].reference)
+    assertThat(visitNotifications[4].reference).isEqualTo(visitNotifications[5].reference)
+    assertThat(visitNotifications[6].reference).isEqualTo(visitNotifications[7].reference)
 
-    Assertions.assertThat(testEventAuditRepository.getAuditCount("NON_ASSOCIATION_EVENT")).isEqualTo(8)
+    assertThat(testEventAuditRepository.getAuditCount(NON_ASSOCIATION_EVENT)).isEqualTo(8)
   }
 
   @Test
@@ -284,25 +287,25 @@ class CreateNonAssociationVisitNotificationControllerTest : NotificationTestBase
 
     // Then
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
-    Assertions.assertThat(visitNotifications).hasSize(4)
+    assertThat(visitNotifications).hasSize(4)
 
     with(visitNotifications[0]) {
-      Assertions.assertThat(reference).isNotNull()
-      Assertions.assertThat(bookingReference).isEqualTo(primaryVisit1.reference)
+      assertThat(reference).isNotNull()
+      assertThat(bookingReference).isEqualTo(primaryVisit1.reference)
     }
     with(visitNotifications[1]) {
-      Assertions.assertThat(bookingReference).isEqualTo(secondaryVisit1.reference)
-      Assertions.assertThat(reference).isEqualTo(visitNotifications[0].reference)
+      assertThat(bookingReference).isEqualTo(secondaryVisit1.reference)
+      assertThat(reference).isEqualTo(visitNotifications[0].reference)
     }
     with(visitNotifications[2]) {
-      Assertions.assertThat(reference).isNotNull()
-      Assertions.assertThat(bookingReference).isEqualTo(primaryVisit2.reference)
+      assertThat(reference).isNotNull()
+      assertThat(bookingReference).isEqualTo(primaryVisit2.reference)
     }
     with(visitNotifications[3]) {
-      Assertions.assertThat(bookingReference).isEqualTo(secondaryVisit2.reference)
-      Assertions.assertThat(reference).isEqualTo(visitNotifications[2].reference)
+      assertThat(bookingReference).isEqualTo(secondaryVisit2.reference)
+      assertThat(reference).isEqualTo(visitNotifications[2].reference)
     }
-    Assertions.assertThat(testEventAuditRepository.getAuditCount("NON_ASSOCIATION_EVENT")).isEqualTo(4)
+    assertThat(testEventAuditRepository.getAuditCount(NON_ASSOCIATION_EVENT)).isEqualTo(4)
   }
 
   @Test
@@ -591,6 +594,6 @@ class CreateNonAssociationVisitNotificationControllerTest : NotificationTestBase
   private fun assertNotHandle() {
     verify(telemetryClient, times(0)).trackEvent(eq("flagged-visit-event"), any(), isNull())
     verify(visitNotificationEventRepository, times(0)).saveAndFlush(any<VisitNotificationEvent>())
-    Assertions.assertThat(testEventAuditRepository.getAuditCount("NON_ASSOCIATION_EVENT")).isEqualTo(0)
+    assertThat(testEventAuditRepository.getAuditCount(NON_ASSOCIATION_EVENT)).isEqualTo(0)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/TestEventAuditRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/TestEventAuditRepository.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.EventAudit
 
 @Repository
@@ -19,17 +20,17 @@ interface TestEventAuditRepository : JpaRepository<EventAudit, Long> {
 
   @Query(
     "SELECT count(*) FROM event_audit " +
-      "WHERE type = :type",
+      "WHERE type = :#{#eventAuditType.name()}",
     nativeQuery = true,
   )
-  fun getAuditCount(type: String): Int
+  fun getAuditCount(eventAuditType: EventAuditType): Int
 
   @Query(
     "SELECT * FROM event_audit " +
-      "WHERE type = :type",
+      "WHERE type = :#{#eventAuditType.name()}",
     nativeQuery = true,
   )
-  fun getAuditByType(type: String): List<EventAudit>
+  fun getAuditByType(eventAuditType: EventAuditType): List<EventAudit>
 
   @Query(
     "SELECT * FROM event_audit " +
@@ -38,4 +39,12 @@ interface TestEventAuditRepository : JpaRepository<EventAudit, Long> {
     nativeQuery = true,
   )
   fun findLastBookedVisitEventByBookingReference(bookingReference: String): EventAudit
+
+  @Query(
+    "SELECT * FROM event_audit " +
+      "WHERE application_reference = :applicationReference AND type = :#{#eventAuditType.name()}  " +
+      "ORDER BY id DESC LIMIT 1 ",
+    nativeQuery = true,
+  )
+  fun findLastEventByApplicationReference(applicationReference: String, eventAuditType: EventAuditType): EventAudit
 }


### PR DESCRIPTION
Added user Type to audit table, notifications, migrations, application and visits and cancelation of visits have been affected.