### PR TITLE
VB-4513 Update telemetry event properties 

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,6 @@
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for Spring Framework path directory traversal as it only affects
+#   applications that use RouterFunctions and FileSystemResource locations
+CVE-2024-38816

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
@@ -228,7 +228,7 @@ class TelemetryClientService(
     val reportEvent = mutableMapOf<String, String>()
     with(overbookedSession) {
       reportEvent["sessionDate"] = formatDateToString(sessionDate)
-      reportEvent["prisonCode"] = prisonCode
+      reportEvent["prisonId"] = prisonCode
       reportEvent["sessionStart"] = formatTimeToString(sessionTimeSlot.startTime)
       reportEvent["sessionEnd"] = formatTimeToString(sessionTimeSlot.endTime)
       reportEvent["openCapacity"] = sessionCapacity.open.toString()
@@ -403,8 +403,8 @@ class TelemetryClientService(
     excludeDateDto: PrisonExcludeDateDto,
   ): Map<String, String> {
     val excludeDateEvent = mutableMapOf<String, String>()
-    excludeDateEvent["prison"] = prisonCode
-    excludeDateEvent["date"] = formatDateToString(excludeDateDto.excludeDate)
+    excludeDateEvent["prisonId"] = prisonCode
+    excludeDateEvent["excludedDate"] = formatDateToString(excludeDateDto.excludeDate)
 
     // TODO - remove the ?: "NOT_KNOWN" later
     excludeDateEvent["actionedBy"] = excludeDateDto.actionedBy ?: "NOT_KNOWN"


### PR DESCRIPTION

## What does this pull request do?

Update telemetry event properties replace prison and prisonCode with prisonId and date to excludedDate.
## What is the intent behind these changes?

Fix VB-4513