### PR TITLE
Bug fix - Exclude reservations from the "Get single session" endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -159,7 +159,7 @@ class SessionService(
     }.also {
       addConflicts(it, nonAssociationConflictSessions, doubleBookingOrReservationSessions)
     }.also {
-      populateBookedCount(sessionSlots, it, excludedApplicationReference, usernameToExcludeFromReservedApplications)
+      populateBookedCount(sessionSlots, it, excludedApplicationReference, usernameToExcludeFromReservedApplications, true)
     }.sortedWith(compareBy { it.startTimestamp })
   }
 

--- a/src/main/resources/db.scripts.mvp/fix_NMI_session_part_2.sql
+++ b/src/main/resources/db.scripts.mvp/fix_NMI_session_part_2.sql
@@ -1,0 +1,11 @@
+-- Fix to update Nottingham NMI from old session template to new session template
+--| **new session** | **old session** | **day**              |
+--| --------------- | --------------- | -------------------- |
+--| kyy.coq.vwd     | jzy.hdv.mpd     | Monday PM            |
+
+BEGIN;
+SET SCHEMA 'public';
+
+UPDATE session_slot set session_template_reference = 'kyy.coq.vwd' where session_template_reference = 'jzy.hdv.mpd' and prison_id = (select id from prison where code = 'NMI');
+
+END;


### PR DESCRIPTION
## What does this pull request do?

The booked count will be used by frontend for displaying "Fully booked" session information. So we don't need to include reservations, only booked count.

## JIRA Link

https://dsdmoj.atlassian.net/browse/VB-4687