### PR TITLE
Update PrisonExcludeDateDto to allow actionedBy as null 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/admin/PrisonAdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/admin/PrisonAdminController.kt
@@ -367,7 +367,8 @@ class PrisonAdminController(
     @Valid
     prisonExcludeDateDto: PrisonExcludeDateDto,
   ): PrisonDto {
-    return prisonConfigService.addExcludeDate(prisonCode, prisonExcludeDateDto.excludeDate, prisonExcludeDateDto.actionedBy)
+    // TODO - remove ?: "NOT_KNOWN" when we remove the admin functionality of adding exclude date
+    return prisonConfigService.addExcludeDate(prisonCode, prisonExcludeDateDto.excludeDate, prisonExcludeDateDto.actionedBy ?: "NOT_KNOWN")
   }
 
   @Deprecated("to be moved out of prison admin")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/admin/PrisonExcludeDatesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/admin/PrisonExcludeDatesController.kt
@@ -75,7 +75,12 @@ class PrisonExcludeDatesController(
     @Valid
     prisonExcludeDateDto: PrisonExcludeDateDto,
   ): Set<LocalDate> {
-    prisonConfigService.addExcludeDate(prisonCode, prisonExcludeDateDto.excludeDate, prisonExcludeDateDto.actionedBy)
+    prisonConfigService.addExcludeDate(
+      prisonCode,
+      prisonExcludeDateDto.excludeDate,
+      // TODO - remove !! later
+      actionedBy = prisonExcludeDateDto.actionedBy!!,
+    )
     return prisonsService.getPrison(prisonCode).excludeDates
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/PrisonExcludeDateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/PrisonExcludeDateDto.kt
@@ -12,6 +12,7 @@ data class PrisonExcludeDateDto(
   @FutureOrPresent
   val excludeDate: LocalDate,
 
+  // TODO - setting actionedBy as a nullable value for now to ensure the existing admin calls still work.
   @Schema(description = "actioned by", required = true)
-  val actionedBy: String,
+  val actionedBy: String? = "NOT_KNOWN",
 )


### PR DESCRIPTION
Update PrisonExcludeDateDto to allow actionedBy as null till we remove the admin functionality of adding and removing exclude dates.

## What does this pull request do?
Update PrisonExcludeDateDto to allow actionedBy to be null for the time being

## What is the intent behind these changes?

Backward compatibility with admin service.