### PR TITLE
When frequency of session template is more than 4 weeks it was causing a bug of not displaying the session template

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@
 #
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
+kotlin.incremental.useClasspathSnapshot=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@
 #
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
-kotlin.incremental.useClasspathSnapshot=false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -289,23 +289,23 @@ class SessionService(
     sessionDayOfWeek: DayOfWeek,
     sessionFrequency: Int,
   ): LocalDate {
-  // Step 1: Adjust the session start date to the correct day of the week.
-  val firstDayMatchingDate = adjustDateByDayOfWeek(sessionDayOfWeek, sessionStartDate)
+    // Step 1: Adjust the session start date to the correct day of the week.
+    val firstDayMatchingDate = adjustDateByDayOfWeek(sessionDayOfWeek, sessionStartDate)
 
-  // Step 2: Calculate the difference in days between this date and the bookable period start date.
-  val daysDifference = ChronoUnit.DAYS.between(firstDayMatchingDate, bookablePeriodStartDate)
+    // Step 2: Calculate the difference in days between this date and the bookable period start date.
+    val daysDifference = ChronoUnit.DAYS.between(firstDayMatchingDate, bookablePeriodStartDate)
 
-  // Step 3: Calculate the number of weeks to add to get the firstDayMatchingDate past the bookablePeriodStartDate.
-  // If daysDifference is positive, we calculate the number of weeks required.
-  // Else we're already on or past the bookablePeriodStartDate so don't add any weeks.
-  val weeksToAdd = if (daysDifference > 0) {
-    (daysDifference / (sessionFrequency * 7)) + if (daysDifference % (sessionFrequency * 7) > 0) 1 else 0
-  } else {
-    0
-  }
+    // Step 3: Calculate the number of weeks to add to get the firstDayMatchingDate past the bookablePeriodStartDate.
+    // If daysDifference is positive, we calculate the number of weeks required.
+    // Else we're already on or past the bookablePeriodStartDate so don't add any weeks.
+    val weeksToAdd = if (daysDifference > 0) {
+      (daysDifference / (sessionFrequency * 7)) + if (daysDifference % (sessionFrequency * 7) > 0) 1 else 0
+    } else {
+      0
+    }
 
-  // Step 4: Return the date after adding the correct number of intervals.
-  return firstDayMatchingDate.plusWeeks((weeksToAdd * sessionFrequency).toLong())
+    // Step 4: Return the date after adding the correct number of intervals.
+    return firstDayMatchingDate.plusWeeks((weeksToAdd * sessionFrequency))
   }
 
   private fun getLastBookableSession(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -289,23 +289,23 @@ class SessionService(
     sessionDayOfWeek: DayOfWeek,
     sessionFrequency: Int,
   ): LocalDate {
-    // Get the first matching session day in the future based on the sessionStartDate
-    val firstDayMatchingDate = adjustDateByDayOfWeek(sessionDayOfWeek, sessionStartDate)
+  // Step 1: Adjust the session start date to the correct day of the week.
+  val firstDayMatchingDate = adjustDateByDayOfWeek(sessionDayOfWeek, sessionStartDate)
 
-    // Calculate the difference in days between the first matching session day and the bookable period start date
-    val daysDifference = ChronoUnit.DAYS.between(firstDayMatchingDate, bookablePeriodStartDate)
+  // Step 2: Calculate the difference in days between this date and the bookable period start date.
+  val daysDifference = ChronoUnit.DAYS.between(firstDayMatchingDate, bookablePeriodStartDate)
 
-    // Calculate the number of weeks to add to get the firstDayMatchingDate past the bookablePeriodStartDate.
-    // If daysDifference is positive, we calculate the number of weeks required.
-    // Else we're already on or past the bookablePeriodStartDate so don't add any weeks.
-    val weeksToAdd = if (daysDifference > 0) {
-      (daysDifference + (sessionFrequency * 7) - 1) / (sessionFrequency * 7)
-    } else {
-      0
-    }
+  // Step 3: Calculate the number of weeks to add to get the firstDayMatchingDate past the bookablePeriodStartDate.
+  // If daysDifference is positive, we calculate the number of weeks required.
+  // Else we're already on or past the bookablePeriodStartDate so don't add any weeks.
+  val weeksToAdd = if (daysDifference > 0) {
+    (daysDifference / (sessionFrequency * 7)) + if (daysDifference % (sessionFrequency * 7) > 0) 1 else 0
+  } else {
+    0
+  }
 
-    // Return the first bookable session day, keeping it on the same day, that is on or after the bookablePeriodStartDate date.
-    return firstDayMatchingDate.plusWeeks(weeksToAdd * sessionFrequency)
+  // Step 4: Return the date after adding the correct number of intervals.
+  return firstDayMatchingDate.plusWeeks((weeksToAdd * sessionFrequency).toLong())
   }
 
   private fun getLastBookableSession(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -300,7 +300,9 @@ class SessionService(
     // Else we're already on or past the bookablePeriodStartDate so don't add any weeks.
     val weeksToAdd = if (daysDifference > 0) {
       (daysDifference + (sessionFrequency * 7) - 1) / (sessionFrequency * 7)
-    } else 0
+    } else {
+      0
+    }
 
     // Return the first bookable session day, keeping it on the same day, that is on or after the bookablePeriodStartDate date.
     return firstDayMatchingDate.plusWeeks(weeksToAdd * sessionFrequency)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -295,7 +295,7 @@ class SessionService(
     // Calculate the difference in days between the first matching session day and the bookable period start date
     val daysDifference = ChronoUnit.DAYS.between(firstDayMatchingDate, bookablePeriodStartDate)
 
-    // Calculate the number of weeks to add to get the firstDayMatchingDate paste the bookablePeriodStartDate.
+    // Calculate the number of weeks to add to get the firstDayMatchingDate past the bookablePeriodStartDate.
     // If daysDifference is positive, we calculate the number of weeks required.
     // Else we're already on or past the bookablePeriodStartDate so don't add any weeks.
     val weeksToAdd = if (daysDifference > 0) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -239,7 +239,7 @@ class SessionService(
     requestedBookableEndDate: LocalDate,
   ): List<VisitSessionDto> {
     val firstBookableSessionDay =
-      getFirstBookableSessionDay(requestedBookableStartDate, sessionTemplate.validFromDate, sessionTemplate.dayOfWeek)
+      getFirstBookableSessionDay(requestedBookableStartDate, sessionTemplate.validFromDate, sessionTemplate.dayOfWeek, sessionTemplate.weeklyFrequency)
     val lastBookableSessionDay = getLastBookableSession(requestedBookableEndDate, sessionTemplate.validToDate)
     val excludeDates = getExcludeDates(sessionTemplate.prison)
 
@@ -286,13 +286,15 @@ class SessionService(
     bookablePeriodStartDate: LocalDate,
     sessionStartDate: LocalDate,
     sessionDayOfWeek: DayOfWeek,
+    sessionFrequency: Int,
   ): LocalDate {
-    var firstBookableSessionDate = sessionStartDate
-    if (bookablePeriodStartDate.isAfter(firstBookableSessionDate)) {
-      firstBookableSessionDate = bookablePeriodStartDate
+    var firstDayMatchingDate = adjustDateByDayOfWeek(sessionDayOfWeek, sessionStartDate)
+
+    while (firstDayMatchingDate < bookablePeriodStartDate) {
+      firstDayMatchingDate = firstDayMatchingDate.plusWeeks(sessionFrequency.toLong())
     }
 
-    return adjustDateByDayOfWeek(sessionDayOfWeek, firstBookableSessionDate)
+    return firstDayMatchingDate
   }
 
   private fun getLastBookableSession(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtil.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtil.kt
@@ -20,12 +20,11 @@ class SessionDatesUtil {
   ): Stream<LocalDate> {
     val lastBookableSessionDayAdjusted = lastBookableSessionDay.plusDays(1)
 
-    val weeklyFirstBookableSessionDay = getFirstBookableSessionDayAdjustForFrequency(firstBookableSessionDay, sessionTemplate)
-    if (lastBookableSessionDayAdjusted.isBefore(weeklyFirstBookableSessionDay)) {
+    if (lastBookableSessionDayAdjusted.isBefore(firstBookableSessionDay)) {
       // There is no sessions because the first bookable date is after
       return Stream.empty()
     }
-    return weeklyFirstBookableSessionDay.datesUntil(
+    return firstBookableSessionDay.datesUntil(
       lastBookableSessionDayAdjusted,
       Period.ofWeeks(sessionTemplate.weeklyFrequency),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtilTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/utils/SessionDatesUtilTest.kt
@@ -98,7 +98,8 @@ class SessionDatesUtilTest {
     )
 
     // Then
-    assertThat(dates).hasSize(0)
+    assertThat(dates).hasSize(1)
+    assertThat(dates).contains(firstBookableSessionDay)
   }
 
   @Test
@@ -139,11 +140,12 @@ class SessionDatesUtilTest {
     )
 
     // Then
-    assertThat(dates).hasSize(4)
-    assertThat(dates[0]).isEqualTo(firstBookableSessionDay.plusWeeks(1))
+    assertThat(dates).hasSize(5)
+    assertThat(dates[0]).isEqualTo(firstBookableSessionDay)
     assertThat(dates[1]).isEqualTo(dates[0].plusWeeks(2))
     assertThat(dates[2]).isEqualTo(dates[1].plusWeeks(2))
     assertThat(dates[3]).isEqualTo(dates[2].plusWeeks(2))
+    assertThat(dates[4]).isEqualTo(dates[3].plusWeeks(2))
   }
 
   @Test
@@ -161,7 +163,8 @@ class SessionDatesUtilTest {
     )
 
     // Then
-    assertThat(dates).hasSize(0)
+    assertThat(dates).hasSize(1)
+    assertThat(dates).contains(firstBookableSessionDay)
   }
 
   @Test
@@ -180,7 +183,7 @@ class SessionDatesUtilTest {
 
     // Then
     assertThat(dates).hasSize(3)
-    assertThat(dates[0]).isEqualTo(firstBookableSessionDay.plusWeeks(2))
+    assertThat(dates[0]).isEqualTo(firstBookableSessionDay)
     assertThat(dates[1]).isEqualTo(dates[0].plusWeeks(3))
     assertThat(dates[2]).isEqualTo(dates[1].plusWeeks(3))
   }
@@ -200,15 +203,16 @@ class SessionDatesUtilTest {
     )
 
     // Then
-    assertThat(dates).hasSize(4)
-    assertThat(dates[0]).isEqualTo(firstBookableSessionDay.plusWeeks(1))
-    assertThat(dates[0].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
-    assertThat(dates[1]).isEqualTo(firstBookableSessionDay.plusWeeks(3))
+    assertThat(dates).hasSize(5)
+    assertThat(dates[0]).isEqualTo(firstBookableSessionDay)
+    assertThat(dates[1]).isEqualTo(firstBookableSessionDay.plusWeeks(2))
     assertThat(dates[1].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
-    assertThat(dates[2]).isEqualTo(firstBookableSessionDay.plusWeeks(5))
+    assertThat(dates[2]).isEqualTo(firstBookableSessionDay.plusWeeks(4))
     assertThat(dates[2].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
-    assertThat(dates[3]).isEqualTo(firstBookableSessionDay.plusWeeks(7))
+    assertThat(dates[3]).isEqualTo(firstBookableSessionDay.plusWeeks(6))
     assertThat(dates[3].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
+    assertThat(dates[4]).isEqualTo(firstBookableSessionDay.plusWeeks(8))
+    assertThat(dates[4].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
   }
 
   @Test
@@ -227,15 +231,16 @@ class SessionDatesUtilTest {
     )
 
     // Then
-    assertThat(dates).hasSize(4)
-    assertThat(dates[0]).isEqualTo(firstBookableSessionDay.plusWeeks(1))
-    assertThat(dates[0].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
-    assertThat(dates[1]).isEqualTo(firstBookableSessionDay.plusWeeks(3))
+    assertThat(dates).hasSize(5)
+    assertThat(dates[0]).isEqualTo(firstBookableSessionDay)
+    assertThat(dates[1]).isEqualTo(firstBookableSessionDay.plusWeeks(2))
     assertThat(dates[1].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
-    assertThat(dates[2]).isEqualTo(firstBookableSessionDay.plusWeeks(5))
+    assertThat(dates[2]).isEqualTo(firstBookableSessionDay.plusWeeks(4))
     assertThat(dates[2].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
-    assertThat(dates[3]).isEqualTo(firstBookableSessionDay.plusWeeks(7))
+    assertThat(dates[3]).isEqualTo(firstBookableSessionDay.plusWeeks(6))
     assertThat(dates[3].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
+    assertThat(dates[4]).isEqualTo(firstBookableSessionDay.plusWeeks(8))
+    assertThat(dates[4].dayOfWeek).isEqualTo(sessionTemplate.dayOfWeek)
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?
This was due to how we aligned the date with the closest day of the week matching the template and the booking window start date.

Rework the logic to first align the date and then loop through using the frequency to get first future date.

Currently this is a crude fix, we're looking into optimising as templates can be created many years ago and this wouldn't be suitable for those due to the while loop constantly checking.