### PR TITLE
Fix owasp scan by providing jdk_tag of 21 and cache_key v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@8
+  hmpps: ministryofjustice/hmpps@9
 
 parameters:
   alerts-slack-channel:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,8 @@ workflows:
     jobs:
       - hmpps/gradle_owasp_dependency_check:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          jdk_tag: "21.0"
+          cache_key: "v2_0"
           context:
             - hmpps-common-vars
       - hmpps/trivy_latest_scan:
@@ -279,6 +281,7 @@ workflows:
             - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          jdk_tag: "21.0"
           context:
             - veracode-credentials
             - hmpps-common-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,7 @@ workflows:
     jobs:
       - hmpps/veracode_policy_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          jdk_tag: "21.0"
           context:
             - veracode-credentials
             - hmpps-common-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,9 +270,9 @@ workflows:
                 - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          jdk_tag: "21.0"
           cache_key: "v2_0"
+          jdk_tag: "21.0"
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
       - hmpps/trivy_latest_scan:
@@ -280,8 +280,8 @@ workflows:
           context:
             - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           jdk_tag: "21.0"
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - veracode-credentials
             - hmpps-common-vars
@@ -295,8 +295,8 @@ workflows:
                 - main
     jobs:
       - hmpps/veracode_policy_scan:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           jdk_tag: "21.0"
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - veracode-credentials
             - hmpps-common-vars


### PR DESCRIPTION
## What does this pull request do?

Fix owasp scan by providing jdk_tag of 21 and cache_key v2