### PR TITLE
Revert add visit sub status script back to original

### DIFF
--- a/src/main/resources/db/migration/V4_0__add_visit_sub_status_to_visit_table.sql
+++ b/src/main/resources/db/migration/V4_0__add_visit_sub_status_to_visit_table.sql
@@ -2,22 +2,19 @@
 -- to allow us to differentiate between instant bookings and requested bookings.
 
 -- Add sub_status column
--- set DEFAULT to AUTO_APPROVED - this would ensure that we need not run a UPDATE for BOOKED visits as it is taking a long time on PROD
+ALTER TABLE visit ADD visit_sub_status VARCHAR(50);
 
-ALTER TABLE visit ADD visit_sub_status VARCHAR(50) DEFAULT 'AUTO_APPROVED';
-
--- Back fill existing rows with 'CANCELLED' for visit_status = CANCELLED - AUTO_APPROVED for BOOKED should already be set
--- UPDATE visit SET visit_sub_status = 'CANCELLED' WHERE visit_status = 'CANCELLED';
--- finally, drop the default value of AUTO_APPROVED from visit_sub_status
--- ALTER TABLE visit ALTER COLUMN visit_sub_status DROP DEFAULT;
+-- Back fill existing rows with 'Auto_Approved' / 'Cancelled'
+UPDATE visit SET visit_sub_status = 'AUTO_APPROVED' WHERE visit_status = 'BOOKED';
+UPDATE visit SET visit_sub_status = 'CANCELLED' WHERE visit_status = 'CANCELLED';
 
 -- Set NOT NULL
--- ALTER TABLE visit ALTER COLUMN visit_sub_status SET NOT NULL;
+ALTER TABLE visit ALTER COLUMN visit_sub_status SET NOT NULL;
 
 -- Add CHECK constraint to enforce allowed combinations of visit_status and sub_status
--- ALTER TABLE visit ADD CONSTRAINT chk_visit_sub_status
-  --  CHECK (
-    --    (visit_status = 'BOOKED' AND visit_sub_status IN ('AUTO_APPROVED', 'REQUESTED', 'APPROVED'))
-      --      OR
-       -- (visit_status = 'CANCELLED' AND visit_sub_status IN ('CANCELLED', 'WITHDRAWN', 'AUTO_REJECTED', 'REJECTED'))
-        -- );
+ALTER TABLE visit ADD CONSTRAINT chk_visit_sub_status
+    CHECK (
+        (visit_status = 'BOOKED' AND visit_sub_status IN ('AUTO_APPROVED', 'REQUESTED', 'APPROVED'))
+            OR
+        (visit_status = 'CANCELLED' AND visit_sub_status IN ('CANCELLED', 'WITHDRAWN', 'AUTO_REJECTED', 'REJECTED'))
+        );


### PR DESCRIPTION

## What does this pull request do?

Revert script back to original now that it has been deployed to Prod with a workaround (due to perf issues).
## What is the intent behind these changes?

Revert script back to original