### PR TITLE
Improve issue with endpoint eager loading collections for no reason

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/controller/VisitController.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.CancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.CreateVisitFromExternalSystemDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.UpdateVisitFromExternalSystemDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitPreviewDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
@@ -463,7 +464,7 @@ class VisitController(
       example = "50",
     )
     size: Int,
-  ): Page<VisitDto> = visitService.findVisitsBySessionTemplateFilterPageableDescending(
+  ): Page<VisitPreviewDto> = visitService.findVisitsBySessionTemplateFilterPageableDescending(
     sessionTemplateReference = sessionTemplateReference,
     fromDate = fromDate,
     toDate = toDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/VisitPreviewDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/VisitPreviewDto.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTimeSlotDto
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
+import java.time.LocalDateTime
+
+data class VisitPreviewDto(
+  @Schema(required = true, description = "Prisoner Number", example = "A1234AA")
+  @NotNull
+  val prisonerId: String,
+
+  @Schema(description = "First name of the prisoner", example = "John", required = true)
+  @NotNull
+  val firstName: String,
+
+  @Schema(description = "Last name of the prisoner", example = "Smith", required = true)
+  @NotNull
+  val lastName: String,
+
+  @Schema(description = "Visit reference", example = "dp-we-rs-te", required = true)
+  @NotNull
+  val visitReference: String,
+
+  @Schema(description = "Number of visitors added to the visit", example = "10", required = true)
+  @NotNull
+  val visitorCount: Int,
+
+  @Schema(description = "Timeslot for the visit", required = true)
+  @NotNull
+  val visitTimeSlot: SessionTimeSlotDto,
+
+  @Schema(description = "Date the visit was first booked or migrated", example = "2018-12-01T13:45:00", required = true)
+  val firstBookedDateTime: LocalDateTime,
+
+  @Schema(description = "Visit Restriction", example = "OPEN", required = true)
+  val visitRestriction: VisitRestriction,
+
+  @Schema(description = "Visit Status", example = "BOOKED", required = true)
+  val visitStatus: VisitStatus,
+
+  @Schema(description = "Visit Sub Status", example = "REQUESTED", required = true)
+  val visitSubStatus: VisitSubStatus,
+) {
+  constructor(visit: Visit, visitFirstBookedDateTime: LocalDateTime?) :
+    this(
+      prisonerId = visit.prisonerId,
+      firstName = visit.prisonerId,
+      lastName = visit.prisonerId,
+      visitReference = visit.reference,
+      visitorCount = visit.visitors.size,
+      visitTimeSlot = SessionTimeSlotDto(visit.sessionSlot.slotStart.toLocalTime(), visit.sessionSlot.slotEnd.toLocalTime()),
+      firstBookedDateTime = visitFirstBookedDateTime ?: visit.createTimestamp ?: LocalDateTime.now(),
+      visitRestriction = visit.visitRestriction,
+      visitStatus = visit.visitStatus,
+      visitSubStatus = visit.visitSubStatus,
+    )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/audit/EventAuditDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/audit/EventAuditDto.kt
@@ -59,4 +59,15 @@ class EventAuditDto(
     text = eventAuditEntity.text,
     notifyHistory = notifyHistoryDtoBuilder.build(eventAuditEntity.notifyHistory),
   )
+
+  constructor(eventAuditEntity: EventAudit) : this(
+    id = eventAuditEntity.id,
+    type = eventAuditEntity.type,
+    applicationMethodType = eventAuditEntity.applicationMethodType,
+    actionedBy = ActionedByDto(eventAuditEntity.actionedBy),
+    bookingReference = eventAuditEntity.bookingReference,
+    sessionTemplateReference = eventAuditEntity.sessionTemplateReference,
+    createTimestamp = eventAuditEntity.createTimestamp,
+    text = eventAuditEntity.text,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/EventAudit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/EventAudit.kt
@@ -60,10 +60,10 @@ class EventAudit private constructor(
   @CreationTimestamp
   @Column
   val createTimestamp: LocalDateTime = LocalDateTime.now(),
-
-  @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "eventAudit", orphanRemoval = true)
-  val notifyHistory: MutableList<VisitNotifyHistory> = mutableListOf(),
 ) {
+  @OneToMany(fetch = FetchType.LAZY, cascade = [ALL], mappedBy = "eventAudit", orphanRemoval = true)
+  val notifyHistory: MutableList<VisitNotifyHistory> = mutableListOf()
+
   constructor(actionedBy: ActionedBy, bookingReference: String?, applicationReference: String?, sessionTemplateReference: String?, type: EventAuditType, applicationMethodType: ApplicationMethodType, text: String?) : this(
     actionedById = actionedBy.id,
     actionedBy = actionedBy,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/PublicVisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/PublicVisitService.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.builder.NotifyHistoryDtoBuilder
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.builder.VisitDtoBuilder
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.EventAuditRepository
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 class PublicVisitService(
   private val visitRepository: VisitRepository,
   private val eventAuditRepository: EventAuditRepository,
-  private val notifyHistoryDtoBuilder: NotifyHistoryDtoBuilder,
 ) {
   @Autowired
   private lateinit var visitDtoBuilder: VisitDtoBuilder
@@ -40,7 +38,7 @@ class PublicVisitService(
     )
 
     return eventAuditRepository.getVisitEventsByBookingReference(bookerReference, ignoreEventTypes)
-      .map { EventAuditDto(it, notifyHistoryDtoBuilder) }
+      .map { EventAuditDto(it) }
       .sortedByDescending { it.createTimestamp }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitEventAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitEventAuditService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.MigratedCancelVisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.builder.NotifyHistoryDtoBuilder
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType.NOT_APPLICABLE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType.NOT_KNOWN
@@ -41,7 +40,7 @@ import java.time.LocalDateTime
 
 @Service
 @Transactional
-class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryDtoBuilder) {
+class VisitEventAuditService {
 
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
@@ -78,7 +77,7 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
     actionedBy.eventAuditList.add(eventAudit)
     actionedByRepository.saveAndFlush(actionedBy)
 
-    return EventAuditDto(eventAudit, notifyHistoryDtoBuilder)
+    return EventAuditDto(eventAudit)
   }
 
   fun saveBookingEventAudit(
@@ -103,7 +102,6 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
           text = text,
         ),
       ),
-      notifyHistoryDtoBuilder,
     )
   }
 
@@ -126,7 +124,6 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
           text = text,
         ),
       ),
