### PR TITLE
Add new sub-status for visits

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/VisitStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/VisitStatus.kt
@@ -6,8 +6,4 @@ enum class VisitStatus(
 ) {
   BOOKED("Booked"),
   CANCELLED("Cancelled"),
-  REQUESTED("Requested"),
-  REJECTED("Rejected"),
-  AUTO_REJECTED("Auto Rejected"),
-  WITHDRAWN("Withdrawn"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/VisitSubStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/VisitSubStatus.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.enums
+
+@Suppress("unused")
+enum class VisitSubStatus(
+  val description: String,
+) {
+  APPROVED("Approved"),
+  AUTO_APPROVED("Auto_Approved"),
+  REQUESTED("Requested"),
+
+  REJECTED("Rejected"),
+  AUTO_REJECTED("Auto_Rejected"),
+  WITHDRAWN("Withdrawn"),
+  CANCELLED("Cancelled"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/Visit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/Visit.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Application
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.base.AbstractIdEntity
@@ -60,6 +61,10 @@ class Visit(
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   var visitStatus: VisitStatus,
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  var visitSubStatus: VisitSubStatus,
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitNoteType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.ExpiredVisitAmendException
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.PrisonNotFoundException
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.VisitNotFoundException
@@ -103,6 +104,7 @@ class VisitStoreService(
       it.visitRestriction = application.restriction
       it.visitRoom = visitRoom
       it.visitStatus = BOOKED
+      it.visitSubStatus = VisitSubStatus.AUTO_APPROVED // TODO [Request a visit feature]: Allow 'Requested' visits.
       it
     } ?: run {
       // Create new booking
@@ -116,6 +118,7 @@ class VisitStoreService(
         visitRestriction = application.restriction,
         visitRoom = visitRoom,
         visitStatus = BOOKED,
+        visitSubStatus = VisitSubStatus.AUTO_APPROVED, // TODO [Request a visit feature]: Allow 'Requested' visits.
         userType = application.userType,
       )
     }
@@ -197,6 +200,7 @@ class VisitStoreService(
     val cancelOutcome = cancelVisitDto.cancelOutcome
 
     visitEntity.visitStatus = CANCELLED
+    visitEntity.visitSubStatus = VisitSubStatus.CANCELLED // TODO [Request a visit feature]: Allow 'Requested' visits to have custom cancel statuses.
     visitEntity.outcomeStatus = cancelOutcome.outcomeStatus
 
     cancelOutcome.text?.let {
@@ -258,6 +262,7 @@ class VisitStoreService(
         visitRestriction = createVisitFromExternalSystemDto.visitRestriction,
         visitRoom = createVisitFromExternalSystemDto.visitRoom,
         visitStatus = BOOKED,
+        visitSubStatus = VisitSubStatus.AUTO_APPROVED,
         userType = UserType.PRISONER,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/reporting/VisitCountsByDateReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/reporting/VisitCountsByDateReportService.kt
@@ -138,11 +138,6 @@ class VisitCountsByDateReportService(
             it,
           )
         }
-
-        else -> {
-          LOG.error("Unsupported visit status $visitStatus encountered")
-          emptyList()
-        }
       }
     }
 

--- a/src/main/resources/db/migration/V4_0__add_visit_sub_status_to_visit_table.sql
+++ b/src/main/resources/db/migration/V4_0__add_visit_sub_status_to_visit_table.sql
@@ -1,0 +1,19 @@
+-- Begin work on "Request a visit" Feature. Add new "sub status" column to Visit table
+-- to allow us to differentiate between instant bookings and requested bookings.
+
+-- Add sub_status column
+ALTER TABLE visit ADD visit_sub_status VARCHAR(50);
+
+-- Back fill existing rows with 'Auto_Approved'
+UPDATE visit SET visit_sub_status = 'AUTO_APPROVED';
+
+-- Set NOT NULL
+ALTER TABLE visit ALTER COLUMN visit_sub_status SET NOT NULL;
+
+-- Add CHECK constraint to enforce allowed combinations of visit_status and sub_status
+ALTER TABLE visit ADD CONSTRAINT chk_visit_sub_status
+    CHECK (
+        (visit_status = 'BOOKED' AND visit_sub_status IN ('AUTO_APPROVED', 'REQUESTED', 'APPROVED'))
+            OR
+        (visit_status = 'CANCELLED' AND visit_sub_status IN ('CANCELLED', 'WITHDRAWN', 'AUTO_REJECTED', 'REJECTED'))
+        );

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/builder/VisitDtoBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/builder/VisitDtoBuilderTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitNoteType.VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTimeSlotDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.ApplicationEntityHelper
@@ -140,6 +141,7 @@ class VisitDtoBuilderTest {
 
   private fun create(
     visitStatus: VisitStatus = BOOKED,
+    visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     prisonerId: String = "FF0000AA",
     visitRoom: String = "A1",
     slotDate: LocalDate,
@@ -159,6 +161,7 @@ class VisitDtoBuilderTest {
 
     val visit = Visit(
       visitStatus = visitStatus,
+      visitSubStatus = visitSubStatus,
       prisonerId = prisonerId,
       prisonId = prison.id,
       prison = prison,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitNoteType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.ActionedBy
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.EventAudit
@@ -217,11 +218,13 @@ class VisitEntityHelper(
   fun createFromApplication(
     application: Application,
     visitStatus: VisitStatus = BOOKED,
+    visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     sessionTemplate: SessionTemplate,
     outcomeStatus: OutcomeStatus? = null,
   ): Visit {
     val visit = create(
       visitStatus = visitStatus,
+      visitSubStatus = visitSubStatus,
       sessionTemplate = sessionTemplate,
       prisonerId = application.prisonerId,
       slotDate = application.sessionSlot.slotDate,
@@ -241,10 +244,12 @@ class VisitEntityHelper(
   fun createFromApplication(
     application: Application,
     visitStatus: VisitStatus = BOOKED,
+    visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     outcomeStatus: OutcomeStatus? = null,
   ): Visit {
     val visit = create(
       visitStatus = visitStatus,
+      visitSubStatus = visitSubStatus,
       prisonerId = application.prisonerId,
       slotDate = application.sessionSlot.slotDate,
       visitStart = application.sessionSlot.slotStart.toLocalTime(),
@@ -265,6 +270,7 @@ class VisitEntityHelper(
   @Transactional
   fun create(
     visitStatus: VisitStatus = BOOKED,
+    visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     sessionTemplate: SessionTemplate,
     prisonerId: String = "testPrisonerId",
     prisonCode: String = sessionTemplate.prison.code,
@@ -285,6 +291,7 @@ class VisitEntityHelper(
 
     val notSaved = Visit(
       visitStatus = visitStatus,
+      visitSubStatus = visitSubStatus,
       prisonerId = prisonerId,
       prisonId = prison.id,
       prison = prison,
@@ -314,6 +321,7 @@ class VisitEntityHelper(
   @Transactional
   fun create(
     visitStatus: VisitStatus = BOOKED,
+    visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     prisonerId: String = "testPrisonerId",
     prisonCode: String,
     visitRoom: String,
@@ -333,6 +341,7 @@ class VisitEntityHelper(
 
     val notSaved = Visit(
       visitStatus = visitStatus,
+      visitSubStatus = visitSubStatus,
       prisonerId = prisonerId,
       prisonId = prison.id,
       prison = prison,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.notify.NotifyCallbackNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.notify.NotifyCreateNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateDto
@@ -273,25 +274,27 @@ abstract class IntegrationTestBase {
     prisonerId: String? = "testPrisonerId",
     sessionTemplate: SessionTemplate,
     visitStatus: VisitStatus? = VisitStatus.BOOKED,
+    visitSubStatus: VisitSubStatus? = VisitSubStatus.AUTO_APPROVED,
     slotDate: LocalDate? = null,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,
     visitContact: ContactDto = ContactDto(name = "Jane Doe", telephone = "01234 098765", email = "email@example.com"),
     userType: UserType = STAFF,
   ): Visit {
     val application = createApplicationAndSave(prisonerId = prisonerId, sessionTemplate, sessionTemplate.prison.code, slotDate, applicationStatus = ACCEPTED, visitRestriction = visitRestriction, visitContact = visitContact, userType = userType)
-    return createVisitAndSave(visitStatus = visitStatus!!, applicationEntity = application, sessionTemplateLocal = sessionTemplate)
+    return createVisitAndSave(visitStatus = visitStatus!!, visitSubStatus = visitSubStatus!!, applicationEntity = application, sessionTemplateLocal = sessionTemplate)
   }
 
   fun createApplicationAndVisit(
     prisonerId: String? = "testPrisonerId",
     visitStatus: VisitStatus? = VisitStatus.BOOKED,
+    visitSubStatus: VisitSubStatus? = VisitSubStatus.AUTO_APPROVED,
     slotDate: LocalDate,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,
     prisonCode: String? = null,
     userType: UserType = STAFF,
   ): Visit {
     val application = createApplicationAndSave(prisonerId = prisonerId, slotDate = slotDate, applicationStatus = ACCEPTED, visitRestriction = visitRestriction, prisonCode = prisonCode, userType = userType)
-    return createVisitAndSave(visitStatus = visitStatus!!, applicationEntity = application)
+    return createVisitAndSave(visitStatus = visitStatus!!, visitSubStatus = visitSubStatus!!, applicationEntity = application)
   }
 
   fun createApplicationAndSave(
@@ -337,10 +340,10 @@ abstract class IntegrationTestBase {
     return applicationEntityHelper.save(applicationEntity)
   }
 
-  fun createVisitAndSave(visitStatus: VisitStatus, applicationEntity: Application, sessionTemplateLocal: SessionTemplate? = null): Visit = visitEntityHelper.createFromApplication(visitStatus = visitStatus, sessionTemplate = sessionTemplateLocal ?: sessionTemplateDefault, application = applicationEntity)
+  fun createVisitAndSave(visitStatus: VisitStatus, visitSubStatus: VisitSubStatus, applicationEntity: Application, sessionTemplateLocal: SessionTemplate? = null): Visit = visitEntityHelper.createFromApplication(visitStatus = visitStatus, visitSubStatus = visitSubStatus, sessionTemplate = sessionTemplateLocal ?: sessionTemplateDefault, application = applicationEntity)
 
   // creates a visit with a null session template reference
-  fun createVisitAndSave(visitStatus: VisitStatus, applicationEntity: Application): Visit = visitEntityHelper.createFromApplication(visitStatus = visitStatus, application = applicationEntity)
+  fun createVisitAndSave(visitStatus: VisitStatus, visitSubStatus: VisitSubStatus, applicationEntity: Application): Visit = visitEntityHelper.createFromApplication(visitStatus = visitStatus, visitSubStatus = visitSubStatus, application = applicationEntity)
 
   fun parseVisitsPageResponse(responseSpec: ResponseSpec): List<VisitDto> {
     class Page {
@@ -358,6 +361,7 @@ abstract class IntegrationTestBase {
     prisonerId: String? = "testPrisonerId",
     actionedByValue: String,
     visitStatus: VisitStatus,
+    visitSubStatus: VisitSubStatus,
     sessionTemplate: SessionTemplate,
     userType: UserType,
     slotDateWeeks: Long,
@@ -371,6 +375,7 @@ abstract class IntegrationTestBase {
       slotDate = LocalDate.now().plusWeeks(slotDateWeeks),
       sessionTemplate = sessionTemplate,
       visitStatus = visitStatus,
+      visitSubStatus = visitSubStatus,
       userType = userType,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminSessionTemplateVisitStatsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminSessionTemplateVisitStatsTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.CL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.RequestSessionTemplateVisitStatsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionCapacityDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateVisitCountsDto
@@ -70,8 +71,8 @@ class AdminSessionTemplateVisitStatsTest(
     visitEntityHelper.create(visitStatus = BOOKED, sessionTemplate = sessionTemplate1, visitRestriction = OPEN, slotDate = tomorrow)
     visitEntityHelper.create(visitStatus = BOOKED, sessionTemplate = sessionTemplate1, visitRestriction = CLOSED, slotDate = tomorrow)
 
-    visitEntityHelper.create(visitStatus = CANCELLED, outcomeStatus = OutcomeStatus.CANCELLATION, sessionTemplate = sessionTemplate1, visitRestriction = CLOSED, slotDate = tomorrow)
-    visitEntityHelper.create(visitStatus = CANCELLED, sessionTemplate = sessionTemplate1, visitRestriction = CLOSED, slotDate = tomorrow)
+    visitEntityHelper.create(visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, outcomeStatus = OutcomeStatus.CANCELLATION, sessionTemplate = sessionTemplate1, visitRestriction = CLOSED, slotDate = tomorrow)
+    visitEntityHelper.create(visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplate1, visitRestriction = CLOSED, slotDate = tomorrow)
 
     // applications are not counted
     applicationEntityHelper.create(sessionTemplate = sessionTemplate1, visitRestriction = CLOSED, slotDate = tomorrow, applicationStatus = IN_PROGRESS, reservedSlot = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminUpdateSessionTemplateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminUpdateSessionTemplateTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionCapacityDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionDateRangeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateDto
@@ -528,6 +529,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
       visitStart = LocalTime.of(10, 0),
       visitEnd = LocalTime.of(11, 0),
       visitStatus = VisitStatus.CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
     )
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/events/SendDomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/events/SendDomainEventTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callCancelVisit
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callVisitBook
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
@@ -126,7 +127,7 @@ class SendDomainEventTest : IntegrationTestBase() {
     fun `send visit cancelled event`() {
       // Given
       val applicationEntity = createApplicationAndSave(applicationStatus = ACCEPTED)
-      val visitEntity = createVisitAndSave(BOOKED, applicationEntity)
+      val visitEntity = createVisitAndSave(BOOKED, VisitSubStatus.AUTO_APPROVED, applicationEntity)
       val reference = visitEntity.reference
       val authHeader = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
       val cancelVisitDto = CancelVisitDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrateVisitTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitNoteType.VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.VisitNote
@@ -217,7 +218,7 @@ class MigrateVisitTest : MigrationIntegrationTestBase() {
   fun `Migrate cancelled visit`() {
     // Given
 
-    val migrateVisitRequestDto = createMigrateVisitRequestDto(visitStatus = CANCELLED, modifyDateTime = LocalDateTime.of(2022, 9, 11, 12, 30))
+    val migrateVisitRequestDto = createMigrateVisitRequestDto(visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, modifyDateTime = LocalDateTime.of(2022, 9, 11, 12, 30))
     createSessionTemplateFrom(migrateVisitRequestDto)
 
     // When
@@ -231,6 +232,7 @@ class MigrateVisitTest : MigrationIntegrationTestBase() {
     assertThat(visit).isNotNull
     visit?.let {
       assertThat(visit.visitStatus).isEqualTo(CANCELLED)
+      assertThat(visit.visitSubStatus).isEqualTo(VisitSubStatus.CANCELLED)
       val eventAuditList = eventAuditRepository.findAllByBookingReference(visit.reference)
       assertThat(eventAuditList[0].createTimestamp).isEqualTo(migrateVisitRequestDto.modifyDateTime)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrationIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/migration/MigrationIntegrationTestBase.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.AllowedSessionLocationHierarchy
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
@@ -92,6 +93,7 @@ abstract class MigrationIntegrationTestBase : IntegrationTestBase() {
 
   protected fun createMigrateVisitRequestDto(
     visitStatus: VisitStatus = BOOKED,
+    visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     actionedBy: String? = "Aled Evans",
     visitStartTimeAndDate: LocalDateTime = VISIT_TIME,
     visitRoom: String = "A1",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCallbackNotificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCallbackNotificationTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFY_CONTR
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.NotifyHistoryDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationStatus.ACCEPTED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.notify.NotifyNotificationType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.notify.NotifyNotificationType.EMAIL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.notify.NotifyNotificationType.SMS
@@ -47,7 +48,7 @@ class NotifyCallbackNotificationTest : IntegrationTestBase() {
     roleVisitSchedulerHttpHeaders = setAuthorisation(roles = visitSchedulerRoles)
 
     val application = createApplicationAndSave(applicationStatus = ACCEPTED)
-    visit = createVisitAndSave(VisitStatus.BOOKED, application)
+    visit = createVisitAndSave(VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, application)
     eventAudit = eventAuditEntityHelper.create(
       reference = visit.reference,
       text = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCreateNotificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCreateNotificationTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFY_CONTR
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.NotifyHistoryDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationStatus.ACCEPTED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.notify.NotifyNotificationType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.notify.NotifyStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.notify.NotifyCreateNotificationDto
@@ -36,7 +37,7 @@ class NotifyCreateNotificationTest : IntegrationTestBase() {
   fun `when notify create notification called and no other notification for notification id exists an entry is created`() {
     // Given
     val application = createApplicationAndSave(applicationStatus = ACCEPTED)
-    val visit = createVisitAndSave(VisitStatus.BOOKED, application)
+    val visit = createVisitAndSave(VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, application)
     val eventAudit = eventAuditEntityHelper.create(
       reference = visit.reference,
       text = null,
@@ -68,7 +69,7 @@ class NotifyCreateNotificationTest : IntegrationTestBase() {
   fun `when notify create notification called and notification already exists for notification id exists no new entry is created`() {
     // Given
     val application = createApplicationAndSave(applicationStatus = ACCEPTED)
-    val visit = createVisitAndSave(VisitStatus.BOOKED, application)
+    val visit = createVisitAndSave(VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, application)
     val eventAudit = eventAuditEntityHelper.create(
       reference = visit.reference,
       text = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/prison/PrisonExcludeDatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/prison/PrisonExcludeDatesTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.admin.ADMIN_PRISON
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ExcludeDateDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonDateBlockedDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.PrisonEntityHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitNotificationEventHelper
@@ -163,7 +164,7 @@ class PrisonExcludeDatesTest : IntegrationTestBase() {
     createApplicationAndVisit(sessionTemplate = sessionTemplateDefault, visitStatus = VisitStatus.BOOKED, slotDate = excludeDate)
 
     // cancelled visit for excludeDate in same prison
-    createApplicationAndVisit(sessionTemplate = sessionTemplateXYZ, visitStatus = VisitStatus.CANCELLED, slotDate = excludeDate)
+    createApplicationAndVisit(sessionTemplate = sessionTemplateXYZ, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, slotDate = excludeDate)
 
     // existing visit different excludeDate in same prison
     createApplicationAndVisit(sessionTemplate = sessionTemplateXYZ, visitStatus = VisitStatus.BOOKED, slotDate = excludeDate.plusDays(1))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetAvailableSessionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetAvailableSessionsTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.AvailableVisitSessionDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.submitApplication
@@ -1710,6 +1711,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       visitEnd = endTime.toLocalTime(),
       visitType = SOCIAL,
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       visitRestriction = VisitRestriction.OPEN,
       sessionTemplate = sessionTemplate,
     )
@@ -1866,6 +1868,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       visitEnd = endTime.toLocalTime(),
       visitType = SOCIAL,
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       visitRestriction = VisitRestriction.CLOSED,
       sessionTemplate = sessionTemplate,
     )
@@ -2263,6 +2266,7 @@ class GetAvailableSessionsTest : IntegrationTestBase() {
       visitEnd = LocalTime.of(9, 30),
       visitType = SOCIAL,
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       visitRestriction = VisitRestriction.OPEN,
       sessionTemplate = sessionTemplate,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.CL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.VisitSessionDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.AllowedSessionLocationHierarchy
@@ -1121,6 +1122,7 @@ class GetSessionsTest : IntegrationTestBase() {
       visitEnd = endTime.toLocalTime(),
       visitType = SOCIAL,
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       visitRestriction = OPEN,
       sessionTemplate = sessionTemplate,
     )
@@ -1263,6 +1265,7 @@ class GetSessionsTest : IntegrationTestBase() {
       visitEnd = endTime.toLocalTime(),
       visitType = SOCIAL,
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       visitRestriction = CLOSED,
       sessionTemplate = sessionTemplate,
     )
@@ -1669,6 +1672,7 @@ class GetSessionsTest : IntegrationTestBase() {
       visitEnd = LocalTime.of(9, 30),
       visitType = SOCIAL,
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       visitRestriction = OPEN,
       sessionTemplate = sessionTemplate,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/SessionTemplateExcludeDatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/SessionTemplateExcludeDatesTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.admin.ADMIN_PRISON
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ExcludeDateDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.SessionDateBlockedDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitNotificationEventHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callAddSessionTemplateExcludeDate
@@ -158,7 +159,7 @@ class SessionTemplateExcludeDatesTest : IntegrationTestBase() {
     createApplicationAndVisit(sessionTemplate = sessionTemplate2, visitStatus = VisitStatus.BOOKED, slotDate = excludeDate)
 
     // cancelled visit for excludeDate for same session
-    createApplicationAndVisit(sessionTemplate = sessionTemplate1, visitStatus = VisitStatus.CANCELLED, slotDate = excludeDate)
+    createApplicationAndVisit(sessionTemplate = sessionTemplate1, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, slotDate = excludeDate)
 
     // existing visit different excludeDate for same session
     createApplicationAndVisit(sessionTemplate = sessionTemplate1, visitStatus = VisitStatus.BOOKED, slotDate = excludeDate.plusDays(1))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/task/ReportVisitCountsTaskTelemetryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/task/ReportVisitCountsTaskTelemetryTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VSIPReport
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestSessionTemplateRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.task.ReportingTask
@@ -76,9 +77,9 @@ class ReportVisitCountsTaskTelemetryTest : IntegrationTestBase() {
     val prison1 = prisonEntityHelper.create("ABC", activePrison = true, excludeDates = emptyList())
     val sessionTemplate = sessionTemplateEntityHelper.create(prison = prison1, validFromDate = reportDate.minusMonths(3), weeklyFrequency = 1, dayOfWeek = reportDate.dayOfWeek, startTime = LocalTime.of(11, 0), endTime = LocalTime.of(13, 0), openCapacity = 100, closedCapacity = 35)
     visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.BOOKED, visitRestriction = VisitRestriction.OPEN, sessionTemplate = sessionTemplate, slotDate = reportDate)
-    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, visitRestriction = VisitRestriction.OPEN, sessionTemplate = sessionTemplate, outcomeStatus = OutcomeStatus.ADMINISTRATIVE_CANCELLATION, slotDate = reportDate)
+    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, visitRestriction = VisitRestriction.OPEN, sessionTemplate = sessionTemplate, outcomeStatus = OutcomeStatus.ADMINISTRATIVE_CANCELLATION, slotDate = reportDate)
     visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.BOOKED, visitRestriction = VisitRestriction.CLOSED, sessionTemplate = sessionTemplate, slotDate = reportDate)
-    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, visitRestriction = VisitRestriction.CLOSED, sessionTemplate = sessionTemplate, outcomeStatus = OutcomeStatus.ADMINISTRATIVE_CANCELLATION, slotDate = reportDate)
+    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, visitRestriction = VisitRestriction.CLOSED, sessionTemplate = sessionTemplate, outcomeStatus = OutcomeStatus.ADMINISTRATIVE_CANCELLATION, slotDate = reportDate)
 
     // When
     val sessionsReport = reportingTask.getVisitCountsReportByDay()[reportDate]!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/task/ReportVisitCountsTaskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/task/ReportVisitCountsTaskTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VSIPReport
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.reporting.SessionVisitCountsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -92,9 +93,9 @@ class ReportVisitCountsTaskTest : IntegrationTestBase() {
     // visit 5 against sessionTemplate6Prison1, OPEN and RESERVED - not included in counts
     applicationEntityHelper.create(prisonCode = prison1.code, sessionTemplate = sessionTemplate6Prison1, slotDate = reportDate, applicationStatus = ACCEPTED)
     // visit 6 against sessionTemplate6Prison1, OPEN and CANCELLED - included in openCancelledCount
-    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, sessionTemplate = sessionTemplate6Prison1, slotDate = reportDate, outcomeStatus = OutcomeStatus.ADMINISTRATIVE_CANCELLATION)
+    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplate6Prison1, slotDate = reportDate, outcomeStatus = OutcomeStatus.ADMINISTRATIVE_CANCELLATION)
     // visit 7 against sessionTemplate6Prison1, OPEN and CANCELLED but SUPERSEDED_CANCELLATION - included in closedBookedCount as outcomeStatus does not matter anymore
-    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, sessionTemplate = sessionTemplate6Prison1, slotDate = reportDate, outcomeStatus = OutcomeStatus.SUPERSEDED_CANCELLATION)
+    visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplate6Prison1, slotDate = reportDate, outcomeStatus = OutcomeStatus.SUPERSEDED_CANCELLATION)
 
     // visit 1 against sessionTemplate7Prison1, OPEN and BOOKED
     visitEntityHelper.create(prisonCode = prison1.code, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate7Prison1, slotDate = reportDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitValidationTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryTyp
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.prison.api.VisitBalancesDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.prisonersearch.PrisonerSearchResultDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.AllowedSessionLocationHierarchy
@@ -547,6 +548,7 @@ class BookVisitValidationTest : IntegrationTestBase() {
       prisonerId = prisonerId,
       slotDate = reservedPublicApplication.sessionSlot.slotDate,
       visitStatus = VisitStatus.CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       prisonCode = reservedPublicApplication.prison.code,
     )
 
@@ -572,6 +574,7 @@ class BookVisitValidationTest : IntegrationTestBase() {
       prisonerId = prisonerId,
       slotDate = reservedStaffApplication.sessionSlot.slotDate,
       visitStatus = VisitStatus.CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       prisonCode = reservedStaffApplication.prison.code,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FindCancelledPublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FindCancelledPublicVisitsTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_CANCELLED_PUBL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitAssertHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
@@ -43,19 +44,19 @@ class FindCancelledPublicVisitsTest : IntegrationTestBase() {
   internal fun createVisits() {
     otherSessionTemplate = sessionTemplateEntityHelper.create(prisonCode = "AWE")
 
-    visitCancelledLeastRecent = createVisit(prisonerId = "least recent", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 4)
+    visitCancelledLeastRecent = createVisit(prisonerId = "least recent", actionedByValue = "aTestRef", visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 4)
 
-    visitCancelledInDifferentPrison = createVisit(prisonerId = "diff prison", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = otherSessionTemplate, PUBLIC, slotDateWeeks = 3)
+    visitCancelledInDifferentPrison = createVisit(prisonerId = "diff prison", actionedByValue = "aTestRef", visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplate = otherSessionTemplate, PUBLIC, slotDateWeeks = 3)
 
-    visitWithOtherBooker = createVisit(prisonerId = "diff prison", actionedByValue = "aOtherTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 2)
+    visitWithOtherBooker = createVisit(prisonerId = "diff prison", actionedByValue = "aOtherTestRef", visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = 2)
 
-    visitCancelledInPast = createVisit(prisonerId = "in past", actionedByValue = "aTestRef", visitStatus = CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = -1)
+    visitCancelledInPast = createVisit(prisonerId = "in past", actionedByValue = "aTestRef", visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplateDefault, PUBLIC, slotDateWeeks = -1)
 
-    createVisit(actionedByValue = "aTestRef", visitStatus = BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
+    createVisit(actionedByValue = "aTestRef", visitStatus = BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
 
-    createVisit(actionedByValue = "aTestRef", visitStatus = BOOKED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = -1)
+    createVisit(actionedByValue = "aTestRef", visitStatus = BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = -1)
 
-    visitCancelledMostRecent = createVisit(prisonerId = "most recent", actionedByValue = "aTestRef", CANCELLED, sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
+    visitCancelledMostRecent = createVisit(prisonerId = "most recent", actionedByValue = "aTestRef", CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, sessionTemplateDefault, userType = PUBLIC, slotDateWeeks = 1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FuturePublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FuturePublicVisitsTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_FUTURE_BOOKED_
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitAssertHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
@@ -52,24 +53,24 @@ class FuturePublicVisitsTest : IntegrationTestBase() {
     // session template that has started 1 minute back
     sessionTemplate2 = sessionTemplateEntityHelper.create(prisonCode = "DFT", startTime = LocalTime.now().minusMinutes(1), endTime = LocalTime.now().plusHours(1))
 
-    visitFarInTheFuture = createVisit(prisonerId = "visit far away", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 6)
+    visitFarInTheFuture = createVisit(prisonerId = "visit far away", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 6)
 
-    visitInDifferentPrison = createVisit(prisonerId = "visit different prison", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = otherSessionTemplate, userType = PUBLIC, slotDateWeeks = 4)
+    visitInDifferentPrison = createVisit(prisonerId = "visit different prison", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, sessionTemplate = otherSessionTemplate, userType = PUBLIC, slotDateWeeks = 4)
 
-    nearestVisitAfterToday = createVisit(prisonerId = "nearest visit after today", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 1)
+    nearestVisitAfterToday = createVisit(prisonerId = "nearest visit after today", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 1)
 
     // this visit is for a session template that started 1 minute back
-    pastVisitToday = createVisit(prisonerId = "today's visit in past", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate2, userType = PUBLIC, slotDateWeeks = 0)
+    pastVisitToday = createVisit(prisonerId = "today's visit in past", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate2, userType = PUBLIC, slotDateWeeks = 0)
     // this visit is for a session template that started 5 minutes after
-    futureVisitToday = createVisit(prisonerId = "today's visit in future", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 0)
+    futureVisitToday = createVisit(prisonerId = "today's visit in future", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 0)
 
-    var visitInPast = createVisit(prisonerId = "visit", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
+    var visitInPast = createVisit(prisonerId = "visit", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
 
-    var visitBookerByStaff = createVisit(prisonerId = "visit", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = STAFF, slotDateWeeks = 1)
+    var visitBookerByStaff = createVisit(prisonerId = "visit", actionedByValue = "aTestRef", visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = STAFF, slotDateWeeks = 1)
 
-    var visitCancelled = createVisit(prisonerId = "visit", actionedByValue = "aTestRef", visitStatus = VisitStatus.CANCELLED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 1)
+    var visitCancelled = createVisit(prisonerId = "visit", actionedByValue = "aTestRef", visitStatus = VisitStatus.CANCELLED, VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 1)
 
-    visitWithOtherBooker = createVisit(prisonerId = "visit with other broker", actionedByValue = "aOtherTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 2)
+    visitWithOtherBooker = createVisit(prisonerId = "visit with other broker", actionedByValue = "aOtherTestRef", visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 2)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FutureVisitsSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FutureVisitsSearchTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_CONTROLLER_S
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
@@ -32,9 +33,9 @@ class FutureVisitsSearchTest : IntegrationTestBase() {
     sessionTemplateFromNowTimes = sessionTemplateEntityHelper.create(validFromDate = LocalDate.now(), startTime = LocalTime.now().plusHours(1))
 
     beforeNowVisit = createApplicationAndVisit(prisonerId = "FF0000AA", sessionTemplate = sessionTemplateBeforeNowTimes, slotDate = sessionTemplateBeforeNowTimes.validFromDate, visitStatus = BOOKED, visitRestriction = VisitRestriction.OPEN)
-    vist1 = createApplicationAndVisit(prisonerId = "FF0000AA", sessionTemplate = sessionTemplateFromNowTimes, visitStatus = BOOKED, visitRestriction = VisitRestriction.OPEN)
-    vist2 = createApplicationAndVisit(prisonerId = "FF0000AA", sessionTemplate = sessionTemplateFromNowTimes, visitStatus = CANCELLED, visitRestriction = VisitRestriction.OPEN)
-    vist3 = createApplicationAndVisit(prisonerId = "GG0000BB", sessionTemplate = sessionTemplateFromNowTimes, visitStatus = BOOKED, visitRestriction = VisitRestriction.OPEN)
+    vist1 = createApplicationAndVisit(prisonerId = "FF0000AA", sessionTemplate = sessionTemplateFromNowTimes, visitStatus = BOOKED, VisitSubStatus.AUTO_APPROVED, visitRestriction = VisitRestriction.OPEN)
+    vist2 = createApplicationAndVisit(prisonerId = "FF0000AA", sessionTemplate = sessionTemplateFromNowTimes, visitStatus = CANCELLED, VisitSubStatus.CANCELLED, visitRestriction = VisitRestriction.OPEN)
+    vist3 = createApplicationAndVisit(prisonerId = "GG0000BB", sessionTemplate = sessionTemplateFromNowTimes, visitStatus = BOOKED, VisitSubStatus.AUTO_APPROVED, visitRestriction = VisitRestriction.OPEN)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/IgnoreVisitNotificationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/IgnoreVisitNotificationsTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitNotificationEventHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callIgnoreVisitNotifications
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.getIgnoreVisitNotificationsUrl
@@ -103,7 +104,7 @@ class IgnoreVisitNotificationsTest : IntegrationTestBase() {
   @Test
   fun `when ignore visit notifications raised for cancelled visit then NOT_FOUND status is returned`() {
     // Given
-    val visit = visitEntityHelper.create(visitStatus = CANCELLED, slotDate = startDate, sessionTemplate = sessionTemplateDefault, visitContact = ContactDto("Jane Doe", "01111111111", "email@example.com"))
+    val visit = visitEntityHelper.create(visitStatus = CANCELLED, VisitSubStatus.CANCELLED, slotDate = startDate, sessionTemplate = sessionTemplateDefault, visitContact = ContactDto("Jane Doe", "01111111111", "email@example.com"))
     val reference = visit.reference
 
     val ignoreVisitNotification = IgnoreVisitNotificationsDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateCancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/MigrateCancelVisitTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.TelemetryVisitEvent
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason.VISIT_CANCELLED_ON_NOMIS
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitNotificationEventHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callMigrateCancelVisit
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.getMigrateCancelVisitUrl
@@ -87,7 +88,7 @@ class MigrateCancelVisitTest : MigrationIntegrationTestBase() {
     // Given
 
     val application = createApplicationAndSave(applicationStatus = ACCEPTED, sessionTemplate = sessionTemplateDefault)
-    val visit = createVisitAndSave(visitStatus = BOOKED, application, sessionTemplateDefault)
+    val visit = createVisitAndSave(visitStatus = BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, application, sessionTemplateDefault)
 
     val cancelVisitDto = MigratedCancelVisitDto(
       OutcomeDto(
@@ -126,7 +127,7 @@ class MigrateCancelVisitTest : MigrationIntegrationTestBase() {
   fun `when visit cancelled that has notification events then notification events are deleted and an unflag event is sent`() {
     // Given
     val application = createApplicationAndSave(applicationStatus = ACCEPTED, sessionTemplate = sessionTemplateDefault)
-    val visit = createVisitAndSave(visitStatus = BOOKED, application, sessionTemplateDefault)
+    val visit = createVisitAndSave(visitStatus = BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, application, sessionTemplateDefault)
     visitNotificationEventHelper.create(visit, NotificationEventType.NON_ASSOCIATION_EVENT)
     visitNotificationEventHelper.create(visit, NotificationEventType.PRISONER_RESTRICTION_CHANGE_EVENT)
     visitNotificationEventHelper.create(visit, NotificationEventType.PRISONER_RELEASED_EVENT)
@@ -178,7 +179,7 @@ class MigrateCancelVisitTest : MigrationIntegrationTestBase() {
     // Given
     // past dated visit - for yesterday
     val application = createApplicationAndSave(applicationStatus = ACCEPTED, sessionTemplate = sessionTemplateDefault, slotDate = LocalDate.now().minusDays(1))
-    val visit = createVisitAndSave(visitStatus = BOOKED, application, sessionTemplateDefault)
+    val visit = createVisitAndSave(visitStatus = BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, application, sessionTemplateDefault)
     visitNotificationEventHelper.create(visit, NotificationEventType.NON_ASSOCIATION_EVENT)
     visitNotificationEventHelper.create(visit, NotificationEventType.PRISONER_RESTRICTION_CHANGE_EVENT)
     visitNotificationEventHelper.create(visit, NotificationEventType.PRISONER_RELEASED_EVENT)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/PastPublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/PastPublicVisitsTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_PAST_BOOKED_PU
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitAssertHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
@@ -58,24 +59,24 @@ class PastPublicVisitsTest : IntegrationTestBase() {
     // session template that has a start time 5 minutes in the future
     otherSessionTemplate = sessionTemplateEntityHelper.create(prisonCode = "AWE")
 
-    visitFarInThePast = createVisit(prisonerId = "visit far in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -6)
+    visitFarInThePast = createVisit(prisonerId = "visit far in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -6)
 
-    visitInDifferentPrison = createVisit(prisonerId = "visit different prison", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -4)
+    visitInDifferentPrison = createVisit(prisonerId = "visit different prison", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -4)
 
-    nearestPastVisitBeforeToday = createVisit(prisonerId = "nearest visit in past before today", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
+    nearestPastVisitBeforeToday = createVisit(prisonerId = "nearest visit in past before today", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
 
     // this visit is for a session template that started 1 minute back
-    pastVisitToday = createVisit(prisonerId = "today's visit in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate2, userType = PUBLIC, slotDateWeeks = 0)
+    pastVisitToday = createVisit(prisonerId = "today's visit in past", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate2, userType = PUBLIC, slotDateWeeks = 0)
     // this visit is for a session template that started 5 minutes after
-    futureVisitToday = createVisit(prisonerId = "today's visit in future", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 0)
+    futureVisitToday = createVisit(prisonerId = "today's visit in future", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 0)
 
-    var visitInFuture = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 1)
+    var visitInFuture = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = 1)
 
-    var visitBookerByStaff = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = STAFF, slotDateWeeks = -1)
+    var visitBookerByStaff = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = STAFF, slotDateWeeks = -1)
 
-    var visitCancelled = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.CANCELLED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
+    var visitCancelled = createVisit(prisonerId = "visit", actionedByValue = defaultBookerReference, visitStatus = VisitStatus.CANCELLED, VisitSubStatus.CANCELLED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -1)
 
-    visitWithOtherBooker = createVisit(prisonerId = "visit with other broker", actionedByValue = "aOtherTestRef", visitStatus = VisitStatus.BOOKED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -2)
+    visitWithOtherBooker = createVisit(prisonerId = "visit with other broker", actionedByValue = "aOtherTestRef", visitStatus = VisitStatus.BOOKED, VisitSubStatus.AUTO_APPROVED, sessionTemplate = sessionTemplate1, userType = PUBLIC, slotDateWeeks = -2)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitByReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitByReferenceTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.GET_VISIT_BY_REFER
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ContactDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callVisitByReference
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import java.time.LocalDate
@@ -70,7 +71,7 @@ class VisitByReferenceTest : IntegrationTestBase() {
   fun `Canceled visit by reference`() {
     // Given
     val slotDate = sessionDatesUtil.getFirstBookableSessionDay(sessionTemplateDefault)
-    val createdVisit = visitEntityHelper.create(prisonerId = "FF0000AA", visitStatus = CANCELLED, slotDate = slotDate, sessionTemplate = sessionTemplateDefault, visitContact = ContactDto("Jane Doe", "01111111111", "email@example.com"))
+    val createdVisit = visitEntityHelper.create(prisonerId = "FF0000AA", visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, slotDate = slotDate, sessionTemplate = sessionTemplateDefault, visitContact = ContactDto("Jane Doe", "01111111111", "email@example.com"))
 
     val reference = createdVisit.reference
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByFilterTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitNoteType.VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.VisitAssertHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
@@ -53,7 +54,7 @@ class VisitsByFilterTest : IntegrationTestBase() {
     visitEntityHelper.createNote(visit = visit, text = "A visit concern", type = VISITOR_CONCERN)
     visitEntityHelper.save(visit)
 
-    visitCancelled = createApplicationAndVisit(prisonerId = "FF0000CC", slotDate = startDate.plusDays(3), sessionTemplate = sessionTemplateDefault, visitStatus = CANCELLED)
+    visitCancelled = createApplicationAndVisit(prisonerId = "FF0000CC", slotDate = startDate.plusDays(3), sessionTemplate = sessionTemplateDefault, visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED)
     visitEntityHelper.createNote(visit = visitCancelled, text = "A visit concern", type = VISITOR_CONCERN)
     visitCancelled.outcomeStatus = OutcomeStatus.CANCELLATION
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.OP
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
@@ -49,7 +50,7 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     // visit 1 booked for session template reference - session-1
     visit1 = createApplicationAndVisit(slotDate = LocalDate.now(), prisonerId = "FF0000AA", sessionTemplate = sessionTemplateDefault, visitStatus = BOOKED, visitRestriction = OPEN)
     // visit 2 cancelled for session template reference - session-1
-    visit2 = createApplicationAndVisit(slotDate = LocalDate.now(), prisonerId = "FF0000AA", sessionTemplate = sessionTemplateDefault, visitStatus = CANCELLED, visitRestriction = OPEN)
+    visit2 = createApplicationAndVisit(slotDate = LocalDate.now(), prisonerId = "FF0000AA", sessionTemplate = sessionTemplateDefault, visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, visitRestriction = OPEN)
     // visit 3 booked for session template reference - session-2
     visit3 = createApplicationAndVisit(slotDate = LocalDate.now(), prisonerId = "FF0000AA", sessionTemplate = sessionTemplate2, visitStatus = BOOKED, visitRestriction = OPEN)
     // visit 4 booked for session template reference - session-1 but on next day
@@ -59,11 +60,11 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     // session template reference is null and status is BOOKED
     visit6 = createApplicationAndVisit(prisonerId = "FF0000BB", visitStatus = BOOKED, slotDate = LocalDate.now().plusDays(1), prisonCode = "MDI")
     // session template reference is null and status is CANCELLED
-    visit7 = createApplicationAndVisit(prisonerId = "FF0000BB", visitStatus = CANCELLED, slotDate = LocalDate.now().plusDays(1), prisonCode = "MDI")
+    visit7 = createApplicationAndVisit(prisonerId = "FF0000BB", visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, slotDate = LocalDate.now().plusDays(1), prisonCode = "MDI")
 
     // session template reference is null and status is BOOKED but prison is different (DFT)
     createApplicationAndVisit(prisonerId = "FF0000BB", visitStatus = BOOKED, slotDate = LocalDate.now().plusDays(1), prisonCode = prisonDFT.code)
-    createApplicationAndVisit(prisonerId = "FF0000BB", visitStatus = CANCELLED, slotDate = LocalDate.now().plusDays(1), prisonCode = prisonDFT.code)
+    createApplicationAndVisit(prisonerId = "FF0000BB", visitStatus = CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, slotDate = LocalDate.now().plusDays(1), prisonCode = prisonDFT.code)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/application/ChangeReservedSlotThatHasABookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/application/ChangeReservedSlotThatHasABookingTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.CLOSED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callVisitReserveSlotChange
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
@@ -59,7 +60,7 @@ class ChangeReservedSlotThatHasABookingTest : IntegrationTestBase() {
   internal fun setUp() {
     roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
 
-    oldBooking = createApplicationAndVisit("test", sessionTemplateDefault, BOOKED, LocalDate.now())
+    oldBooking = createApplicationAndVisit("test", sessionTemplateDefault, BOOKED, VisitSubStatus.AUTO_APPROVED, LocalDate.now())
     oldApplication = oldBooking.getLastApplication()!!
 
     newRestriction = if (oldBooking.visitRestriction == OPEN) CLOSED else OPEN

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CountVisitNotificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CountVisitNotificationTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.PRISON_VISITS_BLOCKED_FOR_DATE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callCountVisitNotification
 import java.time.LocalDate
 import java.time.LocalTime
@@ -90,6 +91,7 @@ class CountVisitNotificationTest : NotificationTestBase() {
       prisonerId = primaryPrisonerId,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       prisonCode = sessionTemplateDefault.prison.code,
       sessionTemplate = sessionTemplateDefault,
     )
@@ -99,6 +101,7 @@ class CountVisitNotificationTest : NotificationTestBase() {
       prisonerId = secondaryPrisonerId,
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       prisonCode = sessionTemplateDefault.prison.code,
       sessionTemplate = sessionTemplateDefault,
     )
@@ -108,6 +111,7 @@ class CountVisitNotificationTest : NotificationTestBase() {
       prisonerId = secondaryPrisonerId,
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       prisonCode = sessionTemplateDefault.prison.code,
       sessionTemplate = sessionTemplateDefault,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CreateNonAssociationVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CreateNonAssociationVisitNotificationControllerTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NonAssociationChangedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.VisitNotificationEventAttributeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatNonAssociationHasChanged
@@ -831,6 +832,7 @@ class CreateNonAssociationVisitNotificationControllerTest : NotificationTestBase
       prisonerId = primaryPrisonerId,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PersonRestrictionUpsertedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PersonRestrictionUpsertedNotificationControllerTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PersonRestrictionUpsertedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatPersonRestrictionUpserted
@@ -104,6 +105,7 @@ class PersonRestrictionUpsertedNotificationControllerTest : NotificationTestBase
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = otherSessionTemplate,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonExcludeDateNotificatonEventsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonExcludeDateNotificatonEventsTest.kt
@@ -70,7 +70,7 @@ class PrisonExcludeDateNotificatonEventsTest : NotificationTestBase() {
     createApplicationAndVisit(sessionTemplate = sessionTemplateMSI, visitStatus = VisitStatus.BOOKED, slotDate = excludeDate)
 
     // cancelled visit for excludeDate in same prison
-    createApplicationAndVisit(sessionTemplate = sessionTemplateXYZ, visitStatus = VisitStatus.CANCELLED, slotDate = excludeDate)
+    createApplicationAndVisit(sessionTemplate = sessionTemplateXYZ, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.CANCELLED, slotDate = excludeDate)
     // existing visit not for excludeDate in same prison
     createApplicationAndVisit(sessionTemplate = sessionTemplateXYZ, visitStatus = VisitStatus.BOOKED, slotDate = excludeDate.plusDays(1))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonExcludeDateNotificatonEventsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonExcludeDateNotificatonEventsTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonDateBlockedDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.SessionSlotEntityHelper
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callAddPrisonExcludeDate
@@ -187,7 +188,7 @@ class PrisonExcludeDateNotificatonEventsTest : NotificationTestBase() {
 
     // existing visit for excludeDate in same prison
     val application = createApplicationAndSave(sessionTemplate = sessionTemplateXYZ, prisonCode = prisonXYZ.code, applicationStatus = ACCEPTED, slotDate = excludeDate)
-    val bookedVisit = createVisitAndSave(VisitStatus.BOOKED, application, sessionTemplateXYZ)
+    val bookedVisit = createVisitAndSave(VisitStatus.BOOKED, visitSubStatus = VisitSubStatus.AUTO_APPROVED, application, sessionTemplateXYZ)
 
     // When
     // call add exclude dates first

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertCreatedUpdatedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertCreatedUpdatedVisitNotificationControllerTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonerAlertCreatedUpdatedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatPrisonerAlertHasBeenCreatedOrUpdated
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -78,6 +79,7 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().minusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -93,6 +95,7 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -168,6 +171,7 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -232,6 +236,7 @@ class PrisonerAlertCreatedUpdatedVisitNotificationControllerTest : NotificationT
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReceivedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReceivedVisitNotificationControllerTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonerReceivedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatPrisonerHadBeenReceived
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -100,6 +101,7 @@ class PrisonerReceivedVisitNotificationControllerTest : NotificationTestBase() {
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().minusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerReleaseReas
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonerReleasedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatPrisonerHadBeenReleased
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -73,6 +74,7 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().minusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -88,6 +90,7 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -151,6 +154,7 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(3),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerVisitRestrictionChangeNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerVisitRestrictionChangeNotificationControllerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonerRestrictionChangeNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatPrisonerRestrictionHasChanged
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -70,6 +71,7 @@ class PrisonerVisitRestrictionChangeNotificationControllerTest : NotificationTes
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().minusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -85,6 +87,7 @@ class PrisonerVisitRestrictionChangeNotificationControllerTest : NotificationTes
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 
@@ -149,6 +152,7 @@ class PrisonerVisitRestrictionChangeNotificationControllerTest : NotificationTes
       prisonerId = notificationDto.prisonerNumber,
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate1,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorRestrictionUpsertedNotificationControllerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.VisitorRestrictionUpsertedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatVisitorRestrictionUpserted
@@ -107,6 +108,7 @@ class VisitorRestrictionUpsertedNotificationControllerTest : NotificationTestBas
     val visit3 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = otherPrisonSessionTemplate,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
@@ -85,6 +85,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     val visit2 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate,
       prisonerId = prisonerId,
     )
@@ -163,6 +164,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     val visit2 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate,
       prisonerId = prisonerId,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.CANCELLED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.prisonercontactregistry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.VisitorApprovedUnapprovedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatVisitorUnapproved
@@ -247,6 +248,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     val visit2 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate,
       prisonerId = prisonerId,
     )
@@ -324,6 +326,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     val visit2 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(2),
       visitStatus = CANCELLED,
+      visitSubStatus = VisitSubStatus.CANCELLED,
       sessionTemplate = sessionTemplate,
       prisonerId = prisonerId,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.CL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.OPEN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction.UNKNOWN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType.SOCIAL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.prison.api.OtherPrisonerDetails
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.prison.api.PrisonerHousingLevels
@@ -334,6 +335,7 @@ class SessionServiceTest {
         prisonId = prison.id,
         prison = prison,
         visitStatus = BOOKED,
+        visitSubStatus = VisitSubStatus.AUTO_APPROVED,
         visitRestriction = OPEN,
         visitRoom = "1",
         userType = STAFF,
@@ -347,6 +349,7 @@ class SessionServiceTest {
         prisonId = prison.id,
         prison = prison,
         visitStatus = BOOKED,
+        visitSubStatus = VisitSubStatus.AUTO_APPROVED,
         visitRestriction = OPEN,
         visitRoom = "1",
         userType = STAFF,
@@ -360,6 +363,7 @@ class SessionServiceTest {
         prisonId = prison.id,
         prison = prison,
         visitStatus = BOOKED,
+        visitSubStatus = VisitSubStatus.AUTO_APPROVED,
         visitRestriction = CLOSED,
         visitRoom = "1",
         userType = STAFF,
@@ -406,6 +410,7 @@ class SessionServiceTest {
         prisonId = prison.id,
         prison = prison,
         visitStatus = BOOKED,
+        visitSubStatus = VisitSubStatus.AUTO_APPROVED,
         visitRestriction = UNKNOWN,
         visitRoom = "1",
         userType = STAFF,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitNoteType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.exception.PrisonNotFoundException
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -109,6 +110,7 @@ internal class VisitStoreServiceTest {
       visitRestriction = createVisitFromExternalSystemDto.visitRestriction,
       visitRoom = createVisitFromExternalSystemDto.visitRoom,
       visitStatus = VisitStatus.BOOKED,
+      visitSubStatus = VisitSubStatus.AUTO_APPROVED,
       userType = UserType.PRISONER,
     )
 
@@ -201,6 +203,7 @@ internal class VisitStoreServiceTest {
       visitRestriction = updateVisitFromExternalSystemDto.visitRestriction,
       visitRoom = updateVisitFromExternalSystemDto.visitRoom,
       visitStatus = VisitStatus.BOOKED,
+      visitSubStatus = VisitSubStatus.AUTO_APPROVED,
       userType = UserType.PRISONER,
     )
 


### PR DESCRIPTION
## What does this pull request do?

This sub status will be used to determine if a visit is requested (non-instant booking).

Add new column to Visit DB table and model, also enforce checks to stop the VisitStatus and VisitSubStatus getting out of sync at DB level.

Fix all tests.
