### PR TITLE
Changes for VB-4202 - send username as a parameter to getVisitSessions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
@@ -85,8 +85,13 @@ class VisitSessionController(
       example = "28",
     )
     max: Int?,
+    @Parameter(
+      description = "Username for the user making the request. Optional, ignored if not passed in.",
+      example = "user-1",
+    )
+    username: String? = null,
   ): List<VisitSessionDto> {
-    return sessionService.getVisitSessions(prisonCode, prisonerId, minOverride = min, maxOverride = max)
+    return sessionService.getVisitSessions(prisonCode, prisonerId, minOverride = min, maxOverride = max, usernameToExcludeFromReservedApplications = username)
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitSessionController.kt
@@ -86,7 +86,7 @@ class VisitSessionController(
     )
     max: Int?,
     @Parameter(
-      description = "Username for the user making the request. Optional, ignored if not passed in.",
+      description = "Username for the user making the request. Used to exclude user's pending applications from session capacity count. Optional, ignored if not passed in.",
       example = "user-1",
     )
     username: String? = null,
@@ -155,7 +155,7 @@ class VisitSessionController(
     excludedApplicationReference: String? = null,
     @RequestParam(value = "username", required = false)
     @Parameter(
-      description = "Username for the user making the request. Optional, ignored if not passed in.",
+      description = "Username for the user making the request. Used to exclude user's pending applications from session capacity count. Optional, ignored if not passed in.",
       example = "user-1",
     )
     username: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -62,11 +62,18 @@ class SessionService(
     currentApplicationReference: String? = null,
     minOverride: Int? = null,
     maxOverride: Int? = null,
+    usernameToExcludeFromReservedApplications: String? = null,
   ): List<VisitSessionDto> {
     val prison = prisonsService.findPrisonByCode(prisonCode)
     val dateRange = getDateRange(prison, minOverride, maxOverride)
 
-    return getVisitSessions(prison, prisonerId, dateRange, currentApplicationReference)
+    return getVisitSessions(
+      prison = prison,
+      prisonerId = prisonerId,
+      dateRange = dateRange,
+      excludedApplicationReference = currentApplicationReference,
+      usernameToExcludeFromReservedApplications = usernameToExcludeFromReservedApplications,
+    )
   }
 
   @Transactional(readOnly = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ApplicationEntityHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ApplicationEntityHelper.kt
@@ -64,6 +64,7 @@ class ApplicationEntityHelper(
     reservedSlot: Boolean = true,
     completed: Boolean = true,
     userType: UserType = STAFF,
+    createdBy: String = "",
   ): Application {
     val slotDateLocal = slotDate ?: run {
       sessionTemplate.validFromDate.with(sessionTemplate.dayOfWeek).plusWeeks(1)
@@ -81,7 +82,7 @@ class ApplicationEntityHelper(
         sessionSlot = sessionSlot,
         visitType = visitType,
         restriction = visitRestriction,
-        createdBy = "",
+        createdBy = createdBy,
         reservedSlot = reservedSlot,
         completed = completed,
         userType = userType,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsDoubleBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsDoubleBookingTest.kt
@@ -1,0 +1,169 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.integration.session
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.WebTestClient.BodyContentSpec
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionConflict
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.VisitSessionDto
+import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
+import java.time.LocalDate
+
+@DisplayName("Get /visit-sessions")
+class GetSessionsDoubleBookingTest : IntegrationTestBase() {
+
+  private val requiredRole = listOf("ROLE_VISIT_SCHEDULER")
+
+  private val prisonerId = "A0000001"
+
+  private val prisonCode = "STC"
+
+  private lateinit var sessionTemplate: SessionTemplate
+
+  private lateinit var visitDate: LocalDate
+
+  @BeforeEach
+  internal fun setUpTests() {
+    visitDate = getNextAllowedDay()
+    prison = prisonEntityHelper.create(prisonCode = prisonCode)
+    prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId, prisonCode)
+    sessionTemplate = sessionTemplateEntityHelper.create(
+      validFromDate = visitDate,
+      validToDate = visitDate,
+      dayOfWeek = visitDate.dayOfWeek,
+      prisonCode = prisonCode,
+    )
+  }
+
+  @Test
+  fun `visit sessions have double booking flagged when a visit already exists for a session slot`() {
+    // Given
+    this.visitEntityHelper.create(
+      prisonerId = prisonerId,
+      prisonCode = prisonCode,
+      visitRoom = sessionTemplate.visitRoom,
+      slotDate = visitDate,
+      visitStart = sessionTemplate.startTime,
+      visitEnd = sessionTemplate.endTime,
+      visitStatus = VisitStatus.BOOKED,
+      sessionTemplate = sessionTemplate,
+    )
+
+    // When
+    val responseSpec = callGetSessions(prisonCode, prisonerId)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val visitSessionResults = getResults(returnResult)
+    assertThat(visitSessionResults.size).isEqualTo(1)
+    assertThat(visitSessionResults[0].sessionConflicts.contains(SessionConflict.DOUBLE_BOOKING_OR_RESERVATION))
+  }
+
+  @Test
+  fun `visit sessions have double booking flagged when an application already exists for a session slot and username passed is null`() {
+    // Given
+    this.applicationEntityHelper.create(
+      prisonerId = prisonerId,
+      prisonCode = prisonCode,
+      slotDate = visitDate,
+      visitStart = sessionTemplate.startTime,
+      visitEnd = sessionTemplate.endTime,
+      sessionTemplate = sessionTemplate,
+      createdBy = "TEST-USER",
+    )
+
+    // When
+    val responseSpec = callGetSessions(prisonCode, prisonerId, username = null)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val visitSessionResults = getResults(returnResult)
+    assertThat(visitSessionResults.size).isEqualTo(1)
+    assertThat(visitSessionResults[0].sessionConflicts.contains(SessionConflict.DOUBLE_BOOKING_OR_RESERVATION))
+  }
+
+  @Test
+  fun `visit sessions have double booking flagged when an application created by a different user already exists for the same session slot`() {
+    // Given
+    val currentUser = "CURRENT-USER"
+
+    this.applicationEntityHelper.create(
+      prisonerId = prisonerId,
+      prisonCode = prisonCode,
+      slotDate = visitDate,
+      visitStart = sessionTemplate.startTime,
+      visitEnd = sessionTemplate.endTime,
+      sessionTemplate = sessionTemplate,
+      createdBy = "TEST-USER",
+    )
+
+    // When
+    val responseSpec = callGetSessions(prisonCode, prisonerId, username = currentUser)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val visitSessionResults = getResults(returnResult)
+    assertThat(visitSessionResults.size).isEqualTo(1)
+    assertThat(visitSessionResults[0].sessionConflicts.contains(SessionConflict.DOUBLE_BOOKING_OR_RESERVATION))
+  }
+
+  @Test
+  fun `no visit sessions have session conflicts when an application created by same user already exists for the same session slot`() {
+    // Given
+    val currentUser = "CURRENT-USER"
+
+    this.applicationEntityHelper.create(
+      prisonerId = prisonerId,
+      prisonCode = prisonCode,
+      slotDate = visitDate,
+      visitStart = sessionTemplate.startTime,
+      visitEnd = sessionTemplate.endTime,
+      sessionTemplate = sessionTemplate,
+      createdBy = currentUser,
+    )
+
+    // When
+    val responseSpec = callGetSessions(prisonCode, prisonerId, username = currentUser)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val visitSessionResults = getResults(returnResult)
+    assertThat(visitSessionResults.size).isEqualTo(1)
+    assertThat(visitSessionResults[0].sessionConflicts.isEmpty())
+  }
+
+  private fun callGetSessions(
+    prisonCode: String,
+    prisonerId: String,
+    policyNoticeDaysMin: Int = 2,
+    policyNoticeDaysMax: Int = 28,
+    username: String? = null,
+  ): ResponseSpec {
+    val uriQueryParams = mutableListOf(
+      "prisonId=$prisonCode",
+      "prisonerId=$prisonerId",
+      "min=$policyNoticeDaysMin",
+      "max=$policyNoticeDaysMax",
+    ).also { params ->
+      username?.let {
+        params.add("username=$username")
+      }
+    }.joinToString("&")
+
+    return webTestClient.get().uri("/visit-sessions?$uriQueryParams")
+      .headers(setAuthorisation(roles = requiredRole))
+      .exchange()
+  }
+
+  private fun getNextAllowedDay(): LocalDate {
+    return LocalDate.now().plusDays(3)
+  }
+
+  private fun getResults(returnResult: BodyContentSpec): Array<VisitSessionDto> {
+    return objectMapper.readValue(returnResult.returnResult().responseBody, Array<VisitSessionDto>::class.java)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsDoubleBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsDoubleBookingTest.kt
@@ -6,14 +6,14 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.WebTestClient.BodyContentSpec
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionConflict
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionConflict.DOUBLE_BOOKING_OR_RESERVATION
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.VisitSessionDto
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import java.time.LocalDate
 
-@DisplayName("Get /visit-sessions")
+@DisplayName("Get /visit-sessions - Tests to check for DOUBLE_BOOKING_OR_RESERVATION flag.")
 class GetSessionsDoubleBookingTest : IntegrationTestBase() {
 
   private val requiredRole = listOf("ROLE_VISIT_SCHEDULER")
@@ -60,7 +60,7 @@ class GetSessionsDoubleBookingTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk.expectBody()
     val visitSessionResults = getResults(returnResult)
     assertThat(visitSessionResults.size).isEqualTo(1)
-    assertThat(visitSessionResults[0].sessionConflicts.contains(SessionConflict.DOUBLE_BOOKING_OR_RESERVATION))
+    assertThat(visitSessionResults[0].sessionConflicts.contains(DOUBLE_BOOKING_OR_RESERVATION))
   }
 
   @Test
@@ -83,7 +83,7 @@ class GetSessionsDoubleBookingTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk.expectBody()
     val visitSessionResults = getResults(returnResult)
     assertThat(visitSessionResults.size).isEqualTo(1)
-    assertThat(visitSessionResults[0].sessionConflicts.contains(SessionConflict.DOUBLE_BOOKING_OR_RESERVATION))
+    assertThat(visitSessionResults[0].sessionConflicts.contains(DOUBLE_BOOKING_OR_RESERVATION))
   }
 
   @Test
@@ -108,7 +108,7 @@ class GetSessionsDoubleBookingTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk.expectBody()
     val visitSessionResults = getResults(returnResult)
     assertThat(visitSessionResults.size).isEqualTo(1)
-    assertThat(visitSessionResults[0].sessionConflicts.contains(SessionConflict.DOUBLE_BOOKING_OR_RESERVATION))
+    assertThat(visitSessionResults[0].sessionConflicts.contains(DOUBLE_BOOKING_OR_RESERVATION))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsWithExcludeLocationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsWithExcludeLocationsTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.location
 import java.time.LocalDate
 import java.time.LocalTime
 
-@DisplayName("Get /visit-sessions")
+@DisplayName("Get /visit-sessions - tests for exclude locations")
 class GetSessionsWithExcludeLocationsTest : IntegrationTestBase() {
   private val requiredRole = listOf("ROLE_VISIT_SCHEDULER")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsWithLocationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsWithLocationsTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.location
 import java.time.LocalDate
 import java.time.LocalTime
 
-@DisplayName("Get /visit-sessions")
+@DisplayName("Get /visit-sessions - tests for include locations")
 class GetSessionsWithLocationsTest : IntegrationTestBase() {
   private val requiredRole = listOf("ROLE_VISIT_SCHEDULER")
 


### PR DESCRIPTION
Changes for VB-4202 - send username as a parameter to getVisitSessions so that reserved applications by the STAFF user for the same prisoner are ignored.

## What does this pull request do?

Changes for VB-4202 - send username as a parameter to getVisitSession so that reserved applications by the STAFF user for the same prisoner are ignored.

## What is the intent behind these changes?

VB-4202