### PR TITLE
Remove use of foojay resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-# FROM --platform=$BUILDPLATFORM eclipse-temurin:19-jre-jammy AS builder
-FROM eclipse-temurin:21-jre-jammy AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21.0.1_12-jdk-jammy AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
 WORKDIR /app
 ADD . .
-RUN ./gradlew clean assemble -Dorg.gradle.daemon=false
+RUN ./gradlew --no-daemon assemble
 
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21.0.1_12-jre-jammy
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,3 +78,11 @@ allOpen {
 tasks.test {
   jvmArgs = listOf("-Xmx2g", "-XX:MaxMetaspaceSize=512m")
 }
+
+tasks {
+  withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,1 @@
 rootProject.name = "visit-scheduler"
-
-plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0")
-}


### PR DESCRIPTION
## What does this pull request do?

Remove the foojay resolver and change the Dockerfile image to use a JDK image, which allows us to build the code (compared to the JRE image being used which only run the code).

Also added to build gradle the JVM 21 version for the kotlin compile task to align with the version being used everywhere else.