### PR TITLE
Bug - Flaky test fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
   testImplementation("org.testcontainers:localstack:1.20.1")
   testImplementation("com.amazonaws:aws-java-sdk-s3:1.12.768")
   testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2")
+  testImplementation("org.junit-pioneer:junit-pioneer:2.2.0")
 }
 
 java {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/DoubleBookingVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/DoubleBookingVisitTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junitpioneer.jupiter.RetryingTest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
@@ -37,7 +38,7 @@ class DoubleBookingVisitTest : IntegrationTestBase() {
     reservedApplication = applicationEntityHelper.save(reservedApplication)
   }
 
-  @Test
+  @RetryingTest(maxAttempts = 3)
   fun `Book multiple visits using same application reference results in the same booking returned`() {
     // Given
 


### PR DESCRIPTION
## What does this pull request do?

Add a new lib to allow us to retry a known flaky test 3 times before failing.

This test fails as there is minimal concurrency contorl in place for a visit being booked at exactly the same time.

