### PR TITLE
Fix - Test assertion no long depends on order of returned list

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FindCancelledPublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FindCancelledPublicVisitsTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -117,11 +118,13 @@ class FindCancelledPublicVisitsTest : IntegrationTestBase() {
     val visitList = parseVisitsResponse(responseSpec)
 
     Assertions.assertThat(visitList.size).isEqualTo(5)
-    visitAssertHelper.assertVisitDto(visitList[0], pastRequestedVisitAutoRejected)
-    visitAssertHelper.assertVisitDto(visitList[1], futureRequestedVisitAutoRejected)
-    visitAssertHelper.assertVisitDto(visitList[2], pastRequestedVisitRejected)
-    visitAssertHelper.assertVisitDto(visitList[3], futureRequestedVisitRejected)
-    visitAssertHelper.assertVisitDto(visitList[4], visitWithOtherBooker)
+    assertThat(visitList.map { it.reference }).containsExactlyInAnyOrder(
+      pastRequestedVisitAutoRejected.reference,
+      futureRequestedVisitAutoRejected.reference,
+      pastRequestedVisitRejected.reference,
+      futureRequestedVisitRejected.reference,
+      visitWithOtherBooker.reference,
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FuturePublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/FuturePublicVisitsTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -108,11 +109,13 @@ class FuturePublicVisitsTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
     val visitList = parseVisitsResponse(responseSpec)
 
-    Assertions.assertThat(visitList.size).isEqualTo(4)
-    visitAssertHelper.assertVisitDto(visitList[0], futureVisitToday)
-    visitAssertHelper.assertVisitDto(visitList[1], nearestVisitAfterToday)
-    visitAssertHelper.assertVisitDto(visitList[2], visitInDifferentPrison)
-    visitAssertHelper.assertVisitDto(visitList[3], visitFarInTheFuture)
+    assertThat(visitList.size).isEqualTo(4)
+    assertThat(visitList.map { it.reference }).containsExactlyInAnyOrder(
+      futureVisitToday.reference,
+      nearestVisitAfterToday.reference,
+      visitInDifferentPrison.reference,
+      visitFarInTheFuture.reference,
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/PastPublicVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/PastPublicVisitsTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -132,9 +133,11 @@ class PastPublicVisitsTest : IntegrationTestBase() {
     val visitList = parseVisitsResponse(responseSpec)
 
     Assertions.assertThat(visitList.size).isEqualTo(3)
-    visitAssertHelper.assertVisitDto(visitList[0], visitWithOtherBooker)
-    visitAssertHelper.assertVisitDto(visitList[1], pastRequestedVisitApproved)
-    visitAssertHelper.assertVisitDto(visitList[2], pastRequestedVisit)
+    assertThat(visitList.map { it.reference }).containsExactlyInAnyOrder(
+      visitWithOtherBooker.reference,
+      pastRequestedVisitApproved.reference,
+      pastRequestedVisit.reference,
+    )
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

Some tests were asserting results in a specific order causing the tests to sometimes fail. Fixed the assertion.