### PR TITLE
Changes for VB-4200 - send username as a parameter to getAvailableSessions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
@@ -155,7 +155,7 @@ class VisitSessionController(
     )
     currentUser: String? = null,
   ): List<AvailableVisitSessionDto> {
-    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference, excludeReservedApplicationsForUser = currentUser)
+    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference, usernameToExcludeFromReservedApplications = currentUser)
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
@@ -148,14 +148,14 @@ class VisitSessionController(
       example = "dfs-wjs-eqr",
     )
     excludedApplicationReference: String? = null,
-    @RequestParam(value = "currentUser", required = false)
+    @RequestParam(value = "username", required = false)
     @Parameter(
       description = "Username for the user making the request. Optional, ignored if not passed in.",
       example = "user-1",
     )
-    currentUser: String? = null,
+    username: String? = null,
   ): List<AvailableVisitSessionDto> {
-    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference, usernameToExcludeFromReservedApplications = currentUser)
+    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference, usernameToExcludeFromReservedApplications = username)
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
@@ -153,9 +153,9 @@ class VisitSessionController(
       description = "Username for the user making the request. Optional, ignored if not passed in.",
       example = "user-1",
     )
-    userName: String? = null,
+    currentUser: String? = null,
   ): List<AvailableVisitSessionDto> {
-    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference, excludeReservedApplicationsForUser = userName)
+    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference, excludeReservedApplicationsForUser = currentUser)
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
@@ -148,8 +148,14 @@ class VisitSessionController(
       example = "dfs-wjs-eqr",
     )
     excludedApplicationReference: String? = null,
+    @RequestParam(value = "currentUser", required = false)
+    @Parameter(
+      description = "Username for the user making the request. Optional, ignored if not passed in.",
+      example = "user-1",
+    )
+    userName: String? = null,
   ): List<AvailableVisitSessionDto> {
-    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference)
+    return sessionService.getAvailableVisitSessions(prisonCode, prisonerId, sessionRestriction, DateRange(fromDate, toDate), excludedApplicationReference, excludeReservedApplicationsForUser = userName)
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/ApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/ApplicationRepository.kt
@@ -90,14 +90,15 @@ interface ApplicationRepository : JpaRepository<Application, Long>, JpaSpecifica
       "a.prisonerId = :prisonerId AND " +
       "a.modifyTimestamp >= :expiredDateAndTime AND " +
       "a.sessionSlotId = :sessionSlotId AND " +
-      "(:excludedApplicationReference is null OR a.reference != :excludedApplicationReference)",
-
+      "(:excludedApplicationReference is null OR a.reference != :excludedApplicationReference) AND " +
+      "(:excludeReservedApplicationsForUser is null OR a.createdBy != :excludeReservedApplicationsForUser)",
   )
   fun hasReservations(
     @Param("prisonerId") prisonerId: String,
     @Param("sessionSlotId") sessionSlotId: Long,
     @Param("expiredDateAndTime") expiredDateAndTime: LocalDateTime,
     @Param("excludedApplicationReference") excludedApplicationReference: String?,
+    @Param("excludeReservedApplicationsForUser") excludeReservedApplicationsForUser: String?,
   ): Boolean
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/ApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/ApplicationRepository.kt
@@ -91,14 +91,14 @@ interface ApplicationRepository : JpaRepository<Application, Long>, JpaSpecifica
       "a.modifyTimestamp >= :expiredDateAndTime AND " +
       "a.sessionSlotId = :sessionSlotId AND " +
       "(:excludedApplicationReference is null OR a.reference != :excludedApplicationReference) AND " +
-      "(:excludeReservedApplicationsForUser is null OR a.createdBy != :excludeReservedApplicationsForUser)",
+      "(:usernameToExcludeFromReservedApplications is null OR a.createdBy != :usernameToExcludeFromReservedApplications)",
   )
   fun hasReservations(
     @Param("prisonerId") prisonerId: String,
     @Param("sessionSlotId") sessionSlotId: Long,
     @Param("expiredDateAndTime") expiredDateAndTime: LocalDateTime,
     @Param("excludedApplicationReference") excludedApplicationReference: String?,
-    @Param("excludeReservedApplicationsForUser") excludeReservedApplicationsForUser: String?,
+    @Param("usernameToExcludeFromReservedApplications") usernameToExcludeFromReservedApplications: String?,
   ): Boolean
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationService.kt
@@ -440,7 +440,7 @@ class ApplicationService(
     )
   }
 
