### PR TITLE
VB-4934 fix - Flag only future visits.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -203,6 +203,22 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
   ): List<Visit>
 
   @Query(
+    "SELECT v  FROM Visit v " +
+      "WHERE v.sessionSlot.slotStart >= :startDateTime AND " +
+      "v.prisonerId = :prisonerId AND " +
+      "(:#{#prisonCode} is null OR v.prison.code = :prisonCode) AND " +
+      "v.visitStatus = 'BOOKED' AND " +
+      "(cast(:endDateTime as date) is null OR v.sessionSlot.slotEnd < :endDateTime) " +
+      "ORDER BY v.sessionSlot.slotStart,v.id",
+  )
+  fun getBookedVisits(
+    @Param("prisonerId") prisonerId: String,
+    @Param("prisonCode") prisonCode: String?,
+    @Param("startDateTime") startDateTime: LocalDateTime,
+    @Param("endDateTime") endDateTime: LocalDateTime? = null,
+  ): List<Visit>
+
+  @Query(
     "SELECT v FROM Visit v " +
       "LEFT JOIN VisitVisitor vv ON v.id = vv.visitId " +
       "WHERE v.sessionSlot.slotStart >= :startDateTime AND " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -135,7 +135,7 @@ class VisitNotificationEventService(
   fun handlePrisonerReleasedNotification(notificationDto: PrisonerReleasedNotificationDto) {
     LOG.debug("PrisonerReleasedNotification notification received : {}", notificationDto)
     if (RELEASED == notificationDto.reasonType) {
-      val affectedVisits = visitService.getFutureVisitsBy(notificationDto.prisonerNumber, notificationDto.prisonCode)
+      val affectedVisits = visitService.getFutureBookedVisits(notificationDto.prisonerNumber, notificationDto.prisonCode)
       val processVisitNotificationDto = ProcessVisitNotificationDto(affectedVisits, PRISONER_RELEASED_EVENT, null, null, null)
       processVisitsWithNotifications(processVisitNotificationDto)
     }
@@ -149,7 +149,7 @@ class VisitNotificationEventService(
 
       val startDateTime = (if (LocalDate.now() > notificationDto.validFromDate) LocalDate.now() else notificationDto.validFromDate).atStartOfDay()
       val endDateTime = notificationDto.validToDate?.atTime(LocalTime.MAX)
-      val affectedVisits = visitService.getFutureVisitsBy(notificationDto.prisonerNumber, prisonCode, startDateTime, endDateTime)
+      val affectedVisits = visitService.getFutureBookedVisits(notificationDto.prisonerNumber, prisonCode, startDateTime, endDateTime)
 
       val processVisitNotificationDto = ProcessVisitNotificationDto(affectedVisits, PRISONER_RESTRICTION_CHANGE_EVENT, null, null, null)
 
@@ -176,7 +176,7 @@ class VisitNotificationEventService(
     LOG.debug("Entered handlePrisonerAlertCreatedUpdated processAlertsAdded")
 
     val prisonCode = prisonerService.getPrisonerPrisonCode(notificationDto.prisonerNumber)
-    val affectedVisits = visitService.getFutureVisitsBy(notificationDto.prisonerNumber, prisonCode)
+    val affectedVisits = visitService.getFutureBookedVisits(notificationDto.prisonerNumber, prisonCode)
 
     val processVisitNotificationDto = ProcessVisitNotificationDto(affectedVisits, PRISONER_ALERTS_UPDATED_EVENT, notificationDto.description, null, null)
     processVisitsWithNotifications(processVisitNotificationDto)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitService.kt
@@ -271,7 +271,7 @@ class VisitService(
     return eventAuditService.findByBookingReferenceOrderById(bookingReference)
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun getFutureVisitsBy(
     prisonerNumber: String,
     prisonCode: String? = null,
@@ -279,6 +279,16 @@ class VisitService(
     endDateTime: LocalDateTime? = null,
   ): List<VisitDto> {
     return visitRepository.getVisits(prisonerNumber, prisonCode, startDateTime, endDateTime).map { visitDtoBuilder.build(it) }
+  }
+
+  @Transactional(readOnly = true)
+  fun getFutureBookedVisits(
+    prisonerNumber: String,
+    prisonCode: String? = null,
+    startDateTime: LocalDateTime = LocalDateTime.now(),
+    endDateTime: LocalDateTime? = null,
+  ): List<VisitDto> {
+    return visitRepository.getBookedVisits(prisonerNumber, prisonCode, startDateTime, endDateTime).map { visitDtoBuilder.build(it) }
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertCreatedUpdatedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertCreatedUpdatedVisitNotificationControllerTest.kt
@@ -88,6 +88,14 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
       sessionTemplate = sessionTemplate1,
     )
 
+    // cancelled visit -should not be flagged
+    createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = CANCELLED,
+      sessionTemplate = sessionTemplate1,
+    )
+
     // When
     val responseSpec = callNotifyVSiPThatPrisonerAlertHasBeenCreatedOrUpdated(
       webTestClient,
@@ -156,6 +164,14 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
     )
     eventAuditEntityHelper.create(visit3)
 
+    // cancelled visit -should not be flagged
+    createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = CANCELLED,
+      sessionTemplate = sessionTemplate1,
+    )
+
     // When
     val responseSpec = callNotifyVSiPThatPrisonerAlertHasBeenCreatedOrUpdated(
       webTestClient,
@@ -210,6 +226,14 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
       sessionTemplate = sessionTemplateDefault,
     )
     eventAuditEntityHelper.create(visit2)
+
+    // cancelled visit -should not be flagged
+    createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = CANCELLED,
+      sessionTemplate = sessionTemplate1,
+    )
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerAlertHasBeenCreatedOrUpdated(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
@@ -50,7 +50,7 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
   }
 
   @Test
-  fun `when prisoner has been released from prison then only valid visits are flagged and saved`() {
+  fun `when prisoner has been released from prison then only valid booked visits are flagged and saved`() {
     // Given
     val notificationDto = PrisonerReleasedNotificationDto(prisonerId, prisonCode, RELEASED)
 
@@ -80,6 +80,14 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
       prisonerId = "ANOTHERPRISONER",
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+
+    // cancelled visit - should not be flagged
+    createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -137,6 +145,14 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
       sessionTemplate = sessionTemplate1,
     )
     eventAuditEntityHelper.create(visit3)
+
+    // cancelled visit - should not be flagged
+    createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(3),
+      visitStatus = CANCELLED,
+      sessionTemplate = sessionTemplate1,
+    )
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerHadBeenReleased(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerVisitRestrictionChangeNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerVisitRestrictionChangeNotificationControllerTest.kt
@@ -80,6 +80,14 @@ class PrisonerVisitRestrictionChangeNotificationControllerTest : NotificationTes
       sessionTemplate = sessionTemplate1,
     )
 
+    // cancelled visit -should not be flagged
+    createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = CANCELLED,
+      sessionTemplate = sessionTemplate1,
+    )
+
     // When
     val responseSpec = callNotifyVSiPThatPrisonerRestrictionHasChanged(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)
 
@@ -135,6 +143,14 @@ class PrisonerVisitRestrictionChangeNotificationControllerTest : NotificationTes
       sessionTemplate = sessionTemplate1,
     )
     eventAuditEntityHelper.create(visit3)
+
+    // cancelled visit -should not be flagged
+    createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = CANCELLED,
+      sessionTemplate = sessionTemplate1,
+    )
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerRestrictionHasChanged(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)


### PR DESCRIPTION
## What does this pull request do?

VB-4934 fix - Replace getFutureVisitsBy with getFutureBookedVisits on VisitNotificationEventService to ensure only BOOKED visits are flagged.

## What is the intent behind these changes?

VB-4934 fix