### PR TITLE
[BUG] - Get notification groups for PVI coming back with NPE

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/EventAuditRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/EventAuditRepository.kt
@@ -24,7 +24,7 @@ interface EventAuditRepository : JpaRepository<EventAudit, Long> {
 
   @Query(
     "SELECT ea.actionedBy FROM EventAudit ea " +
-      " WHERE ea.bookingReference = :bookingReference AND ea.type in (uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.UPDATED_VISIT,uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.BOOKED_VISIT) " +
+      " WHERE ea.bookingReference = :bookingReference AND ea.type in (uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.UPDATED_VISIT,uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.BOOKED_VISIT, EventAuditType.UPDATED_VISIT,uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.MIGRATED_VISIT) " +
       "ORDER BY ea.id DESC LIMIT 1 ",
   )
   fun getLastUserToUpdateBookingByReference(bookingReference: String): ActionedBy


### PR DESCRIPTION
## What does this pull request do?

When a visit is flagged, if it is a migrated visit, it will sometimes cause an error in production.

This is because the call to get notification groups has a result set of null during one of its calls to the database (which isn't allowed). This is due to the visit being a migrated visit and not having a BOOKED_VISIT event in the event audit table. It also hasn't been updated so it doesn't have an UPDATED_VISIT either.

## What is the intent behind these changes?

Adding MIGRATED_VISIT to the query to make sure it never comes back null.