-      notifyHistoryDtoBuilder,
     )
   }
 
@@ -157,7 +154,7 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
 
   fun updateCreateTimestamp(time: LocalDateTime, eventAudit: EventAudit): EventAuditDto {
     eventAuditRepository.updateCreateTimestamp(time, eventAudit.id)
-    return EventAuditDto(eventAudit, notifyHistoryDtoBuilder)
+    return EventAuditDto(eventAudit)
   }
 
   fun saveNotificationEventAudit(type: NotificationEventType, impactedVisit: VisitDto): EventAuditDto {
@@ -174,18 +171,17 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
           text = null,
         ),
       ),
-      notifyHistoryDtoBuilder,
     )
   }
 
   @Transactional(readOnly = true)
   fun getLastEventForBooking(bookingReference: String): EventAuditDto? = eventAuditRepository.findLastBookedVisitEventByBookingReference(bookingReference)?.let {
-    EventAuditDto(it, notifyHistoryDtoBuilder)
+    EventAuditDto(it)
   }
 
   @Transactional(readOnly = true)
   fun getLastEventForBookingOrMigration(bookingReference: String): EventAuditDto? = eventAuditRepository.findLastBookedOrMigratedVisitEventByBookingReference(bookingReference)?.let {
-    EventAuditDto(it, notifyHistoryDtoBuilder)
+    EventAuditDto(it)
   }
 
   @Transactional(readOnly = true)
@@ -220,7 +216,7 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
     )
   }
 
