### PR TITLE
VB-5606 - Allow booked visits to be request visits

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,6 +18,7 @@ generic-service:
     BOOKING_NOTICE_PERIOD_MAXIMUM_DAYS: 50
     TASK_VISIT_COUNTS_REPORT_CRON: "0 0 0/1 * * ?" #every hour on dev
     TASK_FLAG_VISITS_CRON: "0 0 0/4 * * ?" #every 4 hours on dev
+    FEATURE_REQUEST-BOOKING-ENABLED: false
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,7 +18,7 @@ generic-service:
     BOOKING_NOTICE_PERIOD_MAXIMUM_DAYS: 50
     TASK_VISIT_COUNTS_REPORT_CRON: "0 0 0/1 * * ?" #every hour on dev
     TASK_FLAG_VISITS_CRON: "0 0 0/4 * * ?" #every 4 hours on dev
-    FEATURE_REQUEST-BOOKING-ENABLED: false
+    FEATURE_REQUEST-BOOKING-ENABLED: true
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -30,6 +30,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     FEATURE_EVENTS_SNS_ENABLED: true
     MIGRATE_SESSIONTEMPLATE_MAPPING_OFFSET_DAYS: 0
+    FEATURE_REQUEST-BOOKING-ENABLED: false
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -30,6 +30,7 @@ generic-service:
     PRISONER-CONTACT_REGISTRY_URL: https://prisoner-contact-registry.prison.service.justice.gov.uk
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     FEATURE_EVENTS_SNS_ENABLED: true
+    FEATURE_REQUEST-BOOKING-ENABLED: false
 
   postgresDatabaseRestore:
     enabled: true

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -16,7 +16,7 @@ generic-service:
     PRISONER-CONTACT_REGISTRY_URL: https://prisoner-contact-registry-dev.prison.service.justice.gov.uk
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     FEATURE_EVENTS_SNS_ENABLED: false
-    FEATURE_REQUEST-BOOKING-ENABLED: false
+    FEATURE_REQUEST-BOOKING-ENABLED: true
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -16,6 +16,7 @@ generic-service:
     PRISONER-CONTACT_REGISTRY_URL: https://prisoner-contact-registry-dev.prison.service.justice.gov.uk
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     FEATURE_EVENTS_SNS_ENABLED: false
+    FEATURE_REQUEST-BOOKING-ENABLED: false
 
   scheduledDowntime:
     enabled: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/BookingRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/BookingRequestDto.kt