-  fun hasReservations(prisonerId: String, sessionSlotId: Long, excludedApplicationReference: String?, excludeReservedApplicationsForUser: String?): Boolean {
+  fun hasReservations(prisonerId: String, sessionSlotId: Long, excludedApplicationReference: String?, usernameToExcludeFromReservedApplications: String?): Boolean {
     val expiredDateAndTime = getExpiredApplicationDateAndTime()
 
     return applicationRepo.hasReservations(
@@ -448,7 +448,7 @@ class ApplicationService(
       sessionSlotId = sessionSlotId,
       expiredDateAndTime,
       excludedApplicationReference = excludedApplicationReference,
-      excludeReservedApplicationsForUser = excludeReservedApplicationsForUser,
+      usernameToExcludeFromReservedApplications = usernameToExcludeFromReservedApplications,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationService.kt
@@ -440,7 +440,7 @@ class ApplicationService(
     )
   }
 
-  fun hasReservations(prisonerId: String, sessionSlotId: Long, excludedApplicationReference: String?): Boolean {
+  fun hasReservations(prisonerId: String, sessionSlotId: Long, excludedApplicationReference: String?, excludeReservedApplicationsForUser: String?): Boolean {
     val expiredDateAndTime = getExpiredApplicationDateAndTime()
 
     return applicationRepo.hasReservations(
@@ -448,6 +448,7 @@ class ApplicationService(
       sessionSlotId = sessionSlotId,
       expiredDateAndTime,
       excludedApplicationReference = excludedApplicationReference,
+      excludeReservedApplicationsForUser = excludeReservedApplicationsForUser,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -133,7 +133,15 @@ class SessionService(
     excludedApplicationReference: String?,
     excludeReservedApplicationsForUser: String?,
   ): List<AvailableVisitSessionDto> {
-    LOG.debug("Enter getAvailableVisitSessions prisonCode:{}, prisonerId : {}, sessionRestriction: {} ", prisonCode, prisonerId, sessionRestriction)
+    LOG.debug(
+      "Enter getAvailableVisitSessions prisonCode:{}, prisonerId : {}, sessionRestriction: {}, dateRange - {}, excludedApplicationReference - {}, excludeReservedApplicationsForUser - {} ",
+      prisonCode,
+      prisonerId,
+      sessionRestriction,
+      dateRange,
+      excludedApplicationReference,
+      excludeReservedApplicationsForUser,
+    )
 
     val visitSessions = getVisitSessions(prisonCode = prisonCode, prisonerId = prisonerId, dateRange = dateRange, excludedApplicationReference = excludedApplicationReference, excludeReservedApplicationsForUser = excludeReservedApplicationsForUser)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -20,11 +20,15 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ContactDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitorDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationSupportDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.CreateApplicationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.BOOKED_VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.CANCELLED_VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.RESERVED_VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus.CANCELLATION
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
@@ -52,6 +56,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.HmppsAuthExt
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.NonAssociationsApiMockServer
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.PrisonApiMockServer
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.PrisonOffenderSearchMockServer
+import uk.gov.justice.digital.hmpps.visitscheduler.integration.visit.application.ReserveSlotTest
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Application
@@ -392,5 +397,29 @@ abstract class IntegrationTestBase {
       userTypes = userTypes,
     )
     return visit
+  }
+
+  fun createReserveVisitSlotDto(
+    actionedBy: String = ReserveSlotTest.ACTIONED_BY_USER_NAME,
+    prisonerId: String = "FF0000FF",
+    sessionTemplate: SessionTemplate? = null,
+    slotDate: LocalDate? = null,
+    support: String = "Some Text",
+    sessionRestriction: SessionRestriction = SessionRestriction.OPEN,
+    allowOverBooking: Boolean = false,
+    userType: UserType = STAFF,
+  ): CreateApplicationDto {
+    return CreateApplicationDto(
+      prisonerId,
+      sessionTemplateReference = sessionTemplate?.reference ?: "IDontExistSessionTemplate",
+      sessionDate = slotDate ?: sessionTemplate?.let { sessionDatesUtil.getFirstBookableSessionDay(sessionTemplate) } ?: LocalDate.now(),
+      applicationRestriction = sessionRestriction,
+      visitContact = ContactDto("John Smith", "013448811538"),
+      visitors = setOf(VisitorDto(123, true), VisitorDto(124, false)),
+      visitorSupport = ApplicationSupportDto(support),
+      actionedBy = actionedBy,
+      userType = userType,
+      allowOverBooking = allowOverBooking,
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetAvailableSessionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetAvailableSessionsTest.kt
@@ -2269,7 +2269,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode = prisonCode,
       prisonerId = prisonerId,
       sessionRestriction = SessionRestriction.OPEN,
-      currentUser = createdByUser,
+      username = createdByUser,
     )
 
     // Then
@@ -2302,7 +2302,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode = prisonCode,
       prisonerId = prisonerId,
       sessionRestriction = SessionRestriction.OPEN,
-      currentUser = "other-user",
+      username = "other-user",
     )
 
     // Then
@@ -2524,7 +2524,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
     policyNoticeDaysMin: Int = 2,
     policyNoticeDaysMax: Int = 28,
     excludedApplicationReference: String? = null,
-    currentUser: String? = null,
+    username: String? = null,
   ): ResponseSpec {
     val today = LocalDate.now()
     val fromDate = today.plusDays(policyNoticeDaysMin.toLong())
@@ -2540,7 +2540,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       policyNoticeDaysMin = policyNoticeDaysMin,
       policyNoticeDaysMax = policyNoticeDaysMax,
       excludedApplicationReference = excludedApplicationReference,
-      currentUser = currentUser,
+      username = username,
     ).joinToString("&")
 
     return webTestClient.get().uri("$uri?$uriQueryParams")
@@ -2556,7 +2556,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
     policyNoticeDaysMin: Int,
     policyNoticeDaysMax: Int,
     excludedApplicationReference: String?,
-    currentUser: String?,
+    username: String?,
   ): List<String> {
     val queryParams = ArrayList<String>()
     queryParams.add("prisonId=$prisonCode")
@@ -2571,8 +2571,8 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       queryParams.add("excludedApplicationReference=$excludedApplicationReference")
     }
 
-    currentUser?.let {
-      queryParams.add("currentUser=$currentUser")
+    username?.let {
+      queryParams.add("username=$username")
     }
     return queryParams
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetAvailableSessionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetAvailableSessionsTest.kt
@@ -11,11 +11,13 @@ import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.IncentiveLevel
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionRestriction
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.AvailableVisitSessionDto
+import uk.gov.justice.digital.hmpps.visitscheduler.helper.submitApplication
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.service.DateRange
@@ -594,7 +596,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -663,7 +664,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -735,7 +735,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -807,7 +806,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode = "AWE",
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -869,7 +867,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -912,7 +909,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -949,7 +945,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -985,7 +980,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1025,7 +1019,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1065,7 +1058,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1109,7 +1101,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1153,7 +1144,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1186,7 +1176,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
     // Then
     val returnResult = responseSpec.expectStatus().isOk.expectBody()
@@ -1236,7 +1225,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1286,7 +1274,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1324,7 +1311,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1401,7 +1387,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1434,7 +1419,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1527,7 +1511,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1547,7 +1530,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1629,7 +1611,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1684,7 +1665,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1783,7 +1763,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1931,7 +1910,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -1957,7 +1935,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
     // Then
     assertResponseLength(responseSpec, 4)
@@ -1984,7 +1961,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2100,7 +2076,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2145,7 +2120,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2187,7 +2161,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2228,7 +2201,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2268,11 +2240,109 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
     assertResponseLength(responseSpec, 4)
+  }
+
+  @Test
+  fun `visit sessions are returned for a prisoner when an abandoned application for the prisoner by the same user exists`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val validFromDate = this.getNextAllowedDay()
+    val sessionTemplate = sessionTemplateEntityHelper.create(validFromDate = validFromDate, validToDate = null, dayOfWeek = validFromDate.dayOfWeek, prisonCode = prisonCode)
+    val createdByUser = "test-user"
+
+    // an application for the prisoner created by the current user exists
+    val reserveVisitSlotDto = createReserveVisitSlotDto(actionedBy = createdByUser, prisonerId = prisonerId, sessionTemplate = sessionTemplate, slotDate = validFromDate, userType = UserType.PUBLIC)
+    submitApplication(webTestClient, setAuthorisation(roles = requiredRole), reserveVisitSlotDto)
+
+    prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId, prison.code)
+    nonAssociationsApiMockServer.stubGetPrisonerNonAssociationEmpty(prisonerId)
+    prisonApiMockServer.stubGetPrisonerHousingLocation(prisonerId, "${prison.code}-C-1-C001")
+
+    // When
+
+    // excludeApplicationsForUser is passed as the same user who reserved an application for the prisoner against the same slot
+    val responseSpec = callGetAvailableSessions(
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = SessionRestriction.OPEN,
+      currentUser = createdByUser,
+    )
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val sessions = getResults(returnResult)
+    assertThat(sessions.size).isEqualTo(4)
+    val sessionDates = sessions.map { it.sessionDate }
+    assertThat(sessionDates).contains(validFromDate)
+  }
+
+  @Test
+  fun `visit sessions are not returned for a prisoner when an abandoned application for the prisoner by a different user exists`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val validFromDate = this.getNextAllowedDay()
+    val createdByUser = "test-user"
+    val sessionTemplate = sessionTemplateEntityHelper.create(validFromDate = validFromDate, validToDate = null, dayOfWeek = validFromDate.dayOfWeek, prisonCode = prisonCode)
+
+    // an application for the prisoner created by the current user exists
+    val reserveVisitSlotDto = createReserveVisitSlotDto(actionedBy = createdByUser, prisonerId = prisonerId, sessionTemplate = sessionTemplate, slotDate = validFromDate, userType = UserType.PUBLIC)
+    submitApplication(webTestClient, setAuthorisation(roles = requiredRole), reserveVisitSlotDto)
+
+    prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId, prison.code)
+    nonAssociationsApiMockServer.stubGetPrisonerNonAssociationEmpty(prisonerId)
+    prisonApiMockServer.stubGetPrisonerHousingLocation(prisonerId, "${prison.code}-C-1-C001")
+
+    // When
+    // excludeApplicationsForUser is not the same as the user who reserved an application for the prisoner against the same slot
+    val responseSpec = callGetAvailableSessions(
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = SessionRestriction.OPEN,
+      currentUser = "other-user",
+    )
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val sessions = getResults(returnResult)
+    assertThat(sessions.size).isEqualTo(3)
+    val sessionDates = sessions.map { it.sessionDate }
+    assertThat(sessionDates).doesNotContain(validFromDate)
+  }
+
+  @Test
+  fun `visit sessions are not returned for a prisoner when excludeApplicationsForUser is not passed in`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val validFromDate = this.getNextAllowedDay()
+    val createdByUser = "test-user"
+    val sessionTemplate = sessionTemplateEntityHelper.create(validFromDate = validFromDate, validToDate = null, dayOfWeek = validFromDate.dayOfWeek, prisonCode = prisonCode)
+
+    // an application for the prisoner created by the current user exists
+    val reserveVisitSlotDto = createReserveVisitSlotDto(actionedBy = createdByUser, prisonerId = prisonerId, sessionTemplate = sessionTemplate, slotDate = validFromDate, userType = UserType.PUBLIC)
+    submitApplication(webTestClient, setAuthorisation(roles = requiredRole), reserveVisitSlotDto)
+
+    prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId, prison.code)
+    nonAssociationsApiMockServer.stubGetPrisonerNonAssociationEmpty(prisonerId)
+    prisonApiMockServer.stubGetPrisonerHousingLocation(prisonerId, "${prison.code}-C-1-C001")
+
+    // When
+    // excludeApplicationsForUser is not the same as the user who reserved an application for the prisoner against the same slot
+    val responseSpec = callGetAvailableSessions(
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = SessionRestriction.OPEN,
+    )
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val sessions = getResults(returnResult)
+    assertThat(sessions.size).isEqualTo(3)
+    val sessionDates = sessions.map { it.sessionDate }
+    assertThat(sessionDates).doesNotContain(validFromDate)
   }
 
   @Test
