### PR TITLE
VB-5148 - allow notification count endpoint to pass event types as a parameter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitNotificationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitNotificationController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
@@ -47,7 +48,6 @@ const val VISIT_NOTIFICATION_PERSON_RESTRICTION_UPSERTED_PATH: String = "$VISIT_
 const val VISIT_NOTIFICATION_VISITOR_RESTRICTION_UPSERTED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/visitor/restriction/upserted"
 const val VISIT_NOTIFICATION_VISITOR_APPROVED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/visitor/approved"
 const val VISIT_NOTIFICATION_VISITOR_UNAPPROVED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/visitor/unapproved"
-const val VISIT_NOTIFICATION_COUNT_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/count"
 const val VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/{prisonCode}/count"
 const val FUTURE_NOTIFICATION_VISIT_GROUPS: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/{prisonCode}/groups"
 const val VISIT_NOTIFICATION_TYPES: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/visit/{reference}/types"
@@ -414,34 +414,11 @@ class VisitNotificationController(
     @Schema(description = "prisonCode", example = "CFI", required = true)
     @PathVariable
     prisonCode: String,
+    @Schema(description = "list of notificationEventTypes", required = false)
+    @RequestParam(value = "types", required = false)
+    notificationEventTypes: List<NotificationEventType>?,
   ): NotificationCountDto {
-    return NotificationCountDto(visitNotificationEventService.getNotificationCountForPrison(prisonCode))
-  }
-
-  @PreAuthorize("hasRole('VISIT_SCHEDULER')")
-  @GetMapping(VISIT_NOTIFICATION_COUNT_PATH)
-  @Operation(
-    summary = "Get notification count",
-    description = "Retrieve notification count by visit reference",
-    responses = [
-      ApiResponse(
-        responseCode = "200",
-        description = "Retrieve notification count",
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorized to access this endpoint",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Incorrect permissions to access this endpoint",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
-    ],
-  )
-  fun getNotificationCount(): NotificationCountDto {
-    return NotificationCountDto(visitNotificationEventService.getNotificationCount())
+    return NotificationCountDto(visitNotificationEventService.getNotificationCountForPrison(prisonCode, notificationEventTypes))
   }
 
   @PreAuthorize("hasRole('VISIT_SCHEDULER')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
@@ -135,11 +135,13 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
       "SELECT count(distinct vne.reference) as ng FROM visit_notification_event vne " +
       " JOIN visit v ON v.reference  = vne.booking_reference " +
       " JOIN session_slot ss on ss.id  = v.session_slot_id " +
-      " WHERE v.visit_status = 'BOOKED' AND ss.slot_start >= NOW()  " +
+      " JOIN prison p on p.id  = v.prison_id AND p.code = :prisonCode " +
+      " WHERE  v.visit_status = 'BOOKED' AND ss.slot_start >= NOW() AND " +
+      " vne.type in (:notificationEventTypes) " +
       " GROUP BY vne.reference) sq ",
     nativeQuery = true,
   )
-  fun getNotificationGroupsCount(): Int?
+  fun getNotificationGroupsCountByPrisonCode(prisonCode: String, notificationEventTypes: List<String>): Int?
 
   @Query(
     "SELECT vne.* FROM visit_notification_event vne " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -485,12 +485,16 @@ class VisitNotificationEventService(
     return validToDate?.let { LocalDateTime.of(validToDate, LocalTime.MAX) }
   }
 
-  fun getNotificationCountForPrison(prisonCode: String): Int {
-    return this.visitNotificationEventRepository.getNotificationGroupsCountByPrisonCode(prisonCode) ?: 0
-  }
-
-  fun getNotificationCount(): Int {
-    return this.visitNotificationEventRepository.getNotificationGroupsCount() ?: 0
+  fun getNotificationCountForPrison(
+    prisonCode: String,
+    notificationEventTypes: List<NotificationEventType>?,
+  ): Int {
+    LOG.debug("getNotificationCountForPrison with prisonCode - {}, notificationEventTypes - {}", prisonCode, notificationEventTypes)
+    return if (notificationEventTypes == null) {
+      this.visitNotificationEventRepository.getNotificationGroupsCountByPrisonCode(prisonCode) ?: 0
+    } else {
+      this.visitNotificationEventRepository.getNotificationGroupsCountByPrisonCode(prisonCode, notificationEventTypes.map { it.name }.toList()) ?: 0
+    }
   }
 
   fun getFutureNotificationVisitGroups(prisonCode: String): List<NotificationGroupDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_VISIT_HISTORY_
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.UPDATE_VISIT_BY_APPLICATION_REFERENCE
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_BOOK
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_CANCEL
+import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_IGNORE
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_NON_ASSOCIATION_CHANGE_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_PERSON_RESTRICTION_UPSERTED_PATH
@@ -61,6 +62,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ChangeApplica
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.CreateApplicationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType.PHONE
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.CreateSessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.MoveVisitsDto
@@ -774,9 +776,17 @@ fun callNotifyVSiPThatPrisonerAlertHasBeenCreatedOrUpdated(
 
 fun callCountVisitNotification(
   webTestClient: WebTestClient,
-  url: String,
+  prisonCode: String,
+  notificationEventTypes: List<NotificationEventType>? = null,
   authHttpHeaders: (HttpHeaders) -> Unit,
 ): ResponseSpec {
+  var url = VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH.replace("{prisonCode}", prisonCode)
+  url = if (notificationEventTypes != null) {
+    url + "?types=${notificationEventTypes.joinToString(",")}"
+  } else {
+    url
+  }
+
   return callGet(
     webTestClient,
     url,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CountVisitNotificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CountVisitNotificationTest.kt
@@ -7,12 +7,13 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.transaction.annotation.Propagation.SUPPORTS
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH
-import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_COUNT_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_NON_ASSOCIATION_CHANGE_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.NON_ASSOCIATION_EVENT
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.PRISONER_ALERTS_UPDATED_EVENT
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.PRISONER_RECEIVED_EVENT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.PRISONER_RELEASED_EVENT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.PRISONER_RESTRICTION_CHANGE_EVENT
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.PRISON_VISITS_BLOCKED_FOR_DATE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callCountVisitNotification
@@ -32,98 +33,6 @@ class CountVisitNotificationTest : NotificationTestBase() {
   @BeforeEach
   internal fun setUp() {
     roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
-  }
-
-  @Test
-  fun `when notification count is requested for all prisons`() {
-    // Given
-
-    val visitPrimary = visitEntityHelper.create(
-      prisonerId = primaryPrisonerId,
-      slotDate = startDate.plusDays(1),
-      visitStatus = BOOKED,
-      prisonCode = sessionTemplateDefault.prison.code,
-      sessionTemplate = sessionTemplateDefault,
-    )
-    eventAuditEntityHelper.create(visitPrimary)
-
-    val visitSecondary = visitEntityHelper.create(
-      prisonerId = secondaryPrisonerId,
-      slotDate = startDate.plusDays(2),
-      visitStatus = BOOKED,
-      prisonCode = sessionTemplateDefault.prison.code,
-      sessionTemplate = sessionTemplateDefault,
-    )
-    eventAuditEntityHelper.create(visitSecondary)
-
-    val sessionTemplateTst = sessionTemplateEntityHelper.create(prisonCode = "TST")
-
-    val visitOther = visitEntityHelper.create(
-      prisonerId = secondaryPrisonerId,
-      slotDate = startDate.plusDays(2),
-      visitStatus = BOOKED,
-      prisonCode = sessionTemplateTst.prison.code,
-      sessionTemplate = sessionTemplateTst,
-    )
-    eventAuditEntityHelper.create(visitOther)
-
-    val visitNotification = testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitPrimary.reference, NON_ASSOCIATION_EVENT))
-    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitSecondary.reference, NON_ASSOCIATION_EVENT, _reference = visitNotification.reference))
-    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitOther.reference, PRISONER_RESTRICTION_CHANGE_EVENT))
-
-    // When
-    val responseSpec = callCountVisitNotification(webTestClient, VISIT_NOTIFICATION_COUNT_PATH, roleVisitSchedulerHttpHeaders)
-
-    // Then
-    responseSpec.expectStatus().isOk
-    val notificationCount = this.getNotificationCountDto(responseSpec)
-    Assertions.assertThat(notificationCount.count).isEqualTo(2)
-  }
-
-  @Test
-  fun `when no booked visits for notification count is zero for all prisons`() {
-    // Given
-
-    val visitPrimary = visitEntityHelper.create(
-      prisonerId = primaryPrisonerId,
-      slotDate = LocalDate.now().plusDays(1),
-      visitStatus = CANCELLED,
-      prisonCode = sessionTemplateDefault.prison.code,
-      sessionTemplate = sessionTemplateDefault,
-    )
-    eventAuditEntityHelper.create(visitPrimary)
-
-    val visitSecondary = visitEntityHelper.create(
-      prisonerId = secondaryPrisonerId,
-      slotDate = LocalDate.now().plusDays(2),
-      visitStatus = CANCELLED,
-      prisonCode = sessionTemplateDefault.prison.code,
-      sessionTemplate = sessionTemplateDefault,
-    )
-    eventAuditEntityHelper.create(visitSecondary)
-
-    val sessionTemplateTst = sessionTemplateEntityHelper.create(prisonCode = "TST")
-
-    val visitOther = visitEntityHelper.create(
-      prisonerId = secondaryPrisonerId,
-      slotDate = LocalDate.now().plusDays(3),
-      visitStatus = CANCELLED,
-      prisonCode = sessionTemplateTst.prison.code,
-      sessionTemplate = sessionTemplateTst,
-    )
-    eventAuditEntityHelper.create(visitOther)
-
-    val visitNotification = testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitPrimary.reference, NON_ASSOCIATION_EVENT))
-    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitSecondary.reference, NON_ASSOCIATION_EVENT, _reference = visitNotification.reference))
-    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitOther.reference, PRISONER_RESTRICTION_CHANGE_EVENT))
-
-    // When
-    val responseSpec = callCountVisitNotification(webTestClient, VISIT_NOTIFICATION_COUNT_PATH, roleVisitSchedulerHttpHeaders)
-
-    // Then
-    responseSpec.expectStatus().isOk
-    val notificationCount = this.getNotificationCountDto(responseSpec)
-    Assertions.assertThat(notificationCount.count).isEqualTo(0)
   }
 
   @Test
