### PR TITLE
VB-4411 - Feature - Visit booking details page rework

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/NotificationEventAttributeType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/NotificationEventAttributeType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.enums
+
+enum class NotificationEventAttributeType() {
+  VISITOR_RESTRICTION,
+  VISITOR_ID,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/PrisonerVisitsNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/PrisonerVisitsNotificationDto.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.ActionedByDto
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 import java.time.LocalDate
 
 class PrisonerVisitsNotificationDto(
@@ -18,11 +17,6 @@ class PrisonerVisitsNotificationDto(
   val visitDate: LocalDate,
   @Schema(description = "Visit Booking Reference", example = "v9-d7-ed-7u", required = true)
   val bookingReference: String,
-  @Schema(description = "Description of the flagged event", example = "Visitor with id <id> has had restriction <restriction> added", required = false)
-  @field:NotBlank
-  val description: String? = null,
-  @Schema(description = "For visitor specific events, the id of the affected visitor", example = "1234567", required = false)
-  val visitorId: Long? = null,
-  @Schema(description = "For visitor specific events, the restriction type of the affected visitor", example = "BAN", required = false)
-  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
+  @Schema(description = "A list of all notification attributes for a given visit", required = true)
+  val notificationEventAttributes: List<VisitNotificationEventAttributeDto>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/ProcessVisitNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/ProcessVisitNotificationDto.kt
@@ -1,13 +1,11 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
 
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAttributeType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 
 data class ProcessVisitNotificationDto(
   val affectedVisits: List<VisitDto>,
   val type: NotificationEventType,
-  val description: String? = null,
-  val visitorId: Long? = null,
-  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
+  val notificationEventAttributes: HashMap<NotificationEventAttributeType, String>?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/SaveVisitNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/SaveVisitNotificationDto.kt
@@ -1,13 +1,11 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
 
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAttributeType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 
 data class SaveVisitNotificationDto(
   val affectedVisits: List<VisitDto>,
   val type: NotificationEventType,
-  val description: String? = null,
-  val visitorId: Long? = null,
-  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
+  val notificationEventAttributes: HashMap<NotificationEventAttributeType, String>?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/VisitNotificationEventAttributeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/VisitNotificationEventAttributeDto.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAttributeType
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.notification.VisitNotificationEventAttribute
+
+class VisitNotificationEventAttributeDto(
+  @Schema(description = "Name of the attribute associated with the notification event", example = "VISITOR_RESTRICTION", required = true)
+  @field:NotNull
+  val attributeName: NotificationEventAttributeType,
+
+  @Schema(description = "Value of the attribute associated with the notification event", example = "BAN", required = true)
+  @field:NotNull
+  val attributeValue: String,
+) {
+  constructor(visitNotificationEventAttribute: VisitNotificationEventAttribute) : this (
+    attributeName = visitNotificationEventAttribute.attributeName,
+    attributeValue = visitNotificationEventAttribute.attributeValue,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEvent.kt
@@ -40,7 +40,6 @@ class VisitNotificationEvent(
   private val _reference: String = "",
 
 ) : AbstractIdEntity() {
-
   @CreationTimestamp
   @Column
   val createTimestamp: LocalDateTime = LocalDateTime.now()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEvent.kt
@@ -1,14 +1,16 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.model.entity.notification
 
+import jakarta.persistence.CascadeType.ALL
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.OneToMany
 import jakarta.persistence.PostPersist
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.base.AbstractIdEntity
 import uk.gov.justice.digital.hmpps.visitscheduler.utils.QuotableEncoder
 import java.time.LocalDateTime
@@ -18,23 +20,12 @@ import java.time.LocalDateTime
   name = "visit_notification_event",
 )
 class VisitNotificationEvent(
-
   @Column(name = "booking_reference", unique = false, nullable = false)
   var bookingReference: String,
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   val type: NotificationEventType,
-
-  @Column(nullable = true)
-  val description: String? = null,
-
-  @Column(nullable = true)
-  val visitorId: Long? = null,
-
-  @Column(nullable = true)
-  @Enumerated(EnumType.STRING)
-  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
 
   @Transient
   private val _reference: String = "",
@@ -46,6 +37,9 @@ class VisitNotificationEvent(
 
   @Column(nullable = false)
   var reference = _reference
+
+  @OneToMany(fetch = FetchType.EAGER, cascade = [ALL], mappedBy = "visitNotificationEvent", orphanRemoval = true)
+  val visitNotificationEventAttributes: MutableList<VisitNotificationEventAttribute> = mutableListOf()
 
   @PostPersist
   fun createReference() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEventAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/notification/VisitNotificationEventAttribute.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.model.entity.notification
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAttributeType
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.base.AbstractIdEntity
+
+@Entity
+@Table(
+  name = "visit_notification_event_attribute",
+)
+class VisitNotificationEventAttribute(
+  @Column(name = "visit_notification_event_id", unique = false, nullable = false)
+  val visitNotificationEventId: Long,
+
+  @Column(name = "attribute_name", nullable = false)
+  @Enumerated(EnumType.STRING)
+  val attributeName: NotificationEventAttributeType,
+
+  @Column(name = "attribute_value", nullable = false)
+  val attributeValue: String,
+
+  @ManyToOne
+  @JoinColumn(name = "visit_notification_event_id", updatable = false, insertable = false)
+  val visitNotificationEvent: VisitNotificationEvent,
+) : AbstractIdEntity()

--- a/src/main/resources/db/migration/V3_36__visit_notification_event_rework_new_attribute_table.sql
+++ b/src/main/resources/db/migration/V3_36__visit_notification_event_rework_new_attribute_table.sql
@@ -1,0 +1,17 @@
+-- V3_36__visit_notification_event_rework_new_attribute_table.sql
+
+-- Step 1: Create the new table visit_notification_event_attribute
+CREATE TABLE visit_notification_event_attribute (
+    id                          SERIAL                   NOT NULL PRIMARY KEY,
+    visit_notification_event_id INTEGER                  NOT NULL,
+    attribute_name              VARCHAR(80)              NOT NULL,
+    attribute_value             TEXT                     NOT NULL,
+    CONSTRAINT fk_visit_notification_event FOREIGN KEY (visit_notification_event_id)
+    REFERENCES visit_notification_event (id) ON DELETE CASCADE
+);
+
+-- Step 2: Remove columns from visit_notification_event
+ALTER TABLE visit_notification_event
+    DROP COLUMN description,
+    DROP COLUMN visitor_id,
+    DROP COLUMN visitor_restriction_type;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PersonRestrictionUpsertedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PersonRestrictionUpsertedNotificationControllerTest.kt
@@ -130,11 +130,9 @@ class PersonRestrictionUpsertedNotificationControllerTest : NotificationTestBase
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(2)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
-    assertThat(visitNotifications[0].visitorId.toString()).isEqualTo(visitorId)
-    assertThat(visitNotifications[0].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(2)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
-    assertThat(visitNotifications[1].visitorId.toString()).isEqualTo(visitorId)
-    assertThat(visitNotifications[1].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes.size).isEqualTo(2)
 
     val auditEvents = testEventAuditRepository.getAuditByType(EventAuditType.PERSON_RESTRICTION_UPSERTED_EVENT)
     assertThat(auditEvents).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertCreatedUpdatedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertCreatedUpdatedVisitNotificationControllerTest.kt
@@ -112,7 +112,6 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(1)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
-    assertThat(visitNotifications[0].description).isEqualTo(description)
 
     val auditEvents = testEventAuditRepository.getAuditByType(PRISONER_ALERTS_UPDATED_EVENT)
     assertThat(auditEvents).hasSize(1)
@@ -188,12 +187,13 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
     val visitNotifications = testVisitNotificationEventRepository.getFutureVisitNotificationEvents(prisonCode)
     assertThat(visitNotifications).hasSize(3)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[0].reference).doesNotContain(visitNotifications[1].reference, visitNotifications[2].reference)
-    assertThat(visitNotifications[0].description).isEqualTo(description)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
-    assertThat(visitNotifications[1].description).isEqualTo(description)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[1].reference).doesNotContain(visitNotifications[0].reference, visitNotifications[2].reference)
     assertThat(visitNotifications[2].bookingReference).isEqualTo(visit3.reference)
+    assertThat(visitNotifications[2].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[2].reference).doesNotContain(visitNotifications[0].reference, visitNotifications[1].reference)
     assertThat(testEventAuditRepository.getAuditCount(PRISONER_ALERTS_UPDATED_EVENT)).isEqualTo(3)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReceivedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReceivedVisitNotificationControllerTest.kt
@@ -122,7 +122,9 @@ class PrisonerReceivedVisitNotificationControllerTest : NotificationTestBase() {
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(2)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes.size).isEqualTo(0)
 
     val auditEvents = testEventAuditRepository.getAuditByType(PRISONER_RECEIVED_EVENT)
     assertThat(auditEvents).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
@@ -167,10 +167,13 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
     assertThat(visitNotifications).hasSize(3)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
     assertThat(visitNotifications[0].reference).doesNotContain(visitNotifications[1].reference, visitNotifications[2].reference)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
     assertThat(visitNotifications[1].reference).doesNotContain(visitNotifications[0].reference, visitNotifications[2].reference)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[2].bookingReference).isEqualTo(visit3.reference)
     assertThat(visitNotifications[2].reference).doesNotContain(visitNotifications[0].reference, visitNotifications[1].reference)
+    assertThat(visitNotifications[2].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(testEventAuditRepository.getAuditCount(PRISONER_RELEASED_EVENT)).isEqualTo(3)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerVisitRestrictionChangeNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerVisitRestrictionChangeNotificationControllerTest.kt
@@ -165,10 +165,13 @@ class PrisonerVisitRestrictionChangeNotificationControllerTest : NotificationTes
     assertThat(visitNotifications).hasSize(3)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
     assertThat(visitNotifications[0].reference).doesNotContain(visitNotifications[1].reference, visitNotifications[2].reference)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
     assertThat(visitNotifications[1].reference).doesNotContain(visitNotifications[0].reference, visitNotifications[2].reference)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(visitNotifications[2].bookingReference).isEqualTo(visit3.reference)
     assertThat(visitNotifications[2].reference).doesNotContain(visitNotifications[0].reference, visitNotifications[1].reference)
+    assertThat(visitNotifications[2].visitNotificationEventAttributes.size).isEqualTo(0)
     assertThat(testEventAuditRepository.getAuditCount(PRISONER_RESTRICTION_CHANGE_EVENT)).isEqualTo(3)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_VISITOR_RESTRICTION_UPSERTED_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType.NOT_KNOWN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAttributeType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
@@ -130,11 +131,17 @@ class VisitorRestrictionUpsertedNotificationControllerTest : NotificationTestBas
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(2)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
-    assertThat(visitNotifications[0].visitorId.toString()).isEqualTo(visitorId)
-    assertThat(visitNotifications[0].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(2)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes[0].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_RESTRICTION)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes[0].attributeValue).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes[1].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_ID)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes[1].attributeValue).isEqualTo(visitorId)
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
-    assertThat(visitNotifications[1].visitorId.toString()).isEqualTo(visitorId)
-    assertThat(visitNotifications[1].visitorRestrictionType.toString()).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes.size).isEqualTo(2)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes[0].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_RESTRICTION)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes[0].attributeValue).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes[1].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_ID)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes[1].attributeValue).isEqualTo(visitorId)
 
     val auditEvents = testEventAuditRepository.getAuditByType(EventAuditType.VISITOR_RESTRICTION_UPSERTED_EVENT)
     assertThat(auditEvents).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit.notifications
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -132,16 +133,21 @@ class VisitorRestrictionUpsertedNotificationControllerTest : NotificationTestBas
     assertThat(visitNotifications).hasSize(2)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
     assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(2)
