### PR TITLE
Update generic-prometheus-alerts.alertSeverity to visits-alerts

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -47,4 +47,4 @@ generic-service:
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  alertSeverity: visits-alerts


### PR DESCRIPTION
Update generic-prometheus-alerts.alertSeverity to visits-alerts to redirect prod alerts to visits Slack channel

## What does this pull request do?

Update generic-prometheus-alerts.alertSeverity to visits-alerts on prod

## What is the intent behind these changes?

redirect prod alerts to visits Slack channel