### PR TITLE
Handle issues with updating visits from external systems due to uniqueness violations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreService.kt
@@ -326,6 +326,7 @@ class VisitStoreService(
     existingVisit.visitRoom = updateVisitFromExternalSystemDto.visitRoom
 
     existingVisit.visitors.clear()
+    visitRepository.saveAndFlush(existingVisit)
     existingVisit.visitors.addAll(
       updateVisitFromExternalSystemDto.visitors?.map {
         VisitVisitor(
@@ -338,6 +339,7 @@ class VisitStoreService(
     )
 
     existingVisit.visitNotes.clear()
+    visitRepository.saveAndFlush(existingVisit)
     existingVisit.visitNotes.addAll(
       updateVisitFromExternalSystemDto.visitNotes.map {
         VisitNote(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -215,7 +216,7 @@ internal class VisitStoreServiceTest {
       whenever(visitRepository.saveAndFlush(visit)).thenReturn(visit)
 
       visitStoreService.updateVisitFromExternalSystem(updateVisitFromExternalSystemDto, visit)
-      verify(visitRepository, times(1)).saveAndFlush(any<Visit>())
+      verify(visitRepository, atLeastOnce()).saveAndFlush(any<Visit>())
       verify(visitDtoBuilder, times(1)).build(any<Visit>())
     }
   }


### PR DESCRIPTION
## What does this pull request do?

This should fix an issue I spotted when trying to update visits from an external system. This is the error in the log:

```
ERROR: duplicate key value violates unique constraint "visit_notes_visit_id_type_key" Detail: Key (visit_id, type)=(1013, VISITOR_CONCERN) already exists.
```
I now force a `saveAndFlush` after clearing the visit notes and before adding the new visit notes that should mean that the table gets cleared before adding new ones, thus not triggering the unique contraint.

## What is the intent behind these changes?

To fix issues with updating visits from external systems