### PR TITLE
VB-3758 - Change count to count by visit, not by event type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
@@ -107,7 +107,7 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
       " JOIN prison p ON p.id = v.prison_id AND p.code = :prisonCode " +
       "WHERE v.visit_status = 'BOOKED' " +
       "  AND ss.slot_start  >= NOW()",
-    nativeQuery = true
+    nativeQuery = true,
   )
   fun getNotificationGroupsCountByPrisonCode(prisonCode: String): Int?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
@@ -99,26 +99,27 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
   ): List<VisitNotificationEvent>
 
   @Query(
-    "SELECT sum(ng) FROM (   " +
-      "SELECT count(distinct vne.reference) as ng FROM visit_notification_event vne " +
-      " JOIN visit v ON v.reference  = vne.booking_reference " +
-      " JOIN session_slot ss on ss.id  = v.session_slot_id " +
-      " JOIN prison p on p.id  = v.prison_id AND p.code = :prisonCode " +
-      " WHERE  v.visit_status = 'BOOKED' AND ss.slot_start >= NOW()   " +
-      " GROUP BY vne.reference) sq ",
-    nativeQuery = true,
+    value =
+    "SELECT COUNT(DISTINCT v.reference) " +
+      "FROM visit_notification_event vne " +
+      " JOIN visit v ON v.reference = vne.booking_reference " +
+      " JOIN session_slot ss ON ss.id = v.session_slot_id " +
+      " JOIN prison p ON p.id = v.prison_id AND p.code = :prisonCode " +
+      "WHERE v.visit_status = 'BOOKED' " +
+      "  AND ss.slot_start  >= NOW()",
+    nativeQuery = true
   )
   fun getNotificationGroupsCountByPrisonCode(prisonCode: String): Int?
 
   @Query(
-    "SELECT sum(ng) FROM (   " +
-      "SELECT count(distinct vne.reference) as ng FROM visit_notification_event vne " +
-      " JOIN visit v ON v.reference  = vne.booking_reference " +
-      " JOIN session_slot ss on ss.id  = v.session_slot_id " +
-      " JOIN prison p on p.id  = v.prison_id AND p.code = :prisonCode " +
-      " WHERE  v.visit_status = 'BOOKED' AND ss.slot_start >= NOW() AND " +
-      " vne.type in (:notificationEventTypes) " +
-      " GROUP BY vne.reference) sq ",
+    "SELECT COUNT(DISTINCT v.reference) " +
+      "FROM visit_notification_event vne " +
+      " JOIN visit v ON v.reference = vne.booking_reference " +
+      " JOIN session_slot ss ON ss.id = v.session_slot_id " +
+      " JOIN prison p ON p.id = v.prison_id AND p.code = :prisonCode " +
+      "WHERE v.visit_status = 'BOOKED' " +
+      "  AND ss.slot_start >= NOW() " +
+      "  AND vne.type IN (:notificationEventTypes)",
     nativeQuery = true,
   )
   fun getNotificationGroupsCountByPrisonCode(prisonCode: String, notificationEventTypes: List<String>): Int?


### PR DESCRIPTION
## What does this pull request do?

It's possible for a visit to have multiple events associated with it. This was causing the count to be higher than it technically was.

Changed to count visits, regardless of how many events are associated with visit.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-3758