@@ -2290,7 +2360,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       incorrectPrisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2330,7 +2399,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2369,7 +2437,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2444,7 +2511,6 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       prisonCode,
       prisonerId,
       SessionRestriction.OPEN,
-
     )
 
     // Then
@@ -2458,19 +2524,58 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
     policyNoticeDaysMin: Int = 2,
     policyNoticeDaysMax: Int = 28,
     excludedApplicationReference: String? = null,
+    currentUser: String? = null,
   ): ResponseSpec {
     val today = LocalDate.now()
     val fromDate = today.plusDays(policyNoticeDaysMin.toLong())
     val toDate = today.plusDays(policyNoticeDaysMax.toLong())
     val dateRange = DateRange(fromDate, toDate)
 
-    val uri = "/visit-sessions/available?prisonId=$prisonCode&prisonerId=$prisonerId&sessionRestriction=$sessionRestriction&fromDate=${dateRange.fromDate}&toDate=${dateRange.toDate}&excludedApplicationReference=$excludedApplicationReference"
+    val uri = "/visit-sessions/available"
+    val uriQueryParams = getAvailableSessionsQueryParams(
+      prisonCode = prisonCode!!,
+      prisonerId = prisonerId,
+      sessionRestriction = sessionRestriction,
+      dateRange = dateRange,
+      policyNoticeDaysMin = policyNoticeDaysMin,
+      policyNoticeDaysMax = policyNoticeDaysMax,
+      excludedApplicationReference = excludedApplicationReference,
+      currentUser = currentUser,
+    ).joinToString("&")
 
-    return webTestClient.get().uri(uri)
+    return webTestClient.get().uri("$uri?$uriQueryParams")
       .headers(setAuthorisation(roles = requiredRole))
       .exchange()
   }
 