-  fun findByBookingReferenceOrderById(bookingReference: String): List<EventAuditDto> = eventAuditRepository.findByBookingReferenceOrderById(bookingReference).map { EventAuditDto(it, notifyHistoryDtoBuilder) }
+  fun findByBookingReferenceOrderById(bookingReference: String): List<EventAuditDto> = eventAuditRepository.findByBookingReferenceOrderById(bookingReference).map { EventAuditDto(it) }
 
   private fun saveCancelledEventAudit(actionedByValue: String, userType: UserType, applicationMethodType: ApplicationMethodType, visit: VisitDto): EventAuditDto {
     val actionedBy = createOrGetActionBy(actionedByValue, userType)
@@ -242,7 +238,7 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
           text = null,
         ),
       ),
-      notifyHistoryDtoBuilder,
+
     )
   }
 
@@ -325,7 +321,6 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
           text = null,
         ),
       ),
-      notifyHistoryDtoBuilder,
     )
   }
 
@@ -344,7 +339,6 @@ class VisitEventAuditService(private val notifyHistoryDtoBuilder: NotifyHistoryD
           text = "Auto rejected by system cron",
         ),
       ),
-      notifyHistoryDtoBuilder,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_SESSIONS_AVA
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_SESSION_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.ContactDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitPreviewDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitorDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationSupportDto
@@ -355,6 +356,16 @@ abstract class IntegrationTestBase {
     class Page {
       @JsonProperty("content")
       lateinit var content: List<VisitDto>
+    }
+
+    val content = objectMapper.readValue(responseSpec.expectBody().returnResult().responseBody, Page::class.java)
+    return content.content
+  }
+
+  fun parseVisitsByDatePageResponse(responseSpec: ResponseSpec): List<VisitPreviewDto> {
+    class Page {
+      @JsonProperty("content")
+      lateinit var content: List<VisitPreviewDto>
     }
 
     val content = objectMapper.readValue(responseSpec.expectBody().returnResult().responseBody, Page::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCallbackNotificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCallbackNotificationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.integration.notify
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
@@ -32,6 +33,7 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID.randomUUID
 
 @DisplayName("Tests for create GOV.UK notify events")
+@Disabled("Currently we don't surface these notifications, until then, tests will be disabled")
 class NotifyCallbackNotificationTest : IntegrationTestBase() {
   private val notifyRoles = listOf("ROLE_VISIT_SCHEDULER__VISIT_NOTIFICATION_ALERTS")
   private val visitSchedulerRoles = listOf("ROLE_VISIT_SCHEDULER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCreateNotificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/notify/NotifyCreateNotificationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.integration.notify
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBa
 import java.time.temporal.ChronoUnit
 
 @DisplayName("Tests for create GOV.UK notify events")
+@Disabled("Currently we don't surface these notifications, until then, tests will be disabled")
 class NotifyCreateNotificationTest : IntegrationTestBase() {
   private val notifyRoles = listOf("ROLE_VISIT_SCHEDULER__VISIT_NOTIFICATION_ALERTS")
   private val visitSchedulerRoles = listOf("ROLE_VISIT_SCHEDULER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByDateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsByDateTest.kt
@@ -62,15 +62,15 @@ class VisitsByDateTest : IntegrationTestBase() {
 
     // Then
     responseSpecVisitsBySession.expectStatus().isOk
-    val visits = parseVisitsPageResponse(responseSpecVisitsBySession)
+    val visits = parseVisitsByDatePageResponse(responseSpecVisitsBySession)
     Assertions.assertThat(visits.size).isEqualTo(5)
 
     // ensure the results are sorted by audit event records
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit1.reference)
-    Assertions.assertThat(visits[1].reference).isEqualTo(visit3.reference)
-    Assertions.assertThat(visits[2].reference).isEqualTo(visit2.reference)
-    Assertions.assertThat(visits[3].reference).isEqualTo(visit4.reference)
-    Assertions.assertThat(visits[4].reference).isEqualTo(visit5.reference)
+    Assertions.assertThat(visits[0].visitReference).isEqualTo(visit1.reference)
+    Assertions.assertThat(visits[1].visitReference).isEqualTo(visit3.reference)
+    Assertions.assertThat(visits[2].visitReference).isEqualTo(visit2.reference)
+    Assertions.assertThat(visits[3].visitReference).isEqualTo(visit4.reference)
+    Assertions.assertThat(visits[4].visitReference).isEqualTo(visit5.reference)
   }
 
   private fun createApplication(sessionTemplate: SessionTemplate, prisonerId: String, slotDate: LocalDate): Application {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/VisitsBySessionTemplateFilterTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.integration.visit
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -80,9 +81,9 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
 
     // Then
     responseSpec.expectStatus().isOk
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(1)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit1.reference)
+    Assertions.assertThat(visits[0].visitReference).isEqualTo(visit1.reference)
   }
 
   @Test
@@ -98,10 +99,12 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
 
     // Then
     responseSpec.expectStatus().isOk
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(2)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit1.reference)
-    Assertions.assertThat(visits[1].reference).isEqualTo(visit2.reference)
+    assertThat(visits.map { it.visitReference }).containsExactlyInAnyOrder(
+      visit1.reference,
+      visit2.reference,
+    )
   }
 
   @Test
@@ -118,11 +121,13 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
 
     // Then
     responseSpec.expectStatus().isOk
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(3)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit1.reference)
-    Assertions.assertThat(visits[1].reference).isEqualTo(visit4.reference)
-    Assertions.assertThat(visits[2].reference).isEqualTo(visit5.reference)
+    assertThat(visits.map { it.visitReference }).containsExactlyInAnyOrder(
+      visit1.reference,
+      visit4.reference,
+      visit5.reference,
+    )
   }
 
   @Test
