### PR TITLE
Change event processing to avoid NPE

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/PrisonerService.kt
@@ -124,11 +124,12 @@ class PrisonerService(
 
   fun hasPrisonGotSessionsWithPrisonersTransitionalLocation(sessionTemplates: List<SessionTemplate>, prisonersTransitionalLocation: String): Boolean = sessionTemplates.asSequence().filter { it.includeLocationGroupType }.map { it.permittedSessionLocationGroups }.flatten().map { it.sessionLocations }.flatten().any { it.levelOneCode == prisonersTransitionalLocation }
 
-  fun getPrisonerPrisonCode(prisonerCode: String): String? {
+  fun getPrisonerPrisonCodeFromPrisonId(prisonerCode: String): String? {
     try {
-      val prisonCode = prisonerOffenderSearchClient.getPrisoner(prisonerCode)?.prisonId
-      prisonCode?.let {
-        return this.prisonService.getPrisonCode(prisonCode)
+      val prisonId = prisonerOffenderSearchClient.getPrisoner(prisonerCode)?.prisonId
+      prisonId?.let {
+        // Check if the prison exists in our DB. If not, return null.
+        return prisonService.getPrisonCode(prisonId)
       }
     } catch (_: ItemNotFoundException) {}
     return null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorApprovedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorApprovedVisitNotificationControllerTest.kt
@@ -89,4 +89,41 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     )
     verify(telemetryClient, times(1)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
+
+  @Test
+  fun `when visitor is from an unsupported prison and is re-approved then processing is skipped`() {
+    // Given
+    val notificationDto = VisitorApprovedUnapprovedNotificationDto(visitorId = visitorId, prisonerNumber = prisonerId)
+
+    val visit1 = createApplicationAndVisit(
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate,
+      prisonerId = prisonerId,
+    )
+    visit1.visitors.add(
+      VisitVisitor(
+        nomisPersonId = visitorId.toLong(),
+        visitId = visit1.id,
+        visit = visit1,
+        visitContact = true,
+      ),
+    )
+    val visit = visitEntityHelper.save(visit1)
+    eventAuditEntityHelper.create(visit1)
+
+    testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visit.reference, NotificationEventType.VISITOR_UNAPPROVED_EVENT))
+
+    prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId, "XYZ")
+    whenever(prisonerService.getPrisonerPrisonCodeFromPrisonId(prisonerId)).thenReturn(null)
+
+    // When
+    val responseSpec = callNotifyVSiPThatVisitorApproved(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    verify(visitNotificationEventRepository, times(0)).deleteAll()
+    verify(telemetryClient, times(0)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorApprovedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorApprovedVisitNotificationControllerTest.kt
@@ -69,7 +69,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     testVisitNotificationEventRepository.saveAndFlush(VisitNotificationEvent(visit.reference, NotificationEventType.VISITOR_UNAPPROVED_EVENT))
 
     prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId, prisonCode)
-    whenever(prisonerService.getPrisonerPrisonCode(prisonerId)).thenReturn(prisonCode)
+    whenever(prisonerService.getPrisonerPrisonCodeFromPrisonId(prisonerId)).thenReturn(prisonCode)
 
     // When
     val responseSpec = callNotifyVSiPThatVisitorApproved(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventServiceTest.kt
@@ -71,7 +71,7 @@ class VisitNotificationEventServiceTest {
 
     val nonAssociationChangedNotification = NonAssociationChangedNotificationDto(NON_ASSOCIATION_CREATED, primaryNonAssociationNumber, secondaryNonAssociationNumber)
 
-    whenever(prisonerService.getPrisonerPrisonCode(any())).thenReturn(
+    whenever(prisonerService.getPrisonerPrisonCodeFromPrisonId(any())).thenReturn(
       "CFI",
     )
     whenever(visitService.getBookedVisits(any(), any(), any())).thenReturn(


### PR DESCRIPTION
## What does this pull request do?
When null comes back for some events, skip processing as it's not required. The null is because the prisonCode we have isn't active in our DB.