+  private fun getAvailableSessionsQueryParams(
+    prisonCode: String,
+    prisonerId: String,
+    sessionRestriction: SessionRestriction,
+    dateRange: DateRange,
+    policyNoticeDaysMin: Int,
+    policyNoticeDaysMax: Int,
+    excludedApplicationReference: String?,
+    currentUser: String?,
+  ): List<String> {
+    val queryParams = ArrayList<String>()
+    queryParams.add("prisonId=$prisonCode")
+    queryParams.add("prisonerId=$prisonerId")
+    queryParams.add("sessionRestriction=$sessionRestriction")
+    queryParams.add("fromDate=${dateRange.fromDate}")
+    queryParams.add("toDate=${dateRange.toDate}")
+    queryParams.add("policyNoticeDaysMin=$policyNoticeDaysMin")
+    queryParams.add("policyNoticeDaysMax=$policyNoticeDaysMax")
+
+    excludedApplicationReference?.let {
+      queryParams.add("excludedApplicationReference=$excludedApplicationReference")
+    }
+
+    currentUser?.let {
+      queryParams.add("currentUser=$currentUser")
+    }
+    return queryParams
+  }
   private fun getNextAllowedDay(): LocalDate {
     // The 3 days is based on the default SessionService.policyNoticeDaysMin
     return LocalDate.now().plusDays(3)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/application/ReserveSlotTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/application/ReserveSlotTest.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.RESERVED_VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionRestriction.OPEN
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
@@ -38,7 +37,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.helper.getSubmitApplicationUr
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.submitApplication
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Application
-import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestApplicationRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestSessionTemplateRepository
 import java.time.LocalDate
@@ -69,30 +67,6 @@ class ReserveSlotTest : IntegrationTestBase() {
   internal fun setUp() {
     roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
     prisonEntityHelper.create("MDI", true)
-  }
-
-  private fun createReserveVisitSlotDto(
-    actionedBy: String = ACTIONED_BY_USER_NAME,
-    prisonerId: String = "FF0000FF",
-    sessionTemplate: SessionTemplate? = null,
-    slotDate: LocalDate? = null,
-    support: String = "Some Text",
-    sessionRestriction: SessionRestriction = OPEN,
-    allowOverBooking: Boolean = false,
-    userType: UserType = STAFF,
-  ): CreateApplicationDto {
-    return CreateApplicationDto(
-      prisonerId,
-      sessionTemplateReference = sessionTemplate?.reference ?: "IDontExistSessionTemplate",
-      sessionDate = slotDate ?: sessionTemplate?.let { sessionDatesUtil.getFirstBookableSessionDay(sessionTemplate) } ?: LocalDate.now(),
-      applicationRestriction = sessionRestriction,
-      visitContact = ContactDto("John Smith", "013448811538"),
-      visitors = setOf(VisitorDto(123, true), VisitorDto(124, false)),
-      visitorSupport = ApplicationSupportDto(support),
-      actionedBy = actionedBy,
-      userType = userType,
-      allowOverBooking = allowOverBooking,
-    )
   }
 
   @Test


### PR DESCRIPTION
Changes for VB-4200 - send username as a parameter to getAvailableSessions so that reserved applications by the user for the same prisoner are ignored.

## What does this pull request do?

Fix for VB-4200
## What is the intent behind these changes?

Bug fixes.