### PR TITLE
Unflag visits which were previously flagged by appointment created event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitNotificationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitNotificationController.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.IgnoreVisitNotificationsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentCreatedNotificationDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NonAssociationChangedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NotificationCountDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PersonRestrictionUpsertedNotificationDto
@@ -51,6 +51,7 @@ const val VISIT_NOTIFICATION_VISITOR_RESTRICTION_UPSERTED_PATH: String = "$VISIT
 const val VISIT_NOTIFICATION_VISITOR_APPROVED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/visitor/approved"
 const val VISIT_NOTIFICATION_VISITOR_UNAPPROVED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/visitor/unapproved"
 const val VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CREATED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/court-video-appointment/created"
+const val VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/court-video-appointment/cancelled-or-deleted"
 const val VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/{prisonCode}/count"
 const val FUTURE_NOTIFICATION_VISITS: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/{prisonCode}/visits"
 const val VISIT_NOTIFICATION_EVENTS: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/visit/{reference}/events"
@@ -420,10 +421,46 @@ class VisitNotificationController(
   )
   fun notifyVSiPThatCourtVideoAppointmentCreated(
     @RequestBody @Valid
-    dto: CourtVideoAppointmentCreatedNotificationDto,
+    dto: CourtVideoAppointmentNotificationDto,
   ): ResponseEntity<HttpStatus> {
     LOG.debug("Entered notifyVSiPThatCourtVideoAppointmentCreated {}", dto)
     visitNotificationEventService.handleCourtVideoAppointmentCreatedNotification(dto)
+    return ResponseEntity(HttpStatus.OK)
+  }
+
+  @PreAuthorize("hasRole('VISIT_SCHEDULER')")
+  @PostMapping(VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_PATH)
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "To notify VSiP that a court video appointment has been cancelled or deleted",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "notification has completed successfully",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to notify VSiP of change",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to notify VSiP of change",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun notifyVSiPThatCourtVideoAppointmentCancelledDeleted(
+    @RequestBody @Valid
+    dto: CourtVideoAppointmentNotificationDto,
+  ): ResponseEntity<HttpStatus> {
+    LOG.debug("Entered notifyVSiPThatCourtVideoAppointmentCancelledDeleted {}", dto)
+    visitNotificationEventService.handleCourtVideoAppointmentCancelledDeletedNotification(dto)
     return ResponseEntity(HttpStatus.OK)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/NotificationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/NotificationEventType.kt
@@ -12,4 +12,5 @@ enum class NotificationEventType(val reviewType: String, val description: String
   VISITOR_RESTRICTION_UPSERTED_EVENT("Visitor-restriction-upserted", "visitor restriction changed"),
   VISITOR_UNAPPROVED_EVENT("Visitor-unapproved", "visitor unapproved"),
   COURT_VIDEO_APPOINTMENT_CREATED_EVENT("Court-video-appointment-created", "Court video appointment created"),
+  COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_EVENT("Court-video-appointment-cancelled-or-deleted", "Court video appointment cancelled or deleted"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/UnFlagEventReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/UnFlagEventReason.kt
@@ -19,4 +19,5 @@ enum class UnFlagEventReason(val desc: String) {
   NON_ASSOCIATION_VISIT_UPDATED("non-association-visit-updated"),
   NON_ASSOCIATION_VISIT_IGNORED("non-association-visit-ignored"),
   PAIRED_VISIT_CANCELLED_IGNORED_OR_UPDATED("paired-visit-cancelled-or-ignored-or-updated"),
+  COURT_VIDEO_APPOINTMENT_CANCELLED_OR_DELETED("court-video-appointment-cancelled-or-deleted"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/CourtVideoAppointmentNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/visitnotification/CourtVideoAppointmentNotificationDto.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification
 
 import jakarta.validation.constraints.NotBlank
 
-data class CourtVideoAppointmentCreatedNotificationDto(
+data class CourtVideoAppointmentNotificationDto(
   @field:NotBlank
   val appointmentInstanceId: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitNotificationEventRepository.kt
@@ -138,6 +138,15 @@ interface VisitNotificationEventRepository : JpaRepository<VisitNotificationEven
   )
   fun getNotificationsTypesForBookingReference(@Param("bookingReference") bookingReference: String): List<NotificationEventType>
 
+  @Query(
+    "select vne.* FROM visit_notification_event vne " +
+      "JOIN visit_notification_event_attribute vnea on vne.id = vnea.visit_notification_event_id " +
+      "WHERE vnea.attribute_name = 'APPOINTMENT_INSTANCE_ID' " +
+      "AND vnea.attribute_value = :appointmentInstanceId",
+    nativeQuery = true,
+  )
+  fun getCourtAppointmentCreatedVisitNotificationEvents(appointmentInstanceId: String): List<VisitNotificationEvent>
+
   fun findVisitNotificationEventByVisitReference(
     reference: String,
   ): List<VisitNotificationEvent>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -39,7 +39,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason.S
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason.VISITOR_APPROVED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitorSupportedRestrictionType
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentCreatedNotificationDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NonAssociationChangedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PersonRestrictionUpsertedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonDateBlockedDto
@@ -297,7 +297,7 @@ class VisitNotificationEventService(
   }
 
   @Transactional
-  fun handleCourtVideoAppointmentCreatedNotification(notificationDto: CourtVideoAppointmentCreatedNotificationDto) {
+  fun handleCourtVideoAppointmentCreatedNotification(notificationDto: CourtVideoAppointmentNotificationDto) {
     LOG.info("handleCourtVideoAppointmentCreatedNotification notification received : {}", notificationDto)
 
     val supportedCourtVideoAppointmentCategoryCodes = SupportedCourtVideoAppointmentCategoryCode.entries.map { it.name }.toSet()
@@ -328,6 +328,19 @@ class VisitNotificationEventService(
       val processVisitNotificationDto = ProcessVisitNotificationDto(affectedVisits, NotificationEventType.COURT_VIDEO_APPOINTMENT_CREATED_EVENT, notificationAttributes)
       processVisitsWithNotifications(processVisitNotificationDto)
     }
+  }
+
+  @Transactional
+  fun handleCourtVideoAppointmentCancelledDeletedNotification(notificationDto: CourtVideoAppointmentNotificationDto) {
+    LOG.info("handleCourtVideoAppointmentCancelledDeletedNotification notification received : {}", notificationDto)
+
+    val currentVisitNotificationsForCreatedAppointment = visitNotificationEventRepository.getCourtAppointmentCreatedVisitNotificationEvents(appointmentInstanceId = notificationDto.appointmentInstanceId)
+
+    deleteNotificationsThatAreNoLongerValid(
+      currentVisitNotificationsForCreatedAppointment,
+      NotificationEventType.COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_EVENT,
+      UnFlagEventReason.COURT_VIDEO_APPOINTMENT_CANCELLED_OR_DELETED,
+    )
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/ClientHelper.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_BOOK
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_CANCEL
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_COUNT_FOR_PRISON_PATH
+import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CREATED_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_EVENTS
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_IGNORE
@@ -86,7 +87,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.incentive.Create
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.incentive.UpdateIncentiveGroupDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.location.CreateLocationGroupDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.location.UpdateLocationGroupDto
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentCreatedNotificationDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NonAssociationChangedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PersonRestrictionUpsertedNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.PrisonerAlertCreatedUpdatedNotificationDto
@@ -834,11 +835,22 @@ fun callNotifyVSiPThatVisitorUnapproved(
 fun callNotifyVSiPThatCourtVideoAppointmentCreated(
   webTestClient: WebTestClient,
   authHttpHeaders: (HttpHeaders) -> Unit,
-  dto: CourtVideoAppointmentCreatedNotificationDto? = null,
+  dto: CourtVideoAppointmentNotificationDto? = null,
 ): ResponseSpec = callNotifyVSiPOfAEvent(
   webTestClient,
   authHttpHeaders,
   VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CREATED_PATH,
+  dto,
+)
+
+fun callNotifyVSiPThatCourtVideoAppointmentCancelledDeleted(
+  webTestClient: WebTestClient,
+  authHttpHeaders: (HttpHeaders) -> Unit,
+  dto: CourtVideoAppointmentNotificationDto? = null,
+): ResponseSpec = callNotifyVSiPOfAEvent(
+  webTestClient,
+  authHttpHeaders,
+  VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_PATH,
   dto,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CourtVideoAppointmentCancelledDeletedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CourtVideoAppointmentCancelledDeletedNotificationControllerTest.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit.notifications
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import org.springframework.http.HttpHeaders
+import org.springframework.transaction.annotation.Propagation.SUPPORTS
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_VISITOR_APPROVED_PATH
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAttributeType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentNotificationDto
+import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatCourtVideoAppointmentCancelledDeleted
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Transactional(propagation = SUPPORTS)
+@DisplayName("POST $VISIT_NOTIFICATION_VISITOR_APPROVED_PATH")
+class CourtVideoAppointmentCancelledDeletedNotificationControllerTest : NotificationTestBase() {
+  private lateinit var roleVisitSchedulerHttpHeaders: (HttpHeaders) -> Unit
+
+  val prisonerId = "A1234AA"
+  val prisonCode = "ABC"
+  val appointmentInstanceId = "123456"
+
+  lateinit var prison1: Prison
+  lateinit var sessionTemplate: SessionTemplate
+  lateinit var sessionTemplateWindowBuffer: SessionTemplate
+
+  @BeforeEach
+  internal fun setUp() {
+    prison1 = prisonEntityHelper.create(prisonCode = prisonCode)
+    sessionTemplate = sessionTemplateEntityHelper.create(prison = prison1, startTime = LocalTime.parse("13:00"), endTime = LocalTime.parse("14:00"))
+    sessionTemplateWindowBuffer = sessionTemplateEntityHelper.create(prison = prison1, startTime = LocalTime.parse("16:15"), endTime = LocalTime.parse("18:15"))
+    roleVisitSchedulerHttpHeaders = setAuthorisation(roles = listOf("ROLE_VISIT_SCHEDULER"))
+  }
+
+  @Test
+  fun `when court video appointment is cancelled or deleted then flagged visits are un-flagged`() {
+    // Given
+    val notificationDto = CourtVideoAppointmentNotificationDto(
+      appointmentInstanceId = appointmentInstanceId,
+    )
+
+    val visit1 = createApplicationAndVisit(
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate,
+      prisonerId = prisonerId,
+    )
+    val visit = visitEntityHelper.save(visit1)
+    eventAuditEntityHelper.create(visit1)
+    visitNotificationEventHelper.create(visit = visit, notificationEventType = NotificationEventType.COURT_VIDEO_APPOINTMENT_CREATED_EVENT, notificationAttributes = mapOf(Pair(NotificationEventAttributeType.APPOINTMENT_INSTANCE_ID, appointmentInstanceId)))
+
+    val visit2NotToBeUnflagged = createApplicationAndVisit(
+      slotDate = LocalDate.now().plusDays(5),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate,
+      prisonerId = prisonerId,
+    )
+    val visitNotTobeUnflagged = visitEntityHelper.save(visit2NotToBeUnflagged)
+    eventAuditEntityHelper.create(visitNotTobeUnflagged)
+    visitNotificationEventHelper.create(visit = visitNotTobeUnflagged, notificationEventType = NotificationEventType.PRISONER_RELEASED_EVENT)
+
+    // When
+    val responseSpec = callNotifyVSiPThatCourtVideoAppointmentCancelledDeleted(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
+    assertThat(visitNotifications).hasSize(1)
+    verify(telemetryClient).trackEvent(
+      eq("unflagged-visit-event"),
+      check {
+        assertThat(it["reference"]).isEqualTo(visit.reference)
+        assertThat(it["reviewTypes"]).isEqualTo(NotificationEventType.COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_EVENT.reviewType)
+        assertThat(it["reason"]).isEqualTo(UnFlagEventReason.COURT_VIDEO_APPOINTMENT_CANCELLED_OR_DELETED.desc)
+      },
+      isNull(),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CourtVideoAppointmentCreatedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/CourtVideoAppointmentCreatedVisitNotificationControllerTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventTy
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SupportedCourtVideoAppointmentCategoryCode
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentCreatedNotificationDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.CourtVideoAppointmentNotificationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.helper.callNotifyVSiPThatCourtVideoAppointmentCreated
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.notification.VisitNotificationEvent
@@ -67,7 +67,7 @@ class CourtVideoAppointmentCreatedVisitNotificationControllerTest : Notification
 
     activitiesApiMockServer.stubGetAppointmentInstanceDetails(appointmentInstanceId = appointmentInstanceId, result = activitiesApiResponse)
 
-    val notificationDto = CourtVideoAppointmentCreatedNotificationDto(
+    val notificationDto = CourtVideoAppointmentNotificationDto(
       appointmentInstanceId = appointmentInstanceId,
     )
 
@@ -135,7 +135,7 @@ class CourtVideoAppointmentCreatedVisitNotificationControllerTest : Notification
 
     activitiesApiMockServer.stubGetAppointmentInstanceDetails(appointmentInstanceId = appointmentInstanceId, result = activitiesApiResponse)
 
-    val notificationDto = CourtVideoAppointmentCreatedNotificationDto(
+    val notificationDto = CourtVideoAppointmentNotificationDto(
       appointmentInstanceId = appointmentInstanceId,
     )
 
@@ -193,7 +193,7 @@ class CourtVideoAppointmentCreatedVisitNotificationControllerTest : Notification
 
     activitiesApiMockServer.stubGetAppointmentInstanceDetails(appointmentInstanceId = appointmentInstanceId, result = activitiesApiResponse)
 
-    val notificationDto = CourtVideoAppointmentCreatedNotificationDto(
+    val notificationDto = CourtVideoAppointmentNotificationDto(
       appointmentInstanceId = appointmentInstanceId,
     )
 
@@ -213,7 +213,7 @@ class CourtVideoAppointmentCreatedVisitNotificationControllerTest : Notification
     // Given
     activitiesApiMockServer.stubGetAppointmentInstanceDetails(appointmentInstanceId = appointmentInstanceId, result = null)
 
-    val notificationDto = CourtVideoAppointmentCreatedNotificationDto(
+    val notificationDto = CourtVideoAppointmentNotificationDto(
       appointmentInstanceId = appointmentInstanceId,
     )
 


### PR DESCRIPTION
## What does this pull request do?

This will be used by the orchestration after listening to deleted / cancelled appointment events, passing in the appointmentInstanceId, which the visit-scheduler uses to find flagged visits and un-flag them.