@@ -164,7 +73,7 @@ class CountVisitNotificationTest : NotificationTestBase() {
     testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitOther.reference, PRISONER_RESTRICTION_CHANGE_EVENT))
 
     // When
-    val responseSpec = callCountVisitNotification(webTestClient, VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH.replace("{prisonCode}", sessionTemplateDefault.prison.code), roleVisitSchedulerHttpHeaders)
+    val responseSpec = callCountVisitNotification(webTestClient, prisonCode = sessionTemplateDefault.prison.code, notificationEventTypes = null, roleVisitSchedulerHttpHeaders)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -208,7 +117,7 @@ class CountVisitNotificationTest : NotificationTestBase() {
     testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visitOther.reference, PRISONER_RESTRICTION_CHANGE_EVENT))
 
     // When
-    val responseSpec = callCountVisitNotification(webTestClient, VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH.replace("{prisonCode}", sessionTemplateDefault.prison.code), roleVisitSchedulerHttpHeaders)
+    val responseSpec = callCountVisitNotification(webTestClient, prisonCode = sessionTemplateDefault.prison.code, notificationEventTypes = null, roleVisitSchedulerHttpHeaders)
 
     // Then
     responseSpec.expectStatus().isOk
@@ -230,30 +139,9 @@ class CountVisitNotificationTest : NotificationTestBase() {
     eventAuditEntityHelper.create(visit)
 
     // When
-    val responseSpec = callCountVisitNotification(webTestClient, VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH.replace("{prisonCode}", sessionTemplateDefault.prison.code), roleVisitSchedulerHttpHeaders)
+    val responseSpec = callCountVisitNotification(webTestClient, prisonCode = sessionTemplateDefault.prison.code, notificationEventTypes = null, roleVisitSchedulerHttpHeaders)
 
     // Then count returned is 0
-    responseSpec.expectStatus().isOk
-    val notificationCount = this.getNotificationCountDto(responseSpec)
-    Assertions.assertThat(notificationCount.count).isEqualTo(0)
-  }
-
-  @Test
-  fun `when notification count is requested for all prisons and none exist then a count of 0 is returned`() {
-    // Given - visits exist but no notifications
-    val visit = visitEntityHelper.create(
-      prisonerId = primaryPrisonerId,
-      slotDate = LocalDate.now().plusDays(1),
-      visitStatus = BOOKED,
-      prisonCode = sessionTemplateDefault.prison.code,
-      sessionTemplate = sessionTemplateDefault,
-    )
-    eventAuditEntityHelper.create(visit)
-
-    // When
-    val responseSpec = callCountVisitNotification(webTestClient, VISIT_NOTIFICATION_COUNT_PATH, roleVisitSchedulerHttpHeaders)
-
-    // Then
     responseSpec.expectStatus().isOk
     val notificationCount = this.getNotificationCountDto(responseSpec)
     Assertions.assertThat(notificationCount.count).isEqualTo(0)
@@ -311,11 +199,196 @@ class CountVisitNotificationTest : NotificationTestBase() {
     testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(futureVisitTomorrow.reference, PRISONER_RELEASED_EVENT))
 
     // When
-    val responseSpec = callCountVisitNotification(webTestClient, VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH.replace("{prisonCode}", prisonCode), roleVisitSchedulerHttpHeaders)
+    val responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = null, roleVisitSchedulerHttpHeaders)
 
     // Then
     responseSpec.expectStatus().isOk
     val notificationCount = this.getNotificationCountDto(responseSpec)
     Assertions.assertThat(notificationCount.count).isEqualTo(2)
