### PR TITLE
VB-4908 - Include event audit id in the HMPPS domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/SnsDomainEventPublishDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/SnsDomainEventPublishDto.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+@Schema(description = "Visit")
+data class SnsDomainEventPublishDto(
+  @Schema(description = "Visit Reference", example = "v9-d7-ed-7u", required = true)
+  val reference: String,
+  @Schema(description = "The visit created date and time", example = "2018-12-01T13:45:00", required = true)
+  @field:NotNull
+  val createdTimestamp: LocalDateTime,
+  @Schema(description = "The visit modified date and time", example = "2018-12-01T13:45:00", required = true)
+  @field:NotNull
+  val modifiedTimestamp: LocalDateTime,
+  @Schema(description = "Prisoner Id", example = "AF34567G", required = true)
+  val prisonerId: String,
+  @Schema(description = "Event audit id", example = "12345", required = true)
+  val eventAuditId: Long,
+
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/audit/EventAuditDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/audit/EventAuditDto.kt
@@ -13,6 +13,9 @@ import java.time.LocalDateTime
 @Schema(description = "Event Audit")
 class EventAuditDto(
 
+  @Schema(description = "The id of the event", required = true)
+  val id: Long,
+
   @Schema(description = "The type of event", required = true)
   @field:NotNull
   val type: EventAuditType,
@@ -38,6 +41,7 @@ class EventAuditDto(
   val createTimestamp: LocalDateTime = LocalDateTime.now(),
 ) {
   constructor(eventAuditEntity: EventAudit) : this(
+    id = eventAuditEntity.id,
     type = eventAuditEntity.type,
     applicationMethodType = eventAuditEntity.applicationMethodType,
     actionedBy = ActionedByDto(eventAuditEntity.actionedBy),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SnsService.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.SnsDomainEventPublishDto
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -48,7 +48,7 @@ class SnsService(
   fun LocalDateTime.toOffsetDateFormat(): String =
     atZone(ZoneId.of(EVENT_ZONE_ID)).toOffsetDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
-  fun sendVisitBookedEvent(visit: VisitDto) {
+  fun sendVisitBookedEvent(visit: SnsDomainEventPublishDto) {
     publishToDomainEventsTopic(
       HMPPSDomainEvent(
         eventType = EVENT_PRISON_VISIT_BOOKED,
@@ -58,12 +58,13 @@ class SnsService(
         prisonerId = visit.prisonerId,
         additionalInformation = AdditionalInformation(
           reference = visit.reference,
+          eventAuditId = visit.eventAuditId,
         ),
       ),
     )
   }
 
-  fun sendVisitCancelledEvent(visit: VisitDto) {
+  fun sendVisitCancelledEvent(visit: SnsDomainEventPublishDto) {
     publishToDomainEventsTopic(
       HMPPSDomainEvent(
         eventType = EVENT_PRISON_VISIT_CANCELLED,
@@ -73,6 +74,7 @@ class SnsService(
         prisonerId = visit.prisonerId,
         additionalInformation = AdditionalInformation(
           reference = visit.reference,
+          eventAuditId = visit.eventAuditId,
         ),
       ),
     )
@@ -109,7 +111,7 @@ class SnsService(
     }
   }
 
-  fun sendChangedVisitBookedEvent(visit: VisitDto) {
+  fun sendChangedVisitBookedEvent(visit: SnsDomainEventPublishDto) {
     publishToDomainEventsTopic(
       HMPPSDomainEvent(
         eventType = EVENT_PRISON_CHANGED_VISIT,
@@ -119,6 +121,7 @@ class SnsService(
         prisonerId = visit.prisonerId,
         additionalInformation = AdditionalInformation(
           reference = visit.reference,
+          eventAuditId = visit.eventAuditId,
         ),
       ),
     )
@@ -127,6 +130,7 @@ class SnsService(
 
 internal data class AdditionalInformation(
   val reference: String,
+  val eventAuditId: Long,
 )
 
 internal data class HMPPSDomainEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.BookingRequestDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.SnsDomainEventPublishDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.builder.VisitDtoBuilder
@@ -175,7 +176,14 @@ class VisitService(
 
     telemetryClientService.trackBookingEvent(bookingRequestDto, bookedVisitDto, bookingEventAuditDto)
 
-    snsService.sendVisitBookedEvent(bookedVisitDto)
+    val snsDomainEventPublishDto = SnsDomainEventPublishDto(
+      bookedVisitDto.reference,
+      bookedVisitDto.createdTimestamp,
+      bookedVisitDto.modifiedTimestamp,
+      bookedVisitDto.prisonerId,
+      bookingEventAuditDto.id,
+    )
+    snsService.sendVisitBookedEvent(snsDomainEventPublishDto)
 
     return bookedVisitDto
   }
@@ -188,7 +196,14 @@ class VisitService(
 
     telemetryClientService.trackUpdateBookingEvent(bookingRequestDto, bookedVisitDto, updatedEventAuditDto)
 
-    snsService.sendChangedVisitBookedEvent(bookedVisitDto)
+    val snsDomainEventPublishDto = SnsDomainEventPublishDto(
+      bookedVisitDto.reference,
+      bookedVisitDto.createdTimestamp,
+      bookedVisitDto.modifiedTimestamp,
+      bookedVisitDto.prisonerId,
+      updatedEventAuditDto.id,
+    )
+    snsService.sendChangedVisitBookedEvent(snsDomainEventPublishDto)
 
     return bookedVisitDto
   }
@@ -201,7 +216,14 @@ class VisitService(
 
     telemetryClientService.trackCancelBookingEvent(visitDto, cancelVisitDto, cancelledEventAuditDto)
 
-    snsService.sendVisitCancelledEvent(visitDto)
+    val snsDomainEventPublishDto = SnsDomainEventPublishDto(
+      visitDto.reference,
+      visitDto.createdTimestamp,
+      visitDto.modifiedTimestamp,
+      visitDto.prisonerId,
+      cancelledEventAuditDto.id,
+    )
+    snsService.sendVisitCancelledEvent(snsDomainEventPublishDto)
 
     // delete all visit notifications for the cancelled visit from the visit notifications table
     visitNotificationEventService.deleteVisitNotificationEvents(visitDto.reference, UnFlagEventReason.VISIT_CANCELLED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/events/SendDomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/events/SendDomainEventTest.kt
@@ -95,6 +95,7 @@ class SendDomainEventTest : IntegrationTestBase() {
       assertThat(ZonedDateTime.parse(occurredAt)).isEqualTo(visit.createdTimestamp.atZone(ZoneId.of(EVENT_ZONE_ID)))
       assertThat(prisonerId).isEqualTo(visit?.prisonerId)
       assertThat(additionalInformation.reference).isEqualTo(visit.reference)
+      assertThat(additionalInformation.eventAuditId).isNotNull()
 
       // And
       verify(telemetryClient).trackEvent(
@@ -159,6 +160,7 @@ class SendDomainEventTest : IntegrationTestBase() {
       assertThat(ZonedDateTime.parse(occurredAt)).isEqualTo(visit.modifiedTimestamp.atZone(ZoneId.of(EVENT_ZONE_ID)))
       assertThat(prisonerId).isEqualTo(visit.prisonerId)
       assertThat(additionalInformation.reference).isEqualTo(visit.reference)
+      assertThat(additionalInformation.eventAuditId).isNotNull()
 
       // And
       verify(telemetryClient).trackEvent(

--- a/visit-scheduler-event-specification.yaml
+++ b/visit-scheduler-event-specification.yaml
@@ -74,6 +74,9 @@ components:
         visitId:
           type: string
           description: Unique identifier for this visit
+        eventAuditId:
+          type: string
+          description: Unique identifier for event audit entry related to visit
         NOMISvisitId:
           type: string
           description: NOMIS's identifier for this visit


### PR DESCRIPTION
## What does this pull request do?

This id will be used by gov notify further down stream as a reference for each notification to tie it to an entry in the event_audit table.

## JIRA Ticket

https://dsdmoj.atlassian.net/browse/VB-4908