### PR TITLE
Correct the endpoint being called on prisoner-contact-registry to get  approved visitors.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/PrisonerContactRegistryClient.kt
@@ -19,15 +19,15 @@ class PrisonerContactRegistryClient(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+    const val GET_PRISONERS_APPROVED_SOCIAL_CONTACTS_URL = "/v2/prisoners/{prisonerId}/contacts/social/approved"
   }
 
-  fun getPrisonersSocialContacts(
+  fun getPrisonersApprovedSocialContacts(
     prisonerId: String,
     withAddress: Boolean,
-    approvedVisitorsOnly: Boolean,
   ): List<PrisonerContactDto>? {
-    val uri = "/v2/prisoners/$prisonerId/contacts/social"
-    return getPrisonersSocialContactsAsMono(prisonerId, withAddress = withAddress, approvedVisitorsOnly = approvedVisitorsOnly)
+    val uri = GET_PRISONERS_APPROVED_SOCIAL_CONTACTS_URL.replace("{prisonerId}", prisonerId)
+    return getPrisonersSocialContactsAsMono(prisonerId, withAddress = withAddress)
       .onErrorResume { e ->
         if (!isNotFoundError(e)) {
           LOG.error("getPrisonersSocialContacts Failed for get request $uri")
@@ -43,11 +43,10 @@ class PrisonerContactRegistryClient(
   private fun getPrisonersSocialContactsAsMono(
     prisonerId: String,
     withAddress: Boolean,
-    approvedVisitorsOnly: Boolean,
   ): Mono<List<PrisonerContactDto>> {
-    val uri = "/v2/prisoners/$prisonerId/contacts/social"
+    val uri = GET_PRISONERS_APPROVED_SOCIAL_CONTACTS_URL.replace("{prisonerId}", prisonerId)
     return webClient.get().uri(uri) {
-      getSocialContactsUriBuilder(withAddress = withAddress, approvedVisitorsOnly = approvedVisitorsOnly, uriBuilder = it).build()
+      getSocialContactsUriBuilder(withAddress = withAddress, uriBuilder = it).build()
     }
       .retrieve()
       .bodyToMono<List<PrisonerContactDto>>()
@@ -55,11 +54,9 @@ class PrisonerContactRegistryClient(
 
   private fun getSocialContactsUriBuilder(
     withAddress: Boolean,
-    approvedVisitorsOnly: Boolean,
     uriBuilder: UriBuilder,
   ): UriBuilder {
     uriBuilder.queryParam("withAddress", withAddress)
-    uriBuilder.queryParam("approvedVisitorsOnly", approvedVisitorsOnly)
     return uriBuilder
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -276,10 +276,10 @@ class VisitNotificationEventService(
     )
 
     if (affectedVisits.isNotEmpty()) {
-      // check if the visitor that was unapproved is still a SOCIAL contact as we have instances where the
+      // check if the visitor that was unapproved is still an approved SOCIAL contact as we have instances where the
       // non-SOCIAL relationship of the visitor has been unapproved which should not affect visits.
       if (doesSocialRelationshipForVisitorStillExist(notificationDto.prisonerNumber, notificationDto.visitorId)) {
-        LOG.info("Visitor ID {} still exists as a SOCIAL contact for prisoner {}, ignoring contact unapproved event.", notificationDto.visitorId, notificationDto.prisonerNumber)
+        LOG.info("Visitor ID {} still exists as an approved SOCIAL contact for prisoner {}, ignoring contact unapproved event.", notificationDto.visitorId, notificationDto.prisonerNumber)
         return
       }
 
@@ -297,10 +297,10 @@ class VisitNotificationEventService(
 
     val prisonCode = prisonerService.getPrisonerPrisonCodeFromPrisonId(notificationDto.prisonerNumber)
     prisonCode?.let {
-      // check if the visitor that was approved is still a SOCIAL contact as we have instances where the
+      // check if the visitor that was approved is still an approved SOCIAL contact as we have instances where the
       // non-SOCIAL relationship of the visitor has been approved which should not affect visits.
       if (!doesSocialRelationshipForVisitorStillExist(notificationDto.prisonerNumber, notificationDto.visitorId)) {
-        LOG.info("Visitor ID {} does not exist as a SOCIAL contact for prisoner {}, ignoring contact approved event.", notificationDto.visitorId, notificationDto.prisonerNumber)
+        LOG.info("Visitor ID {} does not exist as an approved SOCIAL contact for prisoner {}, ignoring contact approved event.", notificationDto.visitorId, notificationDto.prisonerNumber)
         return
       }
 
@@ -594,7 +594,7 @@ class VisitNotificationEventService(
   }
 
   private fun doesSocialRelationshipForVisitorStillExist(prisonerId: String, visitorId: String): Boolean {
-    val prisonerApprovedContacts = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    val prisonerApprovedContacts = prisonerContactRegistryClient.getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     return prisonerApprovedContacts?.filter { it.personId != null }?.map { it.personId.toString() }?.contains(visitorId) ?: false
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/PrisonerContactRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/PrisonerContactRegistryMockServer.kt
@@ -5,18 +5,19 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.visitscheduler.client.PrisonerContactRegistryClient.Companion.GET_PRISONERS_APPROVED_SOCIAL_CONTACTS_URL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.prisonercontactregistry.PrisonerContactDto
 
 class PrisonerContactRegistryMockServer : WireMockServer(8095) {
-  fun stubGetPrisonerContacts(
+  fun stubGetPrisonerApprovedSocialContacts(
     prisonerId: String,
     withAddress: Boolean = false,
-    approvedVisitorsOnly: Boolean = true,
     contactsList: List<PrisonerContactDto>?,
     httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
   ) {
+    val url = GET_PRISONERS_APPROVED_SOCIAL_CONTACTS_URL.replace("{prisonerId}", prisonerId)
     stubFor(
-      get("/v2/prisoners/$prisonerId/contacts/social?${getContactsQueryParams(withAddress, approvedVisitorsOnly)}")
+      get("$url?${getContactsQueryParams(withAddress)}")
         .willReturn(
           if (contactsList == null) {
             aResponse()
@@ -34,14 +35,10 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
 
   private fun getContactsQueryParams(
     withAddress: Boolean? = null,
-    approvedVisitorsOnly: Boolean? = null,
   ): String {
     val queryParams = ArrayList<String>()
     withAddress?.let {
       queryParams.add("withAddress=$it")
-    }
-    approvedVisitorsOnly?.let {
-      queryParams.add("approvedVisitorsOnly=$it")
     }
 
     return queryParams.joinToString("&")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorApprovedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorApprovedVisitNotificationControllerTest.kt
@@ -55,7 +55,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     // Given
     val currentApprovedPrisonerContacts = listOf(PrisonerContactDto(personId = visitorId.toLong()))
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(visitorId = visitorId, prisonerNumber = prisonerId)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, currentApprovedPrisonerContacts)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, currentApprovedPrisonerContacts)
     val visit1 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(1),
       visitStatus = BOOKED,
@@ -95,7 +95,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
       isNull(),
     )
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(telemetryClient, times(1)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
 
@@ -133,7 +133,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(visitNotificationEventRepository, times(0)).deleteAll()
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(telemetryClient, times(0)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
 
@@ -142,7 +142,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     // Given
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(visitorId = visitorId, prisonerNumber = prisonerId)
     val currentApprovedPrisonerContacts = listOf(PrisonerContactDto(personId = visitorId.toLong()))
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, currentApprovedPrisonerContacts)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, currentApprovedPrisonerContacts)
 
     val visit1 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(1),
@@ -183,7 +183,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
       isNull(),
     )
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(telemetryClient, times(1)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
 
@@ -192,7 +192,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     // Given
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(visitorId = visitorId, prisonerNumber = prisonerId)
     val currentApprovedPrisonerContacts = emptyList<PrisonerContactDto>()
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, currentApprovedPrisonerContacts)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, currentApprovedPrisonerContacts)
 
     val visit1 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(1),
@@ -224,7 +224,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(1)
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(telemetryClient, times(0)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
 
@@ -232,7 +232,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
   fun `when visitor is re-approved and call to prisoner contact registry returns a NOT_FOUND error then flagged visits are not un-flagged`() {
     // Given
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(visitorId = visitorId, prisonerNumber = prisonerId)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, null, HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, null, HttpStatus.NOT_FOUND)
 
     val visit1 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(1),
@@ -264,7 +264,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(1)
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(telemetryClient, times(0)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
 
@@ -272,7 +272,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
   fun `when visitor is re-approved and call to prisoner contact registry returns a INTERNAL_SERVER_ERROR error then flagged visits are not un-flagged`() {
     // Given
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(visitorId = visitorId, prisonerNumber = prisonerId)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     val visit1 = createApplicationAndVisit(
       slotDate = LocalDate.now().plusDays(1),
@@ -304,7 +304,7 @@ class VisitorApprovedVisitNotificationControllerTest : NotificationTestBase() {
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(1)
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(telemetryClient, times(0)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/VisitorUnapprovedVisitNotificationControllerTest.kt
@@ -57,7 +57,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
   fun `when visitor has been unapproved then future booked visits are flagged and saved`() {
     // Given
     val currentApprovedPrisonerContacts = emptyList<PrisonerContactDto>()
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, currentApprovedPrisonerContacts)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, currentApprovedPrisonerContacts)
 
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(
       visitorId = visitorId,
@@ -109,7 +109,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     responseSpec.expectStatus().isOk
     assertFlaggedVisitEvent(listOf(visit1), NotificationEventType.VISITOR_UNAPPROVED_EVENT)
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(visitNotificationEventRepository, times(1)).saveAndFlush(any<VisitNotificationEvent>())
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
@@ -136,7 +136,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
   fun `when visitor has been unapproved but the visitor id is still an approved SOCIAL contact on prison contact registry then future booked visits are not flagged`() {
     // Given
     val currentApprovedPrisonerContacts = listOf(PrisonerContactDto(visitorId.toLong()))
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, currentApprovedPrisonerContacts)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, currentApprovedPrisonerContacts)
 
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(
       visitorId = visitorId,
@@ -187,7 +187,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     // Then
     responseSpec.expectStatus().isOk
     verify(visitNotificationEventRepository, times(0)).saveAndFlush(any<VisitNotificationEvent>())
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(0)
@@ -199,7 +199,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
   fun `when no visits then no call is made to prison contact registry`() {
     // Given
     val currentApprovedPrisonerContacts = listOf(PrisonerContactDto(1001))
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, currentApprovedPrisonerContacts)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, currentApprovedPrisonerContacts)
 
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(
       visitorId = visitorId,
@@ -211,7 +211,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     // Then
     responseSpec.expectStatus().isOk
     verify(visitNotificationEventRepository, times(0)).saveAndFlush(any<VisitNotificationEvent>())
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
     assertThat(visitNotifications).hasSize(0)
@@ -222,7 +222,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
   @Test
   fun `when visitor has been unapproved but call to prisoner contact registry throws a NOT_FOUND error still any future booked visits are flagged and saved`() {
     // Given
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, null, HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, null, HttpStatus.NOT_FOUND)
 
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(
       visitorId = visitorId,
@@ -274,7 +274,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     responseSpec.expectStatus().isOk
     assertFlaggedVisitEvent(listOf(visit1), NotificationEventType.VISITOR_UNAPPROVED_EVENT)
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(visitNotificationEventRepository, times(1)).saveAndFlush(any<VisitNotificationEvent>())
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
@@ -300,7 +300,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
   @Test
   fun `when visitor has been unapproved but call to prisoner contact registry throws a INTERNAL_SERVER_ERROR still any future booked visits are flagged and saved`() {
     // Given
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedSocialContacts(prisonerId, withAddress = false, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     val notificationDto = VisitorApprovedUnapprovedNotificationDto(
       visitorId = visitorId,
@@ -352,7 +352,7 @@ class VisitorUnapprovedVisitNotificationControllerTest : NotificationTestBase() 
     responseSpec.expectStatus().isOk
     assertFlaggedVisitEvent(listOf(visit1), NotificationEventType.VISITOR_UNAPPROVED_EVENT)
 
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersApprovedSocialContacts(prisonerId, withAddress = false)
     verify(visitNotificationEventRepository, times(1)).saveAndFlush(any<VisitNotificationEvent>())
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()


### PR DESCRIPTION

## What does this pull request do?

Corrects the /v2 endpoint call on prisoner-contact-registry to get  approved visitors.

## What is the intent behind these changes?

VB-5763