### PR TITLE
Update veracode cron time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ workflows:
   security:
     triggers:
       - schedule:
-          cron: "11 5 * * 1-5"
+          cron: "47 5 * * 1-5"
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this pull request do?

Updates the scheduled cron time for vera code scans. Currently it clashes frequently with other apps being scanned so fails.

## What is the intent behind these changes?

Stop cron job clashes in veracode scans.