-    assertThat(visitNotifications[0].visitNotificationEventAttributes[0].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_RESTRICTION)
-    assertThat(visitNotifications[0].visitNotificationEventAttributes[0].attributeValue).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
-    assertThat(visitNotifications[0].visitNotificationEventAttributes[1].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_ID)
-    assertThat(visitNotifications[0].visitNotificationEventAttributes[1].attributeValue).isEqualTo(visitorId)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes)
+      .extracting({ it.attributeName }, { it.attributeValue })
+      .containsExactlyInAnyOrder(
+        tuple(NotificationEventAttributeType.VISITOR_RESTRICTION, VisitorSupportedRestrictionType.BAN.name),
+        tuple(NotificationEventAttributeType.VISITOR_ID, visitorId),
+      )
+
     assertThat(visitNotifications[1].bookingReference).isEqualTo(visit2.reference)
     assertThat(visitNotifications[1].visitNotificationEventAttributes.size).isEqualTo(2)
-    assertThat(visitNotifications[1].visitNotificationEventAttributes[0].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_RESTRICTION)
-    assertThat(visitNotifications[1].visitNotificationEventAttributes[0].attributeValue).isEqualTo(VisitorSupportedRestrictionType.BAN.name)
-    assertThat(visitNotifications[1].visitNotificationEventAttributes[1].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_ID)
-    assertThat(visitNotifications[1].visitNotificationEventAttributes[1].attributeValue).isEqualTo(visitorId)
+    assertThat(visitNotifications[1].visitNotificationEventAttributes)
+      .extracting({ it.attributeName }, { it.attributeValue })
+      .containsExactlyInAnyOrder(
+        tuple(NotificationEventAttributeType.VISITOR_RESTRICTION, VisitorSupportedRestrictionType.BAN.name),
+        tuple(NotificationEventAttributeType.VISITOR_ID, visitorId),
+      )
 
     val auditEvents = testEventAuditRepository.getAuditByType(EventAuditType.VISITOR_RESTRICTION_UPSERTED_EVENT)
     assertThat(auditEvents).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_VISITOR_UNAPPROVED_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType.NOT_KNOWN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAttributeType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
@@ -101,7 +102,8 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(1)
     assertThat(visitNotifications[0].bookingReference).isEqualTo(visit1.reference)
-    assertThat(visitNotifications[0].visitorId.toString()).isEqualTo(visitorId)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes.size).isEqualTo(1)
+    assertThat(visitNotifications[0].visitNotificationEventAttributes[0].attributeName).isEqualTo(NotificationEventAttributeType.VISITOR_ID)
 
     val auditEvents = testEventAuditRepository.getAuditByType(EventAuditType.VISITOR_UNAPPROVED_EVENT)
     assertThat(auditEvents).hasSize(1)


### PR DESCRIPTION
## What does this PR do?
This PR introduces "attributes" to the visit event notifications. These attributes allow for extra information to be captured for specific event types. Currently only 3 events (VISITOR_RESTRICTION_UPSERTED_EVENT, PERSON_RESTRICTION_UPSERTED_EVENT, VISITOR_UNAPPROVED_EVENT) have extra fields, but this new design allows new fields (attributes) to be added dynamically to the new attributes table with little changes required to the code itself.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-4411

## Extra reading (Original SPIKE)
https://dsdmoj.atlassian.net/browse/VB-5040