### PR TITLE
Fix: Stop non-association client bringing back other prisons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/NonAssociationsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/NonAssociationsApiClient.kt
@@ -26,7 +26,7 @@ class NonAssociationsApiClient(
     LOG.debug("Entered getPrisonerNonAssociation $prisonerNumber")
 
     return webClient.get()
-      .uri("/prisoner/$prisonerNumber/non-associations?includeOtherPrisons=true")
+      .uri("/prisoner/$prisonerNumber/non-associations?includeOtherPrisons=false")
       .retrieve()
       .bodyToMono(TYPE_FOR_OFFENDER_NONASSOCIATION)
       .onErrorResume {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/NonAssociationsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/NonAssociationsApiMockServer.kt
@@ -23,7 +23,7 @@ class NonAssociationsApiMockServer : WireMockServer(8094) {
     val jsonBody = getJsonString(PrisonerNonAssociationDetailsDto(details))
 
     stubFor(
-      get("/prisoner/$prisonerNumber/non-associations?includeOtherPrisons=true")
+      get("/prisoner/$prisonerNumber/non-associations?includeOtherPrisons=false")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -39,7 +39,7 @@ class NonAssociationsApiMockServer : WireMockServer(8094) {
 
   fun stubGetPrisonerNonAssociation(prisonerNumber: String, prisonerNonAssociationDetailsDto: PrisonerNonAssociationDetailsDto? = null, status: HttpStatus = HttpStatus.NOT_FOUND) {
     stubFor(
-      get("/prisoner/$prisonerNumber/non-associations?includeOtherPrisons=true")
+      get("/prisoner/$prisonerNumber/non-associations?includeOtherPrisons=false")
         .willReturn(
           if (prisonerNonAssociationDetailsDto == null) {
             aResponse().withStatus(status.value())


### PR DESCRIPTION
## What does this pull request do?

We only want to check non associations for prisoners at the same prison. Change flag to false to stop including other prisons.