### PR TITLE
VB-4109 Return replicaCount back to 4 for prod

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,17 +2,22 @@
 # Per environment values which override defaults in visit-scheduler/values.yaml
 
 generic-service:
-  replicaCount: 1
 
-  livenessProbe:
-    initialDelaySeconds: 780
-    periodSeconds: 30
-    failureThreshold: 1
+  replicaCount: 4
 
-  readinessProbe:
-    initialDelaySeconds: 780
-    periodSeconds: 30
-    failureThreshold: 1
+  # With big flyway migrations if we change the replicaCount as below we find that the migration does not lock.
+  # You still may find the deployment will register a fail but the migration has happen and once you change the settings back and deploy it works.
+  # replicaCount: 1
+  #
+  # livenessProbe:
+  #  initialDelaySeconds: 780
+  #  periodSeconds: 30
+  #  failureThreshold: 1
+  #
+  # readinessProbe:
+  #  initialDelaySeconds: 780
+  #  periodSeconds: 30
+  #  failureThreshold: 1
 
   ingress:
     host: visit-scheduler.prison.service.justice.gov.uk


### PR DESCRIPTION
After big data migration we need to change replicaCount back to 4 and remove bespoke time out