@@ -19,6 +19,5 @@ data class BookingRequestDto(
   @field:NotNull
   val userType: UserType,
   @Schema(description = "flag to determine if visit should be a request or instant booking", required = false)
-  @field:NotNull
   val isRequestBooking: Boolean? = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/BookingRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/BookingRequestDto.kt
@@ -18,4 +18,7 @@ data class BookingRequestDto(
   @Schema(description = "User type for user who actioned this request", required = true)
   @field:NotNull
   val userType: UserType,
+  @Schema(description = "flag to determine if visit should be a request or instant booking", required = false)
+  @field:NotNull
+  val isRequestBooking: Boolean? = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/VisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/VisitDto.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import java.time.LocalDateTime
 
@@ -31,6 +32,8 @@ data class VisitDto(
   val visitType: VisitType,
   @Schema(description = "Visit Status", example = "BOOKED", required = true)
   val visitStatus: VisitStatus,
+  @Schema(description = "Visit Sub Status", example = "AUTO_APPROVED", required = true)
+  val visitSubStatus: VisitSubStatus,
   @Schema(description = "Outcome Status", example = "VISITOR_CANCELLED", required = false)
   val outcomeStatus: OutcomeStatus? = null,
   @Schema(description = "Visit Restriction", example = "OPEN", required = true)
@@ -47,7 +50,7 @@ data class VisitDto(
   val visitContact: ContactDto,
   @Schema(description = "List of visitors associated with the visit", required = true)
   val visitors: List<VisitorDto> = listOf(),
-  @Schema(description = "Additional support associated with the visit", required = false)
+  @Schema(description = "Additional spport associated with the visit", required = false)
   val visitorSupport: VisitorSupportDto? = null,
   @Schema(description = "The visit created date and time", example = "2018-12-01T13:45:00", required = true)
   @field:NotNull

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/VisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/VisitDto.kt
@@ -50,7 +50,7 @@ data class VisitDto(
   val visitContact: ContactDto,
   @Schema(description = "List of visitors associated with the visit", required = true)
   val visitors: List<VisitorDto> = listOf(),
-  @Schema(description = "Additional spport associated with the visit", required = false)
+  @Schema(description = "Additional support associated with the visit", required = false)
   val visitorSupport: VisitorSupportDto? = null,
   @Schema(description = "The visit created date and time", example = "2018-12-01T13:45:00", required = true)
   @field:NotNull

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/builder/VisitDtoBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/builder/VisitDtoBuilder.kt
@@ -28,6 +28,7 @@ class VisitDtoBuilder {
       prisonCode = visitEntity.prison.code,
       visitRoom = visitEntity.visitRoom,
       visitStatus = visitEntity.visitStatus,
+      visitSubStatus = visitEntity.visitSubStatus,
       outcomeStatus = visitEntity.outcomeStatus,
       visitType = visitEntity.visitType,
       visitRestriction = visitEntity.visitRestriction,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
@@ -334,6 +334,7 @@ class TelemetryClientService(
     "prisonerId" to visitDto.prisonerId,
     "prisonId" to visitDto.prisonCode,
     "visitStatus" to visitDto.visitStatus.name,
+    "visitSubStatus" to visitDto.visitSubStatus.name,
     "visitRestriction" to visitDto.visitRestriction.name,
     "visitStart" to formatDateTimeToString(visitDto.startTimestamp),
     "visitEnd" to formatDateTimeToString(visitDto.endTimestamp),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreService.kt
@@ -105,7 +105,7 @@ class VisitStoreService(
       it.visitRestriction = application.restriction
       it.visitRoom = visitRoom
       it.visitStatus = BOOKED
-      // TODO [Request a visit feature]: Allow 'Requested' visits sub status to change.
+      // TODO [Request a visit feature]: Allow 'Requested' visits sub status to change during update flow.
       it
     } ?: run {
       // Create new booking

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -146,6 +146,7 @@ feature:
       enabled: true
 
 visit:
+  request-booking-enabled: false
   cancel:
     day-limit: 28
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookARequestedVisitFeatureDisabledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookARequestedVisitFeatureDisabledTest.kt
@@ -1,0 +1,175 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import org.springframework.transaction.annotation.Propagation.SUPPORTS
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_BOOK
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.BookingRequestDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationStatus.ACCEPTED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationStatus.IN_PROGRESS
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.prison.api.VisitBalancesDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.prisonersearch.PrisonerSearchResultDto
+import uk.gov.justice.digital.hmpps.visitscheduler.helper.callVisitBook
+import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Application
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestVisitRepository
+import java.time.format.DateTimeFormatter
+
+@Transactional(propagation = SUPPORTS)
+@DisplayName("PUT $VISIT_BOOK")
+@TestPropertySource(properties = ["feature.request-booking-enabled=false"])
+class BookARequestedVisitFeatureDisabledTest : IntegrationTestBase() {
+
+  private lateinit var roleVisitSchedulerHttpHeaders: (HttpHeaders) -> Unit
+
+  @Autowired
+  private lateinit var testVisitRepository: TestVisitRepository
+
+  @MockitoSpyBean
+  private lateinit var telemetryClient: TelemetryClient
+
+  private lateinit var reservedPublicApplication: Application
+
+  @BeforeEach
+  internal fun setUp() {
+    roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
+
+    reservedPublicApplication = applicationEntityHelper.create(sessionTemplate = sessionTemplateDefault, applicationStatus = IN_PROGRESS, userType = PUBLIC)
+    applicationEntityHelper.createContact(application = reservedPublicApplication, name = "Jane Doe", phone = "01234 098765", email = "email@example.com")
+    applicationEntityHelper.createVisitor(application = reservedPublicApplication, nomisPersonId = 321L, visitContact = true)
+    applicationEntityHelper.createSupport(application = reservedPublicApplication, description = "Some Text")
+    reservedPublicApplication = applicationEntityHelper.save(reservedPublicApplication)
+  }
+
+  @Test
+  fun `Book a requested visit feature disabled (booked via public application)`() {
+    // Given
+    val prisonerId = reservedPublicApplication.prisonerId
+    val applicationReference = reservedPublicApplication.reference
+    val prisonerDto = PrisonerSearchResultDto(prisonerNumber = prisonerId, prisonId = reservedPublicApplication.prison.code)
+    prisonOffenderSearchMockServer.stubGetPrisoner(prisonerId, prisonerDto)
+    prisonApiMockServer.stubGetVisitBalances(prisonerId, VisitBalancesDto(remainingVo = 5, remainingPvo = 5))
+
+    // When
+    val responseSpec = callVisitBook(
+      webTestClient,
+      roleVisitSchedulerHttpHeaders,
+      applicationReference,
+      userType = PUBLIC,
+      bookingRequestDto = BookingRequestDto("booking_guy", ApplicationMethodType.PHONE, false, PUBLIC, true),
+    )
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    val visitDto = getVisitDto(responseSpec)
+
+    assertVisitMatchesApplication(visitDto, reservedPublicApplication)
+    val visitEntity = testVisitRepository.findByReference(visitDto.reference)
+    assertAuditEvent(visitDto, visitEntity, PUBLIC)
+    assertThat(visitEntity.getApplications().size).isEqualTo(1)
+    assertThat(visitEntity.getLastApplication()?.reference).isEqualTo(applicationReference)
+    assertThat(visitEntity.getLastApplication()?.applicationStatus).isEqualTo(ACCEPTED)
+
+    assertBookedEvent(visitDto)
+  }
+
+  private fun assertAuditEvent(visitDto: VisitDto, visitEntity: Visit, userType: UserType = STAFF) {
+    val eventAudit = this.eventAuditRepository.findLastEventByBookingReference(visitDto.reference)
+    assertThat(eventAudit.type).isEqualTo(EventAuditType.BOOKED_VISIT)
+    assertThat(eventAudit.actionedBy).isNotNull()
+    assertThat(eventAudit.actionedBy.userType).isEqualTo(userType)
+    assertThat(eventAudit.actionedBy.userName).isNull()
+    assertThat(eventAudit.actionedBy.bookerReference).isEqualTo("booking_guy")
+    assertThat(eventAudit.applicationMethodType).isEqualTo(ApplicationMethodType.PHONE)
+    assertThat(eventAudit.bookingReference).isEqualTo(visitEntity.reference)
+    assertThat(eventAudit.sessionTemplateReference).isEqualTo(visitEntity.sessionSlot.sessionTemplateReference)
+    assertThat(eventAudit.applicationReference).isEqualTo(visitEntity.getLastApplication()!!.reference)
+  }
+
+  private fun assertVisitMatchesApplication(visitDto: VisitDto, application: Application) {
+    assertThat(visitDto.reference).isNotEmpty()
+    assertThat(visitDto.applicationReference).isEqualTo(application.reference)
+    assertThat(visitDto.prisonerId).isEqualTo(application.prisonerId)
+    assertThat(visitDto.prisonCode).isEqualTo(sessionTemplateDefault.prison.code)
+    assertThat(visitDto.visitRoom).isEqualTo(sessionTemplateDefault.visitRoom)
+    assertThat(visitDto.startTimestamp)
+      .isEqualTo(application.sessionSlot.slotStart)
+    assertThat(visitDto.endTimestamp)
+      .isEqualTo(application.sessionSlot.slotEnd)
+    assertThat(visitDto.visitType).isEqualTo(application.visitType)
+    assertThat(visitDto.visitStatus).isEqualTo(BOOKED)
+    assertThat(visitDto.visitRestriction).isEqualTo(application.restriction)
+    assertThat(visitDto.visitStatus).isEqualTo(BOOKED)
+    assertThat(visitDto.visitSubStatus).isEqualTo(VisitSubStatus.AUTO_APPROVED)
+    if (application.visitContact != null) {
+      assertThat(visitDto.visitContact.name).isEqualTo(application.visitContact!!.name)
+      assertThat(visitDto.visitContact.telephone).isEqualTo(application.visitContact!!.telephone)
+    } else {
+      assertThat(visitDto.visitContact).isNull()
+    }
+    assertThat(visitDto.visitors.size).isEqualTo(application.visitors.size)
+    assertThat(visitDto.visitors[0].nomisPersonId).isEqualTo(application.visitors[0].nomisPersonId)
+    assertThat(visitDto.visitors[0].visitContact).isEqualTo(application.visitors[0].contact!!)
+    assertThat(visitDto.visitorSupport?.description).isEqualTo(application.support?.description)
+    assertThat(visitDto.createdTimestamp).isNotNull()
+    assertThat(visitDto).isNotNull()
+    assertThat(visitDto.userType).isEqualTo(application.userType)
+  }
+
+  private fun assertBookedEvent(visit: VisitDto) {
+    val eventAudit = eventAuditRepository.findLastEventByBookingReference(visit.reference)
+
+    verify(telemetryClient).trackEvent(
+      eq("visit-booked"),
+      check {
+        assertThat(it["reference"]).isEqualTo(visit.reference)
+        assertThat(it["applicationReference"]).isEqualTo(visit.applicationReference)
+        assertThat(it["prisonerId"]).isEqualTo(visit.prisonerId)
+        assertThat(it["prisonId"]).isEqualTo(visit.prisonCode)
+        assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
+        assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
+        assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
+        assertThat(it["visitEnd"]).isEqualTo(visit.endTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
+        assertThat(it["visitType"]).isEqualTo(visit.visitType.name)
+        assertThat(it["visitRoom"]).isEqualTo(visit.visitRoom)
+        assertThat(it["hasPhoneNumber"]).isEqualTo((visit.visitContact.telephone != null).toString())
+        assertThat(it["hasEmail"]).isEqualTo((visit.visitContact.email != null).toString())
+        assertThat(it["supportRequired"]).isEqualTo(visit.visitorSupport?.description)
+        assertThat(it["totalVisitors"]).isEqualTo(visit.visitors.size.toString())
+        val commaDelimitedVisitorIds = visit.visitors.map { it.nomisPersonId }.joinToString(",")
+        assertThat(it["visitors"]).isEqualTo(commaDelimitedVisitorIds)
+        eventAudit.actionedBy.userName?.let { value ->
+          assertThat(it["actionedBy"]).isEqualTo(value)
+        }
+        assertThat(it["source"]).isEqualTo(eventAudit.actionedBy.userType.name)
+        assertThat(it["applicationMethodType"]).isEqualTo(eventAudit.applicationMethodType.name)
+      },
+      isNull(),
+    )
+    verify(telemetryClient, times(1)).trackEvent(eq("visit-booked"), any(), isNull())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookARequestedVisitFeatureDisabledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookARequestedVisitFeatureDisabledTest.kt
@@ -39,7 +39,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestVisitRepositor
 import java.time.format.DateTimeFormatter
 
 @Transactional(propagation = SUPPORTS)
-@DisplayName("PUT $VISIT_BOOK")
+@DisplayName("PUT $VISIT_BOOK requested visit feature - disabled")
 @TestPropertySource(properties = ["feature.request-booking-enabled=false"])
 class BookARequestedVisitFeatureDisabledTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookARequestedVisitFeatureDisabledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookARequestedVisitFeatureDisabledTest.kt
@@ -151,6 +151,7 @@ class BookARequestedVisitFeatureDisabledTest : IntegrationTestBase() {
         assertThat(it["prisonerId"]).isEqualTo(visit.prisonerId)
         assertThat(it["prisonId"]).isEqualTo(visit.prisonCode)
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
+        assertThat(it["visitSubStatus"]).isEqualTo(visit.visitSubStatus.name)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
         assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitEnd"]).isEqualTo(visit.endTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitTest.kt
@@ -86,7 +86,7 @@ class BookVisitTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Book a requested visit feature disabled (booked via public application)`() {
+  fun `Book a requested visit feature enabled (booked via public application)`() {
     // Given
     val prisonerId = reservedPublicApplication.prisonerId
     val applicationReference = reservedPublicApplication.reference
@@ -444,6 +444,7 @@ class BookVisitTest : IntegrationTestBase() {
         assertThat(it["prisonerId"]).isEqualTo(visit.prisonerId)
         assertThat(it["prisonId"]).isEqualTo(visit.prisonCode)
         assertThat(it["visitStatus"]).isEqualTo(visit.visitStatus.name)
+        assertThat(it["visitSubStatus"]).isEqualTo(visit.visitSubStatus.name)
         assertThat(it["visitRestriction"]).isEqualTo(visit.visitRestriction.name)
         assertThat(it["visitStart"]).isEqualTo(visit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitEnd"]).isEqualTo(visit.endTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/CancelVisitTest.kt
@@ -580,6 +580,7 @@ class CancelVisitTest : IntegrationTestBase() {
         assertThat(it["prisonerId"]).isEqualTo(cancelledVisit.prisonerId)
         assertThat(it["prisonId"]).isEqualTo(cancelledVisit.prisonCode)
         assertThat(it["visitStatus"]).isEqualTo(cancelledVisit.visitStatus.name)
+        assertThat(it["visitSubStatus"]).isEqualTo(cancelledVisit.visitSubStatus.name)
         assertThat(it["visitRestriction"]).isEqualTo(cancelledVisit.visitRestriction.name)
         assertThat(it["visitStart"]).isEqualTo(cancelledVisit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
         assertThat(it["visitEnd"]).isEqualTo(cancelledVisit.endTimestamp.format(DateTimeFormatter.ISO_DATE_TIME))
@@ -607,6 +608,7 @@ class CancelVisitTest : IntegrationTestBase() {
       "prisonerId" to cancelledVisit.prisonerId,
       "prisonId" to cancelledVisit.prisonCode,
       "visitStatus" to cancelledVisit.visitStatus.name,
+      "visitSubStatus" to cancelledVisit.visitSubStatus.name,
       "visitRestriction" to cancelledVisit.visitRestriction.name,
       "visitStart" to cancelledVisit.startTimestamp.format(DateTimeFormatter.ISO_DATE_TIME),
       "visitEnd" to cancelledVisit.endTimestamp.format(DateTimeFormatter.ISO_DATE_TIME),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
@@ -45,7 +45,7 @@ internal class VisitStoreServiceTest {
   private val applicationService = mock<ApplicationService>()
   private val visitDtoBuilder = mock<VisitDtoBuilder>()
 
-  private val visitStoreService: VisitStoreService = VisitStoreService(visitRepository, prisonRepository, sessionSlotService, applicationValidationService, applicationService, visitDtoBuilder, 28)
+  private val visitStoreService: VisitStoreService = VisitStoreService(visitRepository, prisonRepository, sessionSlotService, applicationValidationService, applicationService, visitDtoBuilder, 28, false)
 
   @Nested
   @DisplayName("createVisitFromExternalSystem")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -80,6 +80,7 @@ hmpps.sqs:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
 
 feature:
+  request-booking-enabled: true
   events:
     sns:
       enabled: true


### PR DESCRIPTION
## What does this pull request do?
Allow booked visits to be request visits. If feature is enabled, check if isRequestVisit boolean is true, and set sub status to REQUESTED instead of AUTO_APPROVED.

Disabled by default until staff can handle requested visits.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5606
https://dsdmoj.atlassian.net/browse/VB-5679
https://dsdmoj.atlassian.net/browse/VB-5680