### PR TITLE
Do not include requested visits in proactive booking count and details page

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,3 +74,7 @@ tasks {
 allOpen {
   annotation("javax.persistence.Entity")
 }
+
+tasks.test {
+  jvmArgs = listOf("-Xmx2g", "-XX:MaxMetaspaceSize=512m")
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,4 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+org.gradle.jvmargs=-Xmx2g -XX:ThreadStackSize=4096 -XX:CompilerThreadStackSize=4096 -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
@@ -75,7 +75,8 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
       " JOIN session_slot ss ON ss.id = v.session_slot_id " +
       " JOIN prison p ON p.id = v.prison_id AND p.code = :prisonCode " +
       "WHERE v.visit_status = 'BOOKED' " +
-      "  AND ss.slot_start  >= NOW()",
+      "AND v.visit_sub_status IN ('APPROVED', 'AUTO_APPROVED') " +
+      "AND ss.slot_start  >= NOW()",
     nativeQuery = true,
   )
   fun getNotificationGroupsCountByPrisonCode(prisonCode: String): Int?
@@ -87,6 +88,7 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
       " JOIN session_slot ss ON ss.id = v.session_slot_id " +
       " JOIN prison p ON p.id = v.prison_id AND p.code = :prisonCode " +
       "WHERE v.visit_status = 'BOOKED' " +
+      "AND v.visit_sub_status IN ('APPROVED', 'AUTO_APPROVED') " +
       "  AND ss.slot_start >= NOW() " +
       "  AND vne.type IN (:notificationEventTypes)",
     nativeQuery = true,
@@ -98,7 +100,9 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
       " JOIN visit v ON v.id  = vne.visit_id " +
       " JOIN prison p on p.id  = v.prison_id  AND p.code= :prisonCode " +
       " JOIN session_slot ss on ss.id  = v.session_slot_id " +
-      " WHERE v.visit_status = 'BOOKED' AND ss.slot_start >= NOW()  " +
+      "WHERE v.visit_status = 'BOOKED' " +
+      "AND v.visit_sub_status IN ('APPROVED', 'AUTO_APPROVED') " +
+      "AND ss.slot_start >= NOW()  " +
       " ORDER BY ss.slot_start, v.id",
     nativeQuery = true,
   )
@@ -110,6 +114,7 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
       " JOIN prison p on p.id  = v.prison_id  AND p.code= :prisonCode " +
       " JOIN session_slot ss on ss.id  = v.session_slot_id " +
       " WHERE v.visit_status = 'BOOKED' AND ss.slot_start >= NOW()  " +
+      "AND v.visit_sub_status IN ('APPROVED', 'AUTO_APPROVED') " +
       "  AND vne.type IN (:notificationEventTypes) " +
       " ORDER BY ss.slot_start, v.id",
     nativeQuery = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CountVisitNotificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CountVisitNotificationTest.kt
@@ -58,6 +58,16 @@ class CountVisitNotificationTest : NotificationTestBase() {
     )
     eventAuditEntityHelper.create(visitSecondary)
 
+    val requestedVisit = visitEntityHelper.create(
+      prisonerId = primaryPrisonerId,
+      slotDate = LocalDate.now().plusDays(2),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      prisonCode = sessionTemplateDefault.prison.code,
+      sessionTemplate = sessionTemplateDefault,
+    )
+    eventAuditEntityHelper.create(requestedVisit)
+
     val sessionTemplateTst = sessionTemplateEntityHelper.create(prisonCode = "TST")
 
     val visitOther = visitEntityHelper.create(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/FutureNotificationVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/FutureNotificationVisitsTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType.PRISONER_RESTRICTION_CHANGE_EVENT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.VisitNotificationEventDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.VisitNotificationsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
@@ -59,6 +60,18 @@ class FutureNotificationVisitsTest : NotificationTestBase() {
     visitNotificationEventHelper.create(
       visit = pastVisitWithNotification,
       notificationEventType = NON_ASSOCIATION_EVENT,
+    )
+
+    val requestedVisitWithNotification = createApplicationAndVisit(
+      prisonerId = primaryPrisonerId,
+      slotDate = LocalDate.now().plusDays(5),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      sessionTemplate = sessionTemplate1,
+    )
+    visitNotificationEventHelper.create(
+      visit = requestedVisitWithNotification,
+      notificationEventType = NotificationEventType.PRISONER_RELEASED_EVENT,
     )
 
     val futureVisitWithNotification1 = createApplicationAndVisit(
@@ -145,6 +158,18 @@ class FutureNotificationVisitsTest : NotificationTestBase() {
     visitNotificationEventHelper.create(
       visit = pastVisitWithNotification,
       notificationEventType = NON_ASSOCIATION_EVENT,
+    )
+
+    val requestedVisitWithNotification = createApplicationAndVisit(
+      prisonerId = primaryPrisonerId,
+      slotDate = LocalDate.now().plusDays(5),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      sessionTemplate = sessionTemplate1,
+    )
+    visitNotificationEventHelper.create(
+      visit = requestedVisitWithNotification,
+      notificationEventType = NotificationEventType.PRISONER_RELEASED_EVENT,
     )
 
     val futureVisitWithNotification1 = createApplicationAndVisit(


### PR DESCRIPTION
## What does this pull request do?

We don't want them showing as they'll appear in their own tile for review. But we do want them still being flagged, and they will show the flags on the booking details page when staff review the visit for approval / rejection.


## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5778