### PR TITLE
Remove old temporary _backup tables

### DIFF
--- a/src/main/resources/db/migration/V3_33__remove_outdated_backup_tables.sql
+++ b/src/main/resources/db/migration/V3_33__remove_outdated_backup_tables.sql
@@ -1,11 +1,5 @@
-BEGIN;
-
-SET SCHEMA 'public';
-
 DROP TABLE visit_backup;
 DROP TABLE visit_contact_backup;
 DROP TABLE visit_notes_backup;
 DROP TABLE visit_support_backup;
 DROP TABLE visit_visitors_backup;
-
-END;

--- a/src/main/resources/db/migration/V3_33__remove_outdated_backup_tables.sql
+++ b/src/main/resources/db/migration/V3_33__remove_outdated_backup_tables.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+SET SCHEMA 'public';
+
+DROP TABLE visit_backup;
+DROP TABLE visit_contact_backup;
+DROP TABLE visit_notes_backup;
+DROP TABLE visit_support_backup;
+DROP TABLE visit_visitors_backup;
+
+END;


### PR DESCRIPTION
## What does this pull request do?

These were added a long time ago when application tables were being introduced. They were intended to be temporary and dropped eventually. Finally cleaning these up.
