### PR TITLE
VB-5940 - auto reject visits only when the released reason type is RELEASED

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/NotificationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/NotificationTestBase.kt
@@ -26,7 +26,9 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestEventAuditRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.TestVisitNotificationEventRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitNotificationEventRepository
+import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.service.PrisonerService
+import uk.gov.justice.digital.hmpps.visitscheduler.service.VisitRequestsApprovalRejectionService
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit.MINUTES
@@ -41,6 +43,12 @@ abstract class NotificationTestBase : IntegrationTestBase() {
 
   @MockitoSpyBean
   lateinit var prisonerService: PrisonerService
+
+  @MockitoSpyBean
+  lateinit var visitRequestsApprovalRejectionService: VisitRequestsApprovalRejectionService
+
+  @MockitoSpyBean
+  lateinit var visitRepository: VisitRepository
 
   @MockitoSpyBean
   lateinit var visitNotificationEventRepository: VisitNotificationEventRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerReleasedVisitNotificationControllerTest.kt
@@ -223,6 +223,22 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
   fun `when prisoner has been released to hospital then no visits are flagged or saved and requested visits are not auto rejected`() {
     // Given
     val notificationDto = PrisonerReleasedNotificationDto(prisonerId, prisonCode, RELEASED_TO_HOSPITAL)
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    val visit2 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(3),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit2)
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerHadBeenReleased(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)
@@ -236,6 +252,22 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
   fun `when prisoner has been temporary released then no visits are flagged or saved and requested visits are not auto rejected`() {
     // Given
     val notificationDto = PrisonerReleasedNotificationDto(prisonerId, prisonCode, TEMPORARY_ABSENCE_RELEASE)
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    val visit2 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(3),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit2)
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerHadBeenReleased(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)
@@ -249,6 +281,22 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
   fun `when prisoner has been sent to cort then no visits are flagged or saved and requested visits are not auto rejected`() {
     // Given
     val notificationDto = PrisonerReleasedNotificationDto(prisonerId, prisonCode, SENT_TO_COURT)
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    val visit2 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(3),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit2)
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerHadBeenReleased(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)
@@ -262,6 +310,22 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
   fun `when prisoner has transferred then no visits are flagged or saved and requested visits are not auto rejected`() {
     // Given
     val notificationDto = PrisonerReleasedNotificationDto(prisonerId, prisonCode, TRANSFERRED)
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    val visit2 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(3),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit2)
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerHadBeenReleased(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)
@@ -275,6 +339,22 @@ class PrisonerReleasedVisitNotificationControllerTest : NotificationTestBase() {
   fun `when prisoner has been released but we dont know why then no visits are flagged or saved and requested visits are not auto rejected`() {
     // Given
     val notificationDto = PrisonerReleasedNotificationDto(prisonerId, prisonCode, UNKNOWN)
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    val visit2 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(3),
+      visitStatus = BOOKED,
+      visitSubStatus = VisitSubStatus.REQUESTED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit2)
 
     // When
     val responseSpec = callNotifyVSiPThatPrisonerHadBeenReleased(webTestClient, roleVisitSchedulerHttpHeaders, notificationDto)


### PR DESCRIPTION

## What does this pull request do?

VB-5940 - auto reject visits only when the released reason type is RELEASED
## What is the intent behind these changes?

Fix for VB-5940 where requested visits are auto rejected when prisoner released to COURT