### PR TITLE
VB-4918 fix - update past visits and future visits criteria

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -324,7 +324,7 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
       " INNER JOIN actioned_by ab on ab.id = ea.actioned_by_id" +
       " INNER JOIN session_slot ss on ss.id = v.session_slot_id " +
       " WHERE ab.booker_reference = :bookerReference " +
-      " AND v.visit_status = 'BOOKED' AND ss.slot_date >= CURRENT_DATE AND v.user_type = 'PUBLIC'",
+      " AND v.visit_status = 'BOOKED' AND ss.slot_start >= CURRENT_TIMESTAMP AND v.user_type = 'PUBLIC'",
     nativeQuery = true,
   )
   fun getPublicFutureBookingsByBookerReference(bookerReference: String): List<Visit>
@@ -335,7 +335,7 @@ interface VisitRepository : JpaRepository<Visit, Long>, JpaSpecificationExecutor
       " INNER JOIN actioned_by ab on ab.id = ea.actioned_by_id" +
       " INNER JOIN session_slot ss on ss.id = v.session_slot_id " +
       " WHERE ab.booker_reference = :bookerReference " +
-      " AND v.visit_status = 'BOOKED' AND ss.slot_date < CURRENT_DATE AND v.user_type = 'PUBLIC'",
+      " AND v.visit_status = 'BOOKED' AND ss.slot_start < CURRENT_TIMESTAMP AND v.user_type = 'PUBLIC'",
     nativeQuery = true,
   )
   fun getPublicPastBookingsByBookerReference(bookerReference: String): List<Visit>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -376,7 +376,7 @@ abstract class IntegrationTestBase {
   }
 
   fun createVisit(
-    prisonId: String? = "testPrisonerId",
+    prisonerId: String? = "testPrisonerId",
     actionedByValue: String,
     visitStatus: VisitStatus,
     sessionTemplate: SessionTemplate,
@@ -388,7 +388,7 @@ abstract class IntegrationTestBase {
     val userTypes = mutableListOf(userType, userType)
 
     var visit = createApplicationAndVisit(
-      prisonerId = prisonId,
+      prisonerId = prisonerId,
       slotDate = LocalDate.now().plusWeeks(slotDateWeeks),
       sessionTemplate = sessionTemplate,
       visitStatus = visitStatus,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FindCancelledPublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FindCancelledPublicVisitsTest.kt
@@ -43,19 +43,19 @@ class FindCancelledPublicVisitsTest : IntegrationTestBase() {
   internal fun createVisits() {
     otherSessionTemplate = sessionTemplateEntityHelper.create(prisonCode = "AWE")
 
-    visitCancelledLeastRecent = createVisit(prisonId = "least recent", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 4)
+    visitCancelledLeastRecent = createVisit(prisonerId = "least recent", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 4)
 
-    visitCancelledInDifferentPrison = createVisit(prisonId = "diff prison", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = otherSessionTemplate, PUBLIC, slotDateWeeks = 3)
+    visitCancelledInDifferentPrison = createVisit(prisonerId = "diff prison", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = otherSessionTemplate, PUBLIC, slotDateWeeks = 3)
 
-    visitWithOtherBooker = createVisit(prisonId = "diff prison", actionedByValue = "aOtherTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 2)
+    visitWithOtherBooker = createVisit(prisonerId = "diff prison", actionedByValue = "aOtherTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 2)
 
-    visitCancelledInPast = createVisit(prisonId = "in past", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = -1)
+    visitCancelledInPast = createVisit(prisonerId = "in past", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = -1)
 
     createVisit(actionedByValue = "aTestRef", visitStatus = BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
 
     createVisit(actionedByValue = "aTestRef", visitStatus = BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = -1)
 
-    visitCancelledMostRecent = createVisit(prisonId = "most recent", actionedByValue = "aTestRef", CANCELLED, sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
+    visitCancelledMostRecent = createVisit(prisonerId = "most recent", actionedByValue = "aTestRef", CANCELLED, sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/PastPublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/PastPublicVisitsTest.kt
@@ -11,7 +11,7 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_FUTURE_BOOKED_PUBLIC_VISITS_BY_BOOKER_REFERENCE
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_PAST_BOOKED_PUBLIC_VISITS_BY_BOOKER_REFERENCE
@@ -22,6 +22,8 @@ import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitAssertHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
+import java.time.LocalDate
+import java.time.LocalTime
 
 @DisplayName("GET $GET_FUTURE_BOOKED_PUBLIC_VISITS_BY_BOOKER_REFERENCE")
 class PastPublicVisitsTest : IntegrationTestBase() {
@@ -29,37 +31,51 @@ class PastPublicVisitsTest : IntegrationTestBase() {
   @Autowired
   private lateinit var visitAssertHelper: VisitAssertHelper
 
-  @SpyBean
+  @MockitoSpyBean
   private lateinit var telemetryClient: TelemetryClient
+
+  private lateinit var sessionTemplate1: SessionTemplate
+  private lateinit var sessionTemplate2: SessionTemplate
 
   private lateinit var otherSessionTemplate: SessionTemplate
 
   private lateinit var visitFarInThePast: Visit
-  private lateinit var nearestPastVisit: Visit
+  private lateinit var nearestPastVisitBeforeToday: Visit
   private lateinit var visitInDifferentPrison: Visit
   private lateinit var visitWithOtherBooker: Visit
+  private lateinit var pastVisitToday: Visit
+  private lateinit var futureVisitToday: Visit
 
   private val defaultBookerReference: String = "aTestRef"
 
   @BeforeEach
   internal fun createVisits() {
+    // session template that has a start time 5 minutes in the future
+    sessionTemplate1 = sessionTemplateEntityHelper.create(prisonCode = "DFT", startTime = LocalTime.now().plusMinutes(5), endTime = LocalTime.now().plusHours(1), dayOfWeek = LocalDate.now().dayOfWeek)
+    // session template that has started 1 minute back
+    sessionTemplate2 = sessionTemplateEntityHelper.create(prisonCode = "DFT", startTime = LocalTime.now().minusMinutes(1), endTime = LocalTime.now().plusHours(1), dayOfWeek = LocalDate.now().dayOfWeek)
+
+    // session template that has a start time 5 minutes in the future
     otherSessionTemplate = sessionTemplateEntityHelper.create(prisonCode = "AWE")
 
-    visitFarInThePast = createVisit(prisonId = "visit far in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = -6)
+    visitFarInThePast = createVisit(prisonerId = "visit far in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -6)
 
-    visitInDifferentPrison = createVisit(prisonId = "visit different prison", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = otherSessionTemplate, userType = PUBLIC, slotDateWeeks = -4)
+    visitInDifferentPrison = createVisit(prisonerId = "visit different prison", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -4)
 
-    nearestPastVisit = createVisit(prisonId = "nearest visit in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = -1)
+    nearestPastVisitBeforeToday = createVisit(prisonerId = "nearest visit in past before today", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
 
-    val visitToday = createVisit(prisonId = "nearest visit in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 0)
+    // this visit is for a session template that started 1 minute back
+    pastVisitToday = createVisit(prisonerId = "today's visit in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate2, userType = PUBLIC, slotDateWeeks = 0)
+    // this visit is for a session template that started 5 minutes after
+    futureVisitToday = createVisit(prisonerId = "today's visit in future", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 0)
 
-    var visitInFuture = createVisit(prisonId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
+    var visitInFuture = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 1)
 
-    var visitBookerByStaff = createVisit(prisonId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplateDefault, userType = STAFF, slotDateWeeks = -1)
+    var visitBookerByStaff = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = STAFF, slotDateWeeks = -1)
 
-    var visitCancelled = createVisit(prisonId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.CANCELLED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = -1)
+    var visitCancelled = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.CANCELLED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
 
-    visitWithOtherBooker = createVisit(prisonId = "visit with other broker", actionedByValue = "aOtherTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = -2)
+    visitWithOtherBooker = createVisit(prisonerId = "visit with other broker", actionedByValue = "aOtherTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -2)
   }
 
   @Test
@@ -74,10 +90,11 @@ class PastPublicVisitsTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
     val visitList = parseVisitsResponse(responseSpec)
 
-    Assertions.assertThat(visitList.size).isEqualTo(3)
-    visitAssertHelper.assertVisitDto(visitList[0], nearestPastVisit)
-    visitAssertHelper.assertVisitDto(visitList[1], visitInDifferentPrison)
-    visitAssertHelper.assertVisitDto(visitList[2], visitFarInThePast)
+    Assertions.assertThat(visitList.size).isEqualTo(4)
+    visitAssertHelper.assertVisitDto(visitList[0], pastVisitToday)
+    visitAssertHelper.assertVisitDto(visitList[1], nearestPastVisitBeforeToday)
+    visitAssertHelper.assertVisitDto(visitList[2], visitInDifferentPrison)
+    visitAssertHelper.assertVisitDto(visitList[3], visitFarInThePast)
   }
 
   @Test
@@ -112,7 +129,7 @@ class PastPublicVisitsTest : IntegrationTestBase() {
   @Test
   fun `access forbidden when unknown role`() {
     // Given
-    val noRoles = listOf<String>("SOME_OTHER_ROLE_VISIT_SCHEDULER")
+    val noRoles = listOf("SOME_OTHER_ROLE_VISIT_SCHEDULER")
 
     // When
     val responseSpec = callPublicPastVisitsEndPoint(bookerReference = "aTestRole", roles = noRoles)


### PR DESCRIPTION
## What does this pull request do?
VB-4918 fix - update past visits as before current date and time and future visits as after current date and time

## What is the intent behind these changes?
VB-4918 fix