### PR TITLE
VB-5570 - Remove duplicate check as it does not allow valid events to be processed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -334,15 +334,15 @@ class VisitNotificationEventService(
   }
 
   private fun processVisitsWithNotifications(processVisitNotificationDto: ProcessVisitNotificationDto) {
-    val affectedVisitsNoDuplicate = processVisitNotificationDto.affectedVisits.filter { !visitNotificationEventRepository.isEventARecentDuplicate(it.reference, processVisitNotificationDto.type) }
+    val affectedVisits = processVisitNotificationDto.affectedVisits
 
-    affectedVisitsNoDuplicate.forEach {
+    affectedVisits.forEach {
       val bookingEventAudit = visitEventAuditService.getLastEventForBooking(it.reference)
       visitNotificationFlaggingService.flagTrackEvents(it, bookingEventAudit, processVisitNotificationDto.type)
     }
 
     if (pairedNotificationEventsUtil.isPairGroupRequired(processVisitNotificationDto.type)) {
-      val affectedVisitsByDateMap = processVisitNotificationDto.affectedVisits.groupBy { it.startTimestamp.toLocalDate() }
+      val affectedVisitsByDateMap = affectedVisits.groupBy { it.startTimestamp.toLocalDate() }
       affectedVisitsByDateMap.forEach {
         val affectedPairedVisits = pairedNotificationEventsUtil.pairWithEachOther(it.value)
 
@@ -352,7 +352,7 @@ class VisitNotificationEventService(
       }
     } else {
       val saveVisitNotificationDto = SaveVisitNotificationDto(
-        affectedVisitsNoDuplicate,
+        affectedVisits,
         processVisitNotificationDto.type,
         processVisitNotificationDto.notificationEventAttributes,
       )


### PR DESCRIPTION
## What does this pull request do?

VB-5570 - Removes duplicate checks while processing notification events as it does not allow valid events to  be processed

## What is the intent behind these changes?

VB-5570 changes