### PR TITLE
Fix: Introduce a gate way timeout exception handler

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/config/VisitSchedulerExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/config/VisitSchedulerExceptionHandler.kt
@@ -17,6 +17,7 @@ import org.springframework.web.reactive.function.client.WebClientException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.TelemetryVisitEvents
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.CapacityNotFoundException
+import uk.gov.justice.digital.hmpps.visitscheduler.exception.GatewayTimeoutException
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.ItemNotFoundException
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.MatchSessionTemplateToMigratedVisitException
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.OverCapacityException
@@ -242,6 +243,20 @@ class VisitSchedulerExceptionHandler(
         ErrorResponse(
           status = HttpStatus.NOT_FOUND,
           userMessage = "Not found",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(GatewayTimeoutException::class)
+  fun handleGatewayTimeoutException(e: GatewayTimeoutException): ResponseEntity<ErrorResponse?>? {
+    log.debug("Gateway timeout exception caught: {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.GATEWAY_TIMEOUT)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.GATEWAY_TIMEOUT,
+          userMessage = "Call to downstream service failed after timeout",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/exception/GatewayTimeoutException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/exception/GatewayTimeoutException.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.exception
+
+import java.util.function.Supplier
+
+class GatewayTimeoutException(message: String? = null, cause: Throwable? = null) :
+  RuntimeException(message, cause),
+  Supplier<GatewayTimeoutException> {
+  override fun get(): GatewayTimeoutException {
+    return GatewayTimeoutException(message, cause)
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Aim of this change is to get a more specific response code than the generic 500 that the spring web client returns.