### PR TITLE
Change visit request approved event name to better reflect it's purpose

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SnsService.kt
@@ -38,8 +38,8 @@ class SnsService(
     const val EVENT_PRISON_CHANGED_VISIT_DESC = "Prison Visit Changed"
     const val EVENT_PRISON_VISIT_CANCELLED = "prison-visit.cancelled"
     const val EVENT_PRISON_VISIT_CANCELLED_DESC = "Prison Visit Cancelled"
-    const val EVENT_PRISON_VISIT_REQUEST_ACTIONED = "prison-visit-request.actioned"
-    const val EVENT_PRISON_VISIT_REQUEST_DESC = "Prison visit request approved or denied"
+    const val EVENT_PRISON_VISIT_REQUEST_APPROVED = "prison-visit-request.approved"
+    const val EVENT_PRISON_VISIT_REQUEST_DESC = "Prison visit request approved"
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
@@ -121,10 +121,10 @@ class SnsService(
     )
   }
 
-  fun sendVisitRequestActionedEvent(details: SnsDomainEventPublishDto) {
+  fun sendVisitRequestApprovedEvent(details: SnsDomainEventPublishDto) {
     publishToDomainEventsTopic(
       HMPPSDomainEvent(
-        eventType = EVENT_PRISON_VISIT_REQUEST_ACTIONED,
+        eventType = EVENT_PRISON_VISIT_REQUEST_APPROVED,
         version = EVENT_PRISON_VISIT_VERSION,
         description = EVENT_PRISON_VISIT_REQUEST_DESC,
         occurredAt = details.createdTimestamp.toOffsetDateFormat(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsService.kt
@@ -79,7 +79,7 @@ class VisitRequestsService(
     telemetryClientService.trackVisitRequestApprovedOrRejectedEvent(approveRejectResponseDto.visitDto, approveRejectResponseDto.eventAuditDto, isApproved)
 
     if (isApproved) {
-      snsService.sendVisitRequestActionedEvent(snsDomainEventPublishDto)
+      snsService.sendVisitRequestApprovedEvent(snsDomainEventPublishDto)
     } else {
       snsService.sendVisitCancelledEvent(snsDomainEventPublishDto)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ApproveVisitRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ApproveVisitRequestTest.kt
@@ -173,12 +173,12 @@ class ApproveVisitRequestTest : IntegrationTestBase() {
 
   private fun assertVisitRequestActionedDomainEvent(visitReference: String) {
     verify(telemetryClient).trackEvent(
-      eq("prison-visit-request.actioned-domain-event"),
+      eq("prison-visit-request.approved-domain-event"),
       org.mockito.kotlin.check {
         assertThat(it["reference"]).isEqualTo(visitReference)
       },
       isNull(),
     )
-    verify(telemetryClient, times(1)).trackEvent(eq("prison-visit-request.actioned-domain-event"), any(), isNull())
+    verify(telemetryClient, times(1)).trackEvent(eq("prison-visit-request.approved-domain-event"), any(), isNull())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ApproveVisitRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/ApproveVisitRequestTest.kt
@@ -94,7 +94,7 @@ class ApproveVisitRequestTest : IntegrationTestBase() {
       isNull(),
     )
 
-    assertVisitRequestActionedDomainEvent(visitPrimary.reference)
+    assertVisitRequestApprovedDomainEvent(visitPrimary.reference)
   }
 
   @Test
@@ -137,7 +137,7 @@ class ApproveVisitRequestTest : IntegrationTestBase() {
     )
     verify(telemetryClient, times(1)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
 
-    assertVisitRequestActionedDomainEvent(visitPrimary.reference)
+    assertVisitRequestApprovedDomainEvent(visitPrimary.reference)
   }
 
   @Test
@@ -171,7 +171,7 @@ class ApproveVisitRequestTest : IntegrationTestBase() {
 
   private fun getApproveVisitRequestResponse(responseSpec: WebTestClient.ResponseSpec): VisitDto = objectMapper.readValue(responseSpec.expectBody().returnResult().responseBody, VisitDto::class.java)
 
-  private fun assertVisitRequestActionedDomainEvent(visitReference: String) {
+  private fun assertVisitRequestApprovedDomainEvent(visitReference: String) {
     verify(telemetryClient).trackEvent(
       eq("prison-visit-request.approved-domain-event"),
       org.mockito.kotlin.check {


### PR DESCRIPTION
## What does this pull request do?

Change name to be more descriptive, as it's only raised when a visit request is approved.