### PR TITLE
Status in VisitNotifyHistory not an Enumerated type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/VisitNotifyHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/VisitNotifyHistory.kt
@@ -38,6 +38,7 @@ class VisitNotifyHistory(
   @Column(name = "template_version", nullable = true)
   val templateVersion: String? = null,
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)
   val status: NotifyStatus,
 


### PR DESCRIPTION
## What does this pull request do?

add missing  @Enumerated(EnumType.STRING) to status in VisitNotifyHistory
## What is the intent behind these changes?
Bug fix