### PR TITLE
VB-4514 - Include additional information for visitor specific events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/NotificationGroupDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/NotificationGroupDto.kt
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 
 class NotificationGroupDto(
   @Schema(description = "notification group Reference", example = "v9*d7*ed*7u", required = true)
@@ -16,4 +17,11 @@ class NotificationGroupDto(
   @Schema(description = "List of details of affected visits", required = true)
   @field:NotEmpty
   val affectedVisits: List<PrisonerVisitsNotificationDto>,
+  @Schema(description = "Description of the flagged event", example = "Visitor with id <id> has had restriction <restriction> added", required = false)
+  @field:NotBlank
+  val description: String? = null,
+  @Schema(description = "For visitor specific events, the id of the affected visitor", example = "1234567L", required = false)
+  val visitorId: Long? = null,
+  @Schema(description = "For visitor specific events, the restriction type of the affected visitor", example = "BAN", required = false)
+  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/NotificationGroupDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/NotificationGroupDto.kt
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 
 class NotificationGroupDto(
   @Schema(description = "notification group Reference", example = "v9*d7*ed*7u", required = true)
@@ -17,11 +16,4 @@ class NotificationGroupDto(
   @Schema(description = "List of details of affected visits", required = true)
   @field:NotEmpty
   val affectedVisits: List<PrisonerVisitsNotificationDto>,
-  @Schema(description = "Description of the flagged event", example = "Visitor with id <id> has had restriction <restriction> added", required = false)
-  @field:NotBlank
-  val description: String? = null,
-  @Schema(description = "For visitor specific events, the id of the affected visitor", example = "1234567L", required = false)
-  val visitorId: Long? = null,
-  @Schema(description = "For visitor specific events, the restriction type of the affected visitor", example = "BAN", required = false)
-  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/PrisonerVisitsNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/PrisonerVisitsNotificationDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 import java.time.LocalDate
 
 class PrisonerVisitsNotificationDto(
@@ -16,4 +17,11 @@ class PrisonerVisitsNotificationDto(
   val visitDate: LocalDate,
   @Schema(description = "Visit Booking Reference", example = "v9-d7-ed-7u", required = true)
   val bookingReference: String,
+  @Schema(description = "Description of the flagged event", example = "Visitor with id <id> has had restriction <restriction> added", required = false)
+  @field:NotBlank
+  val description: String? = null,
+  @Schema(description = "For visitor specific events, the id of the affected visitor", example = "1234567L", required = false)
+  val visitorId: Long? = null,
+  @Schema(description = "For visitor specific events, the restriction type of the affected visitor", example = "BAN", required = false)
+  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/PrisonerVisitsNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/PrisonerVisitsNotificationDto.kt
@@ -20,7 +20,7 @@ class PrisonerVisitsNotificationDto(
   @Schema(description = "Description of the flagged event", example = "Visitor with id <id> has had restriction <restriction> added", required = false)
   @field:NotBlank
   val description: String? = null,
-  @Schema(description = "For visitor specific events, the id of the affected visitor", example = "1234567L", required = false)
+  @Schema(description = "For visitor specific events, the id of the affected visitor", example = "1234567", required = false)
   val visitorId: Long? = null,
   @Schema(description = "For visitor specific events, the restriction type of the affected visitor", example = "BAN", required = false)
   val visitorRestrictionType: VisitorSupportedRestrictionType? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/ProcessVisitNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/ProcessVisitNotificationDto.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
+
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
+
+data class ProcessVisitNotificationDto(
+  val affectedVisits: List<VisitDto>,
+  val type: NotificationEventType,
+  val description: String? = null,
+  val visitorId: Long? = null,
+  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/SaveVisitNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/SaveVisitNotificationDto.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
+
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
+
+data class SaveVisitNotificationDto(
+  val affectedVisits: List<VisitDto>,
+  val type: NotificationEventType,
+  val description: String? = null,
+  val visitorId: Long? = null,
+  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEvent.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.PostPersist
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.base.AbstractIdEntity
 import uk.gov.justice.digital.hmpps.visitscheduler.utils.QuotableEncoder
 import java.time.LocalDateTime
@@ -27,6 +28,13 @@ class VisitNotificationEvent(
 
   @Column(nullable = true)
   val description: String? = null,
+
+  @Column(nullable = true)
+  val visitorId: Long? = null,
+
+  @Column(nullable = true)
+  @Enumerated(EnumType.STRING)
+  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
 
   @Transient
   private val _reference: String = "",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -455,6 +455,9 @@ class VisitNotificationEventService(
         bookedByUserName = bookedByUserName,
         visitDate = visit.startTimestamp.toLocalDate(),
         bookingReference = it.bookingReference,
+        description = it.description,
+        visitorId = it.visitorId,
+        visitorRestrictionType = it.visitorRestrictionType,
       )
     }
   }

--- a/src/main/resources/db/migration/V3_29__add_visitorId_and_visitorRestrictionType_to_visit_notification_event_table.sql
+++ b/src/main/resources/db/migration/V3_29__add_visitorId_and_visitorRestrictionType_to_visit_notification_event_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE visit_notification_event
+    ADD visitor_id integer,
+    ADD visitor_restriction_type VARCHAR(40)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PersonRestrictionUpsertedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PersonRestrictionUpsertedNotificationControllerTest.kt
@@ -130,7 +130,11 @@ class PersonRestrictionUpsertedNotificationControllerTest : NotificationTestBase
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(2)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
+    assertThat(visitNotifications[0].visitorId.toString()).isEqualTo(visitorId)
+    assertThat(visitNotifications[0].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
+    assertThat(visitNotifications[1].visitorId.toString()).isEqualTo(visitorId)
+    assertThat(visitNotifications[1].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
 
     val auditEvents = testEventAuditRepository.getAuditByType(EventAuditType.PERSON_RESTRICTION_UPSERTED_EVENT)
     assertThat(auditEvents).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
@@ -130,7 +130,11 @@ class VisitorRestrictionUpsertedNotificationControllerTest : NotificationTestBas
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(2)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
+    assertThat(visitNotifications[0].visitorId.toString()).isEqualTo(visitorId)
+    assertThat(visitNotifications[0].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
+    assertThat(visitNotifications[1].visitorId.toString()).isEqualTo(visitorId)
+    assertThat(visitNotifications[1].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
 
     val auditEvents = testEventAuditRepository.getAuditByType(EventAuditType.VISITOR_RESTRICTION_UPSERTED_EVENT)
     assertThat(auditEvents).hasSize(2)


### PR DESCRIPTION
## What does this pull request do?

When an event type is for a visitor, capture the additional information from that event in the visit_notification_event table.

VisitorId - The ID of the visitor who has had an event raised about them VisitorRestrictionType - For the visitor, what restriction has been added

Update the NotificationGroupDto to include new fields, ready to be returned to the orchestration and frontend.


## JIRA Link

https://dsdmoj.atlassian.net/browse/VB-4514