### PR TITLE
VB-5800 / VB-5431 - Allow session templates to set a visit order restriction

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/SessionTemplateVisitOrderRestrictionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/SessionTemplateVisitOrderRestrictionType.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.enums
+
+@Suppress("unused")
+enum class SessionTemplateVisitOrderRestrictionType {
+  VO_PVO,
+  VO,
+  PVO,
+  NONE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/CreateSessionTemplateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/CreateSessionTemplateDto.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.validators.Session
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.validators.SessionDateRangeValidation
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.validators.SessionTimeSlotValidation
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.UserClientDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import java.time.DayOfWeek
 
@@ -71,4 +72,7 @@ data class CreateSessionTemplateDto(
 
   @Schema(description = "Determines behaviour of incentive groups. True equates to these incentive groups being included, false equates to them being excluded.", required = true)
   val includeIncentiveGroupType: Boolean,
+
+  @Schema(description = "The type of visit order restriction, defaults to VO_PVO (Either allowed)", example = "PVO", required = false)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/CreateSessionTemplateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/CreateSessionTemplateDto.kt
@@ -73,6 +73,6 @@ data class CreateSessionTemplateDto(
   @Schema(description = "Determines behaviour of incentive groups. True equates to these incentive groups being included, false equates to them being excluded.", required = true)
   val includeIncentiveGroupType: Boolean,
 
-  @Schema(description = "The type of visit order restriction, defaults to VO_PVO (Either allowed)", example = "PVO", required = false)
+  @Schema(description = "The type of visit order restriction, defaults to VO_PVO (Either allowed)", example = "PVO", implementation = SessionTemplateVisitOrderRestrictionType::class, required = false)
   val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/SessionTemplateDto.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.UserClientDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.category.SessionCategoryGroupDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.incentive.SessionIncentiveLevelGroupDto
@@ -53,6 +54,8 @@ data class SessionTemplateDto(
   val includeCategoryGroupType: Boolean,
   @Schema(description = "Determines behaviour of incentive groups. True equates to these incentive groups being included, false equates to them being excluded.", required = true)
   val includeIncentiveGroupType: Boolean,
+  @Schema(description = "The type of visit order restriction", example = "PVO", required = true)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
 ) {
   constructor(sessionTemplateEntity: SessionTemplate) : this(
     reference = sessionTemplateEntity.reference,
@@ -73,5 +76,6 @@ data class SessionTemplateDto(
     includeCategoryGroupType = sessionTemplateEntity.includeCategoryGroupType,
     includeIncentiveGroupType = sessionTemplateEntity.includeIncentiveGroupType,
     clients = sessionTemplateEntity.clients.map { UserClientDto(it.userType, it.active) },
+    visitOrderRestriction = sessionTemplateEntity.visitOrderRestriction,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/UpdateSessionTemplateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/UpdateSessionTemplateDto.kt
@@ -59,6 +59,6 @@ data class UpdateSessionTemplateDto(
   @Schema(description = "Determines behaviour of incentive groups. True equates to these incentive groups being included, false equates to them being excluded.", required = false)
   val includeIncentiveGroupType: Boolean? = null,
 
-  @Schema(description = "The type of visit order restriction, defaults to VO_PVO (Either allowed)", example = "PVO", required = false)
+  @Schema(description = "The type of visit order restriction, defaults to VO_PVO (Either allowed)", example = "PVO", implementation = SessionTemplateVisitOrderRestrictionType::class, required = false)
   val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/UpdateSessionTemplateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/sessions/UpdateSessionTemplateDto.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.validators.Session
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.validators.SessionDateRangeValidation
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.validators.SessionTimeSlotValidation
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.UserClientDto
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 
 data class UpdateSessionTemplateDto(
   @Schema(description = "Name for Session template", example = "Monday Xmas", required = true)
@@ -57,4 +58,7 @@ data class UpdateSessionTemplateDto(
 
   @Schema(description = "Determines behaviour of incentive groups. True equates to these incentive groups being included, false equates to them being excluded.", required = false)
   val includeIncentiveGroupType: Boolean? = null,
+
+  @Schema(description = "The type of visit order restriction, defaults to VO_PVO (Either allowed)", example = "PVO", required = false)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/session/SessionTemplate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/session/SessionTemplate.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToMany
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.base.AbstractReferenceEntity
@@ -109,4 +110,8 @@ class SessionTemplate(
 
   @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], mappedBy = "sessionTemplate", orphanRemoval = true)
   var clients: MutableList<SessionTemplateUserClient> = mutableListOf(),
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
 ) : AbstractReferenceEntity(delimiter = ".", chunkSize = 3)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionTemplateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/SessionTemplateRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionCapacityDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionDateRangeDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTimeSlotDto
@@ -197,6 +198,10 @@ interface SessionTemplateRepository : JpaRepository<SessionTemplate, Long> {
   @Modifying(clearAutomatically = true)
   @Query("Update SessionTemplate s set s.includeIncentiveGroupType = :includeIncentiveGroupType WHERE s.reference = :reference")
   fun updateIncludeIncentiveGroupType(reference: String, includeIncentiveGroupType: Boolean): Int
+
+  @Modifying(clearAutomatically = true)
+  @Query("Update SessionTemplate s set s.visitOrderRestriction = :visitOrderRestriction WHERE s.reference = :reference")
+  fun updateVisitOrderRestriction(reference: String, visitOrderRestriction: SessionTemplateVisitOrderRestrictionType): Int
 
   @Query(
     "SELECT new uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTimeSlotDto(st.startTime,st.endTime)  FROM SessionTemplate st WHERE st.reference = :reference",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
@@ -171,6 +171,7 @@ class SessionTemplateService(
       includeLocationGroupType = createSessionTemplateDto.includeLocationGroupType,
       includeCategoryGroupType = createSessionTemplateDto.includeCategoryGroupType,
       includeIncentiveGroupType = createSessionTemplateDto.includeIncentiveGroupType,
+      visitOrderRestriction = createSessionTemplateDto.visitOrderRestriction,
     )
 
     createSessionTemplateDto.categoryGroupReferences?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionTemplateService.kt
@@ -247,6 +247,10 @@ class SessionTemplateService(
       includeIncentiveGroupType?.let {
         sessionTemplateRepository.updateIncludeIncentiveGroupType(reference, includeIncentiveGroupType = it)
       }
+
+      visitOrderRestriction?.let {
+        sessionTemplateRepository.updateVisitOrderRestriction(reference, visitOrderRestriction = it)
+      }
     }
 
     val updatedSessionTemplateEntity = getSessionTemplate(reference)

--- a/src/main/resources/db/migration/V4_3__add_visit_order_restriction_enum_to_session_template.sql
+++ b/src/main/resources/db/migration/V4_3__add_visit_order_restriction_enum_to_session_template.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE session_template ADD COLUMN visit_order_restriction VARCHAR(20);
+
+UPDATE session_template SET visit_order_restriction = 'VO_PVO';
+
+ALTER TABLE session_template ALTER COLUMN visit_order_restriction SET NOT NULL;
+
+COMMIT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -659,7 +659,7 @@ class SessionTemplateEntityHelper(
       includeIncentiveGroupType = includeIncentiveGroupType,
       excludeDates = excludeDates,
       clients = clients,
-      visitOrderRestriction = visitOrderRestrictionType,
+      visitOrderRestrictionType = visitOrderRestrictionType,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventAt
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
@@ -632,6 +633,7 @@ class SessionTemplateEntityHelper(
     includeIncentiveGroupType: Boolean = true,
     excludeDates: MutableList<LocalDate> = mutableListOf(),
     clients: List<UserClientDto> = listOf(UserClientDto(STAFF, true), UserClientDto(PUBLIC, true)),
+    visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
   ): SessionTemplate {
     val prison = prisonEntityHelper.create(prisonCode, activePrison)
 
@@ -683,6 +685,7 @@ class SessionTemplateEntityHelper(
     includeIncentiveGroupType: Boolean = true,
     excludeDates: MutableList<LocalDate> = mutableListOf(),
     clients: List<UserClientDto> = listOf(UserClientDto(STAFF, true), UserClientDto(PUBLIC, true)),
+    visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
   ): SessionTemplate {
     val sessionTemplate = sessionRepository.saveAndFlush(
       SessionTemplate(
@@ -706,6 +709,7 @@ class SessionTemplateEntityHelper(
         includeLocationGroupType = includeLocationGroupType,
         includeCategoryGroupType = includeCategoryGroupType,
         includeIncentiveGroupType = includeIncentiveGroupType,
+        visitOrderRestriction = visitOrderRestrictionType,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -659,6 +659,7 @@ class SessionTemplateEntityHelper(
       includeIncentiveGroupType = includeIncentiveGroupType,
       excludeDates = excludeDates,
       clients = clients,
+      visitOrderRestriction = visitOrderRestrictionType,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityTestBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityTestBuilder.kt
@@ -251,6 +251,7 @@ fun createUpdateSessionTemplateDto(
   includeCategoryGroupType: Boolean? = true,
   includeIncentiveGroupType: Boolean? = true,
   clients: List<UserClientDto>? = null,
+  visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 ): UpdateSessionTemplateDto = UpdateSessionTemplateDto(
   name = name + dayOfWeek,
   sessionDateRange = sessionDateRange,
@@ -265,6 +266,7 @@ fun createUpdateSessionTemplateDto(
   includeCategoryGroupType = includeCategoryGroupType,
   includeIncentiveGroupType = includeIncentiveGroupType,
   clients = clients,
+  visitOrderRestriction = visitOrderRestrictionType,
 )
 
 fun createUpdateSessionTemplateDto(
@@ -276,6 +278,7 @@ fun createUpdateSessionTemplateDto(
   categoryGroupReferences: List<String>? = null,
   includeIncentiveGroupType: Boolean? = null,
   incentiveLevelReferences: List<String>? = null,
+  visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 ): UpdateSessionTemplateDto = UpdateSessionTemplateDto(
   name = sessionTemplateDto.name,
   sessionDateRange = sessionTemplateDto.sessionDateRange,
@@ -289,6 +292,7 @@ fun createUpdateSessionTemplateDto(
   includeIncentiveGroupType = includeIncentiveGroupType ?: sessionTemplateDto.includeIncentiveGroupType,
   incentiveLevelGroupReferences = incentiveLevelReferences ?: sessionTemplateDto.prisonerIncentiveLevelGroups.stream().map { it.reference }.toList(),
   visitRoom = sessionTemplateDto.visitRoom,
+  visitOrderRestriction = visitOrderRestrictionType,
 )
 
 fun createCreateLocationGroupDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityTestBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityTestBuilder.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.helper
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.UserClientDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.IncentiveLevel
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.CreateSessionTemplateDto
@@ -64,6 +65,7 @@ fun sessionTemplate(
   includeIncentiveGroupType: Boolean = true,
   prison: Prison,
   userTypes: List<UserType> = listOf(UserType.STAFF, UserType.PUBLIC),
+  visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 ): SessionTemplate {
   var sessionTemplate = SessionTemplate(
     name = name + dayOfWeek,
@@ -85,6 +87,7 @@ fun sessionTemplate(
     includeLocationGroupType = includeLocationGroupType,
     includeCategoryGroupType = includeCategoryGroupType,
     includeIncentiveGroupType = includeIncentiveGroupType,
+    visitOrderRestriction = visitOrderRestrictionType,
   ).also { it.reference = UUID.randomUUID().toString() }
 
   sessionTemplate = addUserClients(sessionTemplate, userTypes)
@@ -117,6 +120,7 @@ fun sessionTemplate(
   includeCategoryGroupType: Boolean = true,
   includeIncentiveGroupType: Boolean = true,
   userTypes: List<UserType> = listOf(UserType.STAFF, UserType.PUBLIC),
+  visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 ): SessionTemplate {
   val prison = Prison(code = prisonCode, active = isActive, policyNoticeDaysMin, policyNoticeDaysMax, maxTotalVisitors, maxAdultVisitors, maxChildVisitors, adultAgeYears)
 
@@ -140,6 +144,7 @@ fun sessionTemplate(
     includeLocationGroupType = includeLocationGroupType,
     includeCategoryGroupType = includeCategoryGroupType,
     includeIncentiveGroupType = includeIncentiveGroupType,
+    visitOrderRestriction = visitOrderRestrictionType,
   ).also { it.reference = UUID.randomUUID().toString() }
   sessionTemplate = addUserClients(sessionTemplate, userTypes)
 
@@ -182,6 +187,7 @@ fun createCreateSessionTemplateDto(
   includeCategoryGroupType: Boolean = true,
   includeIncentiveGroupType: Boolean = true,
   userClients: List<UserClientDto> = listOf(),
+  visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 ): CreateSessionTemplateDto = CreateSessionTemplateDto(
   name = name + dayOfWeek,
   prisonCode = prisonCode,
@@ -198,6 +204,7 @@ fun createCreateSessionTemplateDto(
   includeCategoryGroupType = includeCategoryGroupType,
   includeIncentiveGroupType = includeIncentiveGroupType,
   clients = userClients,
+  visitOrderRestriction = visitOrderRestrictionType,
 )
 
 fun createCreateSessionTemplateDto(
@@ -210,6 +217,7 @@ fun createCreateSessionTemplateDto(
   includeLocationGroupType: Boolean = true,
   includeCategoryGroupType: Boolean = true,
   includeIncentiveGroupType: Boolean = true,
+  visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 ): CreateSessionTemplateDto = CreateSessionTemplateDto(
   name = name + sessionTemplateDto.dayOfWeek,
   prisonCode = sessionTemplateDto.prisonCode,
@@ -225,6 +233,7 @@ fun createCreateSessionTemplateDto(
   includeLocationGroupType = includeLocationGroupType,
   includeCategoryGroupType = includeCategoryGroupType,
   includeIncentiveGroupType = includeIncentiveGroupType,
+  visitOrderRestriction = visitOrderRestrictionType,
 )
 
 fun createUpdateSessionTemplateDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminCreateSessionsTemplateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminCreateSessionsTemplateTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.admin.ADMIN_SESSIO
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.UserClientDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.IncentiveLevel
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionCapacityDto
@@ -55,6 +56,7 @@ class AdminCreateSessionsTemplateTest : IntegrationTestBase() {
       includeLocationGroupType = true,
       includeCategoryGroupType = true,
       includeIncentiveGroupType = false,
+      visitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.NONE,
     )
 
     // When
@@ -88,6 +90,7 @@ class AdminCreateSessionsTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.includeCategoryGroupType).isTrue
     Assertions.assertThat(sessionTemplateDto.includeIncentiveGroupType).isFalse
     Assertions.assertThat(sessionTemplateDto.clients).isEqualTo(listOf(staffUserClient, publicUserClient))
+    Assertions.assertThat(sessionTemplateDto.visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.NONE)
   }
 
   @Test
@@ -125,6 +128,7 @@ class AdminCreateSessionsTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.clients.size).isEqualTo(2)
     Assertions.assertThat(sessionTemplateDto.clients[0]).isEqualTo(UserClientDto(STAFF, false))
     Assertions.assertThat(sessionTemplateDto.clients[1]).isEqualTo(UserClientDto(PUBLIC, true))
+    Assertions.assertThat(sessionTemplateDto.visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.VO_PVO)
   }
 
   @Test
@@ -158,6 +162,7 @@ class AdminCreateSessionsTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.prisonerIncentiveLevelGroups).isEmpty()
     Assertions.assertThat(sessionTemplateDto.active).isFalse
     Assertions.assertThat(sessionTemplateDto.clients).isEmpty()
+    Assertions.assertThat(sessionTemplateDto.visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.VO_PVO)
   }
 
   @Test
@@ -194,6 +199,7 @@ class AdminCreateSessionsTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.includeLocationGroupType).isEqualTo(dto.includeLocationGroupType)
     Assertions.assertThat(sessionTemplateDto.includeCategoryGroupType).isFalse
     Assertions.assertThat(sessionTemplateDto.includeIncentiveGroupType).isTrue
+    Assertions.assertThat(sessionTemplateDto.visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.VO_PVO)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminGetSessionTemplateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminGetSessionTemplateTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryTyp
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType.A_HIGH
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType.A_PROVISIONAL
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType.A_STANDARD
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.SessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
@@ -198,5 +199,6 @@ class AdminGetSessionTemplateTest(
     Assertions.assertThat(sessionTemplateDto.visitRoom).isEqualTo(sessionTemplate.visitRoom)
     Assertions.assertThat(sessionTemplateDto.sessionCapacity.closed).isEqualTo(sessionTemplate.closedCapacity)
     Assertions.assertThat(sessionTemplateDto.sessionCapacity.open).isEqualTo(sessionTemplate.openCapacity)
+    Assertions.assertThat(sessionTemplateDto.visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.VO_PVO)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminUpdateSessionTemplateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/admin/AdminUpdateSessionTemplateTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.controller.admin.ADMIN_SESSIO
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.UserClientDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.IncentiveLevel
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
@@ -117,6 +118,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
       incentiveLevelGroupReferences = mutableListOf(sessionIncentiveGroup.reference, sessionIncentiveGroup.reference),
       weeklyFrequency = sessionTemplateDefault.weeklyFrequency + 1,
       includeLocationGroupType = true,
+      visitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.NONE,
     )
 
     // When
@@ -145,6 +147,7 @@ class AdminUpdateSessionTemplateTest : IntegrationTestBase() {
     Assertions.assertThat(sessionTemplateDto.prisonerIncentiveLevelGroups[0].reference).isEqualTo(dto.incentiveLevelGroupReferences!![0])
     Assertions.assertThat(sessionTemplateDto.active).isEqualTo(true)
     Assertions.assertThat(sessionTemplateDto.includeLocationGroupType).isEqualTo(true)
+    Assertions.assertThat(sessionTemplateDto.visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.NONE)
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?


There are 4 options (VO_PVO, VO, PVO, NONE). This will eventually be used to restrict sessions to prisoners who have the required VO type.


## JIRA Link

https://dsdmoj.atlassian.net/browse/VB-5800
https://dsdmoj.atlassian.net/browse/VB-5431