+  }
+
+  @Test
+  fun `when notification count is requested for a prison with  notification types specified then the correct count is returned`() {
+    // Given
+    val futureSessionStartTime = LocalTime.MAX
+    val prisonCode = "ABC"
+
+    val sessionTemplate1 = sessionTemplateEntityHelper.create(startTime = futureSessionStartTime, prisonCode = prisonCode)
+
+    val futureVisit1 = visitEntityHelper.create(
+      prisonerId = primaryPrisonerId,
+      slotDate = LocalDate.now(),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(futureVisit1)
+
+    val futureVisit2 = visitEntityHelper.create(
+      prisonerId = secondaryPrisonerId,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(futureVisit2)
+
+    val futureVisit3 = visitEntityHelper.create(
+      prisonerId = secondaryPrisonerId,
+      slotDate = LocalDate.now().plusDays(2),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(futureVisit3)
+
+    val futureVisit4 = visitEntityHelper.create(
+      prisonerId = primaryPrisonerId,
+      slotDate = LocalDate.now().plusDays(3),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(futureVisit4)
+
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(futureVisit1.reference, PRISONER_RELEASED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(futureVisit2.reference, PRISONER_ALERTS_UPDATED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(futureVisit3.reference, PRISON_VISITS_BLOCKED_FOR_DATE))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(futureVisit4.reference, PRISONER_RELEASED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(futureVisit4.reference, PRISONER_RECEIVED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(futureVisit4.reference, PRISONER_ALERTS_UPDATED_EVENT))
+
+    // When notification count sought for PRISONER_RELEASED_EVENT
+    var responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISONER_RELEASED_EVENT), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    var notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(2)
+
+    // When notification count sought for PRISONER_ALERTS_UPDATED_EVENT
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISONER_ALERTS_UPDATED_EVENT), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(2)
+
+    // When notification count sought for PRISON_VISITS_BLOCKED_FOR_DATE
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISON_VISITS_BLOCKED_FOR_DATE), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(1)
+
+    // When notification count sought for PRISONER_RELEASED_EVENT and PRISON_VISITS_BLOCKED_FOR_DATE
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISONER_RELEASED_EVENT, PRISON_VISITS_BLOCKED_FOR_DATE), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(3)
+
+    // When  notification count sought for all event types
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = null, roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(6)
+  }
+
+  @Test
+  fun `when notification count is requested for a prison with  notification types specified but no future visits exist hen the correct count is returned`() {
+    // Given
+    val sessionStartTime = LocalTime.MAX
+    val prisonCode = "ABC"
+
+    val sessionTemplate1 = sessionTemplateEntityHelper.create(startTime = sessionStartTime, prisonCode = prisonCode)
+
+    // all visits are in the past
+    val pastVisit1 = visitEntityHelper.create(
+      prisonerId = primaryPrisonerId,
+      slotDate = LocalDate.now().minusDays(1),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(pastVisit1)
+
+    val pastVisit2 = visitEntityHelper.create(
+      prisonerId = secondaryPrisonerId,
+      slotDate = LocalDate.now().minusDays(2),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(pastVisit2)
+
+    val pastVisit3 = visitEntityHelper.create(
+      prisonerId = secondaryPrisonerId,
+      slotDate = LocalDate.now().minusDays(3),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(pastVisit3)
+
+    val pastVisit4 = visitEntityHelper.create(
+      prisonerId = primaryPrisonerId,
+      slotDate = LocalDate.now().minusDays(4),
+      visitStatus = BOOKED,
+      prisonCode = sessionTemplate1.prison.code,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(pastVisit4)
+
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(pastVisit1.reference, PRISONER_RELEASED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(pastVisit2.reference, PRISONER_ALERTS_UPDATED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(pastVisit3.reference, PRISON_VISITS_BLOCKED_FOR_DATE))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(pastVisit4.reference, PRISONER_RELEASED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(pastVisit4.reference, PRISONER_RECEIVED_EVENT))
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(pastVisit4.reference, PRISONER_ALERTS_UPDATED_EVENT))
+
+    // When notification count sought for PRISONER_RELEASED_EVENT
+    var responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISONER_RELEASED_EVENT), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    var notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(0)
+
+    // When notification count sought for PRISONER_ALERTS_UPDATED_EVENT
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISONER_ALERTS_UPDATED_EVENT), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(0)
+
+    // When notification count sought for PRISON_VISITS_BLOCKED_FOR_DATE
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISON_VISITS_BLOCKED_FOR_DATE), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(0)
+
+    // When notification count sought for PRISONER_RELEASED_EVENT and PRISON_VISITS_BLOCKED_FOR_DATE
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = listOf(PRISONER_RELEASED_EVENT, PRISON_VISITS_BLOCKED_FOR_DATE), roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(0)
+
+    // When  notification count sought for all event types
+    responseSpec = callCountVisitNotification(webTestClient, prisonCode = prisonCode, notificationEventTypes = null, roleVisitSchedulerHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    notificationCount = this.getNotificationCountDto(responseSpec)
+    Assertions.assertThat(notificationCount.count).isEqualTo(0)
   }
 }


### PR DESCRIPTION

## What does this pull request do?

Restricts notification counts by notification types passed

## What is the intent behind these changes?

Fix for VB-5148