@@ -139,11 +144,13 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
 
     // Then
     responseSpec.expectStatus().isOk
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(3)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit1.reference)
-    Assertions.assertThat(visits[1].reference).isEqualTo(visit2.reference)
-    Assertions.assertThat(visits[2].reference).isEqualTo(visit4.reference)
+    assertThat(visits.map { it.visitReference }).containsExactlyInAnyOrder(
+      visit1.reference,
+      visit2.reference,
+      visit4.reference,
+    )
   }
 
   @Test
@@ -160,12 +167,14 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
 
     // Then
     responseSpec.expectStatus().isOk
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(4)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit1.reference)
-    Assertions.assertThat(visits[1].reference).isEqualTo(visit2.reference)
-    Assertions.assertThat(visits[2].reference).isEqualTo(visit4.reference)
-    Assertions.assertThat(visits[3].reference).isEqualTo(visit5.reference)
+    assertThat(visits.map { it.visitReference }).containsExactlyInAnyOrder(
+      visit1.reference,
+      visit2.reference,
+      visit4.reference,
+      visit5.reference,
+    )
   }
 
   @Test
@@ -182,9 +191,9 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
 
     // Then
     responseSpec.expectStatus().isOk
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(1)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit5.reference)
+    Assertions.assertThat(visits[0].visitReference).isEqualTo(visit5.reference)
     Assertions.assertThat(visits[0].visitRestriction).isEqualTo(CLOSED)
   }
 
@@ -200,10 +209,12 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(2)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit6.reference)
-    Assertions.assertThat(visits[1].reference).isEqualTo(visit7.reference)
+    assertThat(visits.map { it.visitReference }).containsExactlyInAnyOrder(
+      visit6.reference,
+      visit7.reference,
+    )
   }
 
   @Test
@@ -218,9 +229,9 @@ class VisitsBySessionTemplateFilterTest : IntegrationTestBase() {
     val responseSpec = callVisitsBySessionEndPoint(params)
 
     // Then
-    val visits = parseVisitsPageResponse(responseSpec)
+    val visits = parseVisitsByDatePageResponse(responseSpec)
     Assertions.assertThat(visits.size).isEqualTo(1)
-    Assertions.assertThat(visits[0].reference).isEqualTo(visit7.reference)
+    Assertions.assertThat(visits[0].visitReference).isEqualTo(visit7.reference)
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

Some of the collections within event audit and other sub visit entities were being eager loaded but not used by the frontend. Create a custom DTO which only captures the required fields and stop loading of lazy collections