### PR TITLE
Add call to alerts api on update

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,7 @@ generic-service:
     PRISONER_OFFENDER_SEARCH_URL: https://prisoner-search-dev.prison.service.justice.gov.uk
     PRISONER-CONTACT_REGISTRY_URL: https://prisoner-contact-registry-dev.prison.service.justice.gov.uk
     ACTIVITIES_API_URL: https://activities-api-dev.prison.service.justice.gov.uk
+    ALERTS_API_URL: https://alerts-api-dev.hmpps.service.justice.gov.uk
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     BOOKING_NOTICE_PERIOD_MAXIMUM_DAYS: 50
     TASK_REPORTING_VISIT-COUNTS-REPORT_CRON: "0 0 0/1 * * ?" #every hour on dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -28,6 +28,7 @@ generic-service:
     PRISONER_OFFENDER_SEARCH_URL: https://prisoner-search-preprod.prison.service.justice.gov.uk
     PRISONER-CONTACT_REGISTRY_URL: https://prisoner-contact-registry-preprod.prison.service.justice.gov.uk
     ACTIVITIES_API_URL: https://activities-api-preprod.prison.service.justice.gov.uk
+    ALERTS_API_URL: https://alerts-api-preprod.hmpps.service.justice.gov.uk
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     FEATURE_EVENTS_SNS_ENABLED: true
     MIGRATE_SESSIONTEMPLATE_MAPPING_OFFSET_DAYS: 0

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -29,6 +29,7 @@ generic-service:
     PRISONER_OFFENDER_SEARCH_URL: https://prisoner-search.prison.service.justice.gov.uk
     PRISONER-CONTACT_REGISTRY_URL: https://prisoner-contact-registry.prison.service.justice.gov.uk
     ACTIVITIES_API_URL: https://activities-api.prison.service.justice.gov.uk
+    ALERTS_API_URL: https://alerts-api.hmpps.service.justice.gov.uk
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     FEATURE_EVENTS_SNS_ENABLED: true
 

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -15,6 +15,7 @@ generic-service:
     PRISONER_OFFENDER_SEARCH_URL: https://prisoner-search-dev.prison.service.justice.gov.uk
     PRISONER-CONTACT_REGISTRY_URL: https://prisoner-contact-registry-dev.prison.service.justice.gov.uk
     ACTIVITIES_API_URL: https://activities-api-dev.prison.service.justice.gov.uk
+    ALERTS_API_URL: https://alerts-api-dev.hmpps.service.justice.gov.uk
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     FEATURE_EVENTS_SNS_ENABLED: false
     # Enable Swagger UI and Swagger API docs on Staging

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/AlertsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/AlertsApiClient.kt
@@ -28,10 +28,10 @@ class AlertsApiClient(
     .bodyToMono(TYPE_FOR_ALERT_INSTANCE)
     .onErrorResume { e ->
       if (!isNotFoundError(e)) {
-        logger.error("getAlertByUuid Failed get request for alert Uuid $alertUuid")
+        logger.info("getAlertByUuid Failed get request for alert Uuid $alertUuid")
         return@onErrorResume Mono.justOrEmpty(null)
       } else {
-        logger.debug("getAlertByUuid Not Found get request for alert Uuid $alertUuid")
+        logger.info("getAlertByUuid Not Found get request for alert Uuid $alertUuid")
         return@onErrorResume Mono.justOrEmpty(null)
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/AlertsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/AlertsApiClient.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.client
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.alerts.AlertDto
+import java.time.Duration
+
+@Component
+class AlertsApiClient(
+  @param:Qualifier("alertsApiWebClient") private val webClient: WebClient,
+  @param:Value("\${alerts.api.timeout:10s}") private val apiTimeout: Duration,
+) {
+
+  companion object {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val TYPE_FOR_ALERT_INSTANCE = object : ParameterizedTypeReference<AlertDto>() {}
+  }
+
+  fun getAlertByUuid(alertUuid: String): AlertDto? = webClient.get()
+    .uri("/alerts/$alertUuid")
+    .retrieve()
+    .bodyToMono(TYPE_FOR_ALERT_INSTANCE)
+    .onErrorResume { e ->
+      if (!isNotFoundError(e)) {
+        logger.error("getAlertByUuid Failed get request for alert Uuid $alertUuid")
+        return@onErrorResume Mono.justOrEmpty(null)
+      } else {
+        logger.debug("getAlertByUuid Not Found get request for alert Uuid $alertUuid")
+        return@onErrorResume Mono.justOrEmpty(null)
+      }
+    }
+    .block(apiTimeout)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/AlertsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/client/AlertsApiClient.kt
@@ -28,7 +28,7 @@ class AlertsApiClient(
     .bodyToMono(TYPE_FOR_ALERT_INSTANCE)
     .onErrorResume { e ->
       if (!isNotFoundError(e)) {
-        logger.info("getAlertByUuid Failed get request for alert Uuid $alertUuid")
+        logger.error("getAlertByUuid Failed get request for alert Uuid $alertUuid with error: ${e.message}")
         return@onErrorResume Mono.justOrEmpty(null)
       } else {
         logger.info("getAlertByUuid Not Found get request for alert Uuid $alertUuid")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/config/WebClientConfiguration.kt
@@ -23,6 +23,7 @@ class WebClientConfiguration(
   @param:Value("\${prisoner.offender.search.url}") private val prisonOffenderSearchBaseUrl: String,
   @param:Value("\${prisoner-contact.registry.url}") private val prisonContactRegistryUrl: String,
   @param:Value("\${activities.api.url}") private val activitiesApiBaseUrl: String,
+  @param:Value("\${alerts.api.url}") private val alertsApiBaseUrl: String,
   @param:Value("\${api.health.timeout:2s}") val healthTimeout: Duration,
   @param:Value("\${api.timeout:10s}") val apiTimeout: Duration,
 ) {
@@ -46,6 +47,9 @@ class WebClientConfiguration(
   fun prisonerContactRegistryWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = getWebClient(prisonContactRegistryUrl, authorizedClientManager, builder)
 
   @Bean
+  fun alertsApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = getWebClient(alertsApiBaseUrl, authorizedClientManager, builder)
+
+  @Bean
   fun prisonApiHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(prisonApiBaseUrl, healthTimeout)
 
   @Bean
@@ -59,6 +63,9 @@ class WebClientConfiguration(
 
   @Bean
   fun prisonerContactRegistryHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(prisonContactRegistryUrl, healthTimeout)
+
+  @Bean
+  fun alertsApiHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(alertsApiBaseUrl, healthTimeout)
 
   @Bean
   fun authorizedClientManager(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/alerts/AlertDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/alerts/AlertDto.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.alerts
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Alert dto response from alerts API")
+data class AlertDto(
+  @param:Schema(description = "The unique identifier assigned to the alert", example = "8cdadcf3-b003-4116-9956-c99bd8df6a00")
+  val alertUuid: String,
+
+  @param:Schema(description = "True / False based on alert status", example = "false", required = true)
+  @param:JsonProperty("isActive")
+  val active: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventService.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.client.ActivitiesApiClient
+import uk.gov.justice.digital.hmpps.visitscheduler.client.AlertsApiClient
 import uk.gov.justice.digital.hmpps.visitscheduler.client.PrisonerContactRegistryClient
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.IgnoreVisitNotificationsDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
@@ -73,8 +74,8 @@ class VisitNotificationEventService(
   private val pairedNotificationEventsUtil: PairedNotificationEventsUtil,
   private val prisonerContactRegistryClient: PrisonerContactRegistryClient,
   private val activitiesApiClient: ActivitiesApiClient,
+  private val alertsApiClient: AlertsApiClient,
 ) {
-
   @Autowired
   private lateinit var visitRepository: VisitRepository
 
@@ -219,12 +220,12 @@ class VisitNotificationEventService(
 
   private fun processAlertCreated(notificationDto: PrisonerAlertNotificationDto) {
     LOG.debug("Entered processAlertCreated, alert code {}, prisoner number - {}", notificationDto.alertCode, notificationDto.prisonerNumber)
-    processAlertUpserted(notificationDto, NotificationEventType.PRISONER_ALERT_CREATED_EVENT)
+    processAlertCreated(notificationDto, NotificationEventType.PRISONER_ALERT_CREATED_EVENT)
   }
 
   private fun processAlertUpdated(notificationDto: PrisonerAlertNotificationDto) {
     LOG.debug("Entered processAlertUpdated, alert code {}, prisoner number - {}", notificationDto.alertCode, notificationDto.prisonerNumber)
-    processAlertUpserted(notificationDto, NotificationEventType.PRISONER_ALERT_UPDATED_EVENT)
+    processAlertUpdated(notificationDto, NotificationEventType.PRISONER_ALERT_UPDATED_EVENT)
   }
 
   private fun processAlertDeleted(notificationDto: PrisonerAlertNotificationDto) {
@@ -232,14 +233,48 @@ class VisitNotificationEventService(
     processAlertDeleted(notificationDto, UnFlagEventReason.PRISONER_ALERT_DELETED)
   }
 
-  private fun processAlertUpserted(notificationDto: PrisonerAlertNotificationDto, notificationEventType: NotificationEventType) {
+  private fun processAlertCreated(notificationDto: PrisonerAlertNotificationDto, notificationEventType: NotificationEventType) {
     val affectedVisits = visitService.getFutureBookedVisits(notificationDto.prisonerNumber)
+    if (affectedVisits.isNotEmpty()) {
+      addAlertUpsertedNotificationEvents(
+        alertCode = notificationDto.alertCode,
+        alertUuid = notificationDto.alertUuid,
+        notificationEventType = notificationEventType,
+        affectedVisits = affectedVisits,
+      )
+    }
+  }
+
+  private fun processAlertUpdated(notificationDto: PrisonerAlertNotificationDto, notificationEventType: NotificationEventType) {
+    val affectedVisits = visitService.getFutureBookedVisits(notificationDto.prisonerNumber)
+    if (affectedVisits.isNotEmpty()) {
+      // retrieve alert
+      val alert = alertsApiClient.getAlertByUuid(notificationDto.alertUuid)
+
+      // if an alert is active, then we need to flag the visit as update events are also sent for deactivating an alert
+      // also adding an alert if an alert could not be retrieved
+      val isAlertNullOrActive = (alert == null || alert.active)
+      if (isAlertNullOrActive) {
+        addAlertUpsertedNotificationEvents(
+          alertCode = notificationDto.alertCode,
+          alertUuid = notificationDto.alertUuid,
+          notificationEventType = notificationEventType,
+          affectedVisits = affectedVisits,
+        )
+      } else {
+        LOG.info("Alert is not active, skipping alert update for alert Uuid {} and prisoner number {}", notificationDto.alertUuid, notificationDto.prisonerNumber)
+      }
+    }
+  }
+
+  private fun addAlertUpsertedNotificationEvents(affectedVisits: List<VisitDto>, alertCode: String, alertUuid: String, notificationEventType: NotificationEventType) {
     val notificationAttributes = hashMapOf(
-      NotificationEventAttributeType.ALERT_CODE to notificationDto.alertCode,
-      NotificationEventAttributeType.ALERT_UUID to notificationDto.alertUuid,
+      NotificationEventAttributeType.ALERT_CODE to alertCode,
+      NotificationEventAttributeType.ALERT_UUID to alertUuid,
     )
 
-    val processVisitNotificationDto = ProcessVisitNotificationDto(affectedVisits, notificationEventType, notificationAttributes)
+    val processVisitNotificationDto =
+      ProcessVisitNotificationDto(affectedVisits, notificationEventType, notificationAttributes)
     processVisitsWithNotifications(processVisitNotificationDto)
   }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,6 +42,12 @@ activities:
     url: https://activities-api-dev.prison.service.justice.gov.uk
     timeout: 10s
 
+alerts:
+  api:
+    url: https://alerts-api-dev.prison.service.justice.gov.uk
+    timeout: 10s
+
+
 policy:
   session:
     booking-notice-period:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -47,7 +47,6 @@ alerts:
     url: https://alerts-api-dev.prison.service.justice.gov.uk
     timeout: 10s
 
-
 policy:
   session:
     booking-notice-period:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -44,7 +44,7 @@ activities:
 
 alerts:
   api:
-    url: https://alerts-api-dev.prison.service.justice.gov.uk
+    url: https://alerts-api-dev.hmpps.service.justice.gov.uk
     timeout: 10s
 
 policy:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/IntegrationTestBase.kt
@@ -72,6 +72,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.integration.container.LocalSt
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.container.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.container.PostgresContainer
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.ActivitiesApiMockServer
+import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.AlertsApiMockServer
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.HmppsAuthExtension
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.NonAssociationsApiMockServer
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.mock.PrisonApiMockServer
@@ -224,6 +225,7 @@ abstract class IntegrationTestBase {
     internal val prisonOffenderSearchMockServer = PrisonOffenderSearchMockServer()
     internal val prisonerContactRegistryMockServer = PrisonerContactRegistryMockServer()
     internal val activitiesApiMockServer = ActivitiesApiMockServer()
+    internal val alertsApiMockServer = AlertsApiMockServer()
 
     @BeforeAll
     @JvmStatic
@@ -233,6 +235,7 @@ abstract class IntegrationTestBase {
       prisonOffenderSearchMockServer.start()
       prisonerContactRegistryMockServer.start()
       activitiesApiMockServer.start()
+      alertsApiMockServer.start()
     }
 
     @AfterAll
@@ -243,6 +246,7 @@ abstract class IntegrationTestBase {
       prisonOffenderSearchMockServer.stop()
       prisonerContactRegistryMockServer.stop()
       activitiesApiMockServer.stop()
+      alertsApiMockServer.stop()
     }
 
     private val pgContainer = PostgresContainer.instance

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/AlertsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/mock/AlertsApiMockServer.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.integration.mock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.alerts.AlertDto
+
+class AlertsApiMockServer : WireMockServer(8097) {
+
+  companion object {
+    val MAPPER: ObjectMapper = jacksonObjectMapper()
+  }
+
+  fun stubGetAlertDetails(
+    alertUuid: String,
+    alert: AlertDto?,
+    httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
+  ) {
+    stubFor(
+      get("/alerts/$alertUuid")
+        .willReturn(
+          if (alert == null) {
+            aResponse().withStatus(httpStatus.value())
+          } else {
+            aResponse()
+              .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+              .withStatus(200)
+              .withBody(
+                getJsonString(alert),
+              )
+          },
+        ),
+    )
+  }
+
+  private fun getJsonString(obj: Any): String = MAPPER.writer().withDefaultPrettyPrinter().writeValueAsString(obj)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/NotificationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/NotificationTestBase.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+import uk.gov.justice.digital.hmpps.visitscheduler.client.AlertsApiClient
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.visitnotification.NotificationCountDto
@@ -46,6 +47,9 @@ abstract class NotificationTestBase : IntegrationTestBase() {
 
   @MockitoSpyBean
   lateinit var visitNotificationEventRepository: VisitNotificationEventRepository
+
+  @MockitoSpyBean
+  lateinit var alertsApiClientSpy: AlertsApiClient
 
   @Captor
   lateinit var mapCapture: ArgumentCaptor<Map<String, String>>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertUpdatedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertUpdatedNotificationControllerTest.kt
@@ -10,9 +10,11 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Propagation.SUPPORTS
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_NOTIFICATION_PRISONER_ALERT_UPDATED_PATH
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.alerts.AlertDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationMethodType.NOT_KNOWN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
@@ -124,6 +126,8 @@ class PrisonerAlertUpdatedNotificationControllerTest : NotificationTestBase() {
       sessionTemplate = sessionTemplate1,
     )
 
+    alertsApiMockServer.stubGetAlertDetails(notificationDto.alertUuid, AlertDto(notificationDto.alertUuid, true))
+
     // When
     val responseSpec = callNotifyVSiPThatPrisonerAlertHasBeenUpdated(
       webTestClient,
@@ -145,6 +149,7 @@ class PrisonerAlertUpdatedNotificationControllerTest : NotificationTestBase() {
 
     assertFlaggedVisitEvent(listOf(visit1), NotificationEventType.PRISONER_ALERT_UPDATED_EVENT)
     verify(telemetryClient, times(1)).trackEvent(eq("flagged-visit-event"), any(), isNull())
+    verify(alertsApiClientSpy, times(1)).getAlertByUuid(notificationDto.alertUuid)
   }
 
   @Test
@@ -203,6 +208,7 @@ class PrisonerAlertUpdatedNotificationControllerTest : NotificationTestBase() {
 
     assertFlaggedVisitEvent(listOf(visit1, visit2), NotificationEventType.PRISONER_ALERT_UPDATED_EVENT)
     verify(telemetryClient, times(2)).trackEvent(eq("flagged-visit-event"), any(), isNull())
+    verify(alertsApiClientSpy, times(1)).getAlertByUuid(notificationDto.alertUuid)
   }
 
   @Test
@@ -275,6 +281,151 @@ class PrisonerAlertUpdatedNotificationControllerTest : NotificationTestBase() {
     val auditEvents = testEventAuditRepository.getAuditByType(PRISONER_ALERT_UPDATED_EVENT)
     assertThat(auditEvents).hasSize(0)
     verify(telemetryClient, times(0)).trackEvent(eq("flagged-visit-event"), any(), isNull())
+    verify(alertsApiClientSpy, times(0)).getAlertByUuid(notificationDto.alertUuid)
+  }
+
+  @Test
+  fun `when prisoner has had an alert updated but alert is inactive then no future booked visits for the prisoner are flagged`() {
+    // Given
+    val notificationDto = PrisonerAlertNotificationDto(
+      prisonerNumber = prisonerId,
+      alertCode = "C1",
+      alertUuid = "1234-5678-abcd",
+      description = "alert updated",
+    )
+
+    // future booked visit
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    // the alert is inactive - so no visits should be flagged
+    alertsApiMockServer.stubGetAlertDetails(notificationDto.alertUuid, AlertDto(notificationDto.alertUuid, false))
+
+    // When
+    val responseSpec = callNotifyVSiPThatPrisonerAlertHasBeenUpdated(
+      webTestClient,
+      roleVisitSchedulerHttpHeaders,
+      notificationDto,
+    )
+
+    // Then
+    responseSpec.expectStatus().isOk
+    verify(visitNotificationEventRepository, times(0)).saveAndFlush(any<VisitNotificationEvent>())
+
+    val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
+    assertThat(visitNotifications).hasSize(0)
+
+    val auditEvents = testEventAuditRepository.getAuditByType(PRISONER_ALERT_UPDATED_EVENT)
+    assertThat(auditEvents).hasSize(0)
+    verify(telemetryClient, times(0)).trackEvent(eq("flagged-visit-event"), any(), isNull())
+    verify(alertsApiClientSpy, times(1)).getAlertByUuid(notificationDto.alertUuid)
+  }
+
+  @Test
+  fun `when prisoner has had an alert updated but alerts-api returns a NOT_FOUND then too any future booked visits for the prisoner are flagged`() {
+    // Given
+    val notificationDto = PrisonerAlertNotificationDto(
+      prisonerNumber = prisonerId,
+      alertCode = "C1",
+      alertUuid = "1234-5678-abcd",
+      description = "alert updated",
+    )
+
+    val expectedEventAttributes = mapOf(
+      NotificationEventAttributeType.ALERT_CODE to notificationDto.alertCode,
+      NotificationEventAttributeType.ALERT_UUID to notificationDto.alertUuid,
+    )
+
+    // future booked visit
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    // the alert is inactive - so no visits should be flagged
+    alertsApiMockServer.stubGetAlertDetails(notificationDto.alertUuid, null, HttpStatus.NOT_FOUND)
+
+    // When
+    val responseSpec = callNotifyVSiPThatPrisonerAlertHasBeenUpdated(
+      webTestClient,
+      roleVisitSchedulerHttpHeaders,
+      notificationDto,
+    )
+
+    // Then
+    responseSpec.expectStatus().isOk
+    verify(visitNotificationEventRepository, times(1)).saveAndFlush(any<VisitNotificationEvent>())
+
+    val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
+    assertThat(visitNotifications).hasSize(1)
+    assertNotificationEvent(visitNotifications[0], visit1, expectedEventAttributes)
+
+    val auditEvents = testEventAuditRepository.getAuditByType(PRISONER_ALERT_UPDATED_EVENT)
+    assertThat(auditEvents).hasSize(1)
+    assertAuditEvent(auditEvents[0], visit = visit1, eventType = PRISONER_ALERT_UPDATED_EVENT)
+
+    assertFlaggedVisitEvent(listOf(visit1), NotificationEventType.PRISONER_ALERT_UPDATED_EVENT)
+    verify(telemetryClient, times(1)).trackEvent(eq("flagged-visit-event"), any(), isNull())
+    verify(alertsApiClientSpy, times(1)).getAlertByUuid(notificationDto.alertUuid)
+  }
+
+  @Test
+  fun `when prisoner has had an alert updated but alerts-api returns an INTERNAL_SERVER_ERROR then too future booked visits for the prisoner are flagged`() {
+    // Given
+    val notificationDto = PrisonerAlertNotificationDto(
+      prisonerNumber = prisonerId,
+      alertCode = "C1",
+      alertUuid = "1234-5678-abcd",
+      description = "alert updated",
+    )
+
+    val expectedEventAttributes = mapOf(
+      NotificationEventAttributeType.ALERT_CODE to notificationDto.alertCode,
+      NotificationEventAttributeType.ALERT_UUID to notificationDto.alertUuid,
+    )
+
+    // future booked visit
+    val visit1 = createApplicationAndVisit(
+      prisonerId = notificationDto.prisonerNumber,
+      slotDate = LocalDate.now().plusDays(1),
+      visitStatus = BOOKED,
+      sessionTemplate = sessionTemplate1,
+    )
+    eventAuditEntityHelper.create(visit1)
+
+    // the alert is inactive - so no visits should be flagged
+    alertsApiMockServer.stubGetAlertDetails(notificationDto.alertUuid, null, HttpStatus.INTERNAL_SERVER_ERROR)
+
+    // When
+    val responseSpec = callNotifyVSiPThatPrisonerAlertHasBeenUpdated(
+      webTestClient,
+      roleVisitSchedulerHttpHeaders,
+      notificationDto,
+    )
+
+    // Then
+    responseSpec.expectStatus().isOk
+    verify(visitNotificationEventRepository, times(1)).saveAndFlush(any<VisitNotificationEvent>())
+
+    val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
+    assertThat(visitNotifications).hasSize(1)
+    assertNotificationEvent(visitNotifications[0], visit1, expectedEventAttributes)
+
+    val auditEvents = testEventAuditRepository.getAuditByType(PRISONER_ALERT_UPDATED_EVENT)
+    assertThat(auditEvents).hasSize(1)
+    assertAuditEvent(auditEvents[0], visit = visit1, eventType = PRISONER_ALERT_UPDATED_EVENT)
+
+    assertFlaggedVisitEvent(listOf(visit1), NotificationEventType.PRISONER_ALERT_UPDATED_EVENT)
+    verify(telemetryClient, times(1)).trackEvent(eq("flagged-visit-event"), any(), isNull())
+    verify(alertsApiClientSpy, times(1)).getAlertByUuid(notificationDto.alertUuid)
   }
 
   private fun assertNotificationEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertUpdatedNotificationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/notifications/PrisonerAlertUpdatedNotificationControllerTest.kt
@@ -350,7 +350,7 @@ class PrisonerAlertUpdatedNotificationControllerTest : NotificationTestBase() {
     )
     eventAuditEntityHelper.create(visit1)
 
-    // the alert is inactive - so no visits should be flagged
+    // the alert API returns a NOT_FOUND - still visits should be flagged
     alertsApiMockServer.stubGetAlertDetails(notificationDto.alertUuid, null, HttpStatus.NOT_FOUND)
 
     // When
@@ -378,7 +378,7 @@ class PrisonerAlertUpdatedNotificationControllerTest : NotificationTestBase() {
   }
 
   @Test
-  fun `when prisoner has had an alert updated but alerts-api returns an INTERNAL_SERVER_ERROR then too future booked visits for the prisoner are flagged`() {
+  fun `when prisoner has had an alert updated but alerts-api returns an INTERNAL_SERVER_ERROR then too any future booked visits for the prisoner are flagged`() {
     // Given
     val notificationDto = PrisonerAlertNotificationDto(
       prisonerNumber = prisonerId,
@@ -401,7 +401,7 @@ class PrisonerAlertUpdatedNotificationControllerTest : NotificationTestBase() {
     )
     eventAuditEntityHelper.create(visit1)
 
-    // the alert is inactive - so no visits should be flagged
+    // the alert API returns an INTERNAL_SERVER_ERROR - still visits should be flagged
     alertsApiMockServer.stubGetAlertDetails(notificationDto.alertUuid, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitNotificationEventServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.visitscheduler.client.ActivitiesApiClient
+import uk.gov.justice.digital.hmpps.visitscheduler.client.AlertsApiClient
 import uk.gov.justice.digital.hmpps.visitscheduler.client.PrisonerContactRegistryClient
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.PrisonerDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NonAssociationDomainEventType.NON_ASSOCIATION_CREATED
@@ -31,6 +32,7 @@ class VisitNotificationEventServiceTest {
   private val prisonerContactRegistryClient = mock<PrisonerContactRegistryClient>()
   private val pairedNotificationEventsUtil = mock<PairedNotificationEventsUtil>()
   private val activitiesApiClient = mock<ActivitiesApiClient>()
+  private val alertsApiClient = mock<AlertsApiClient>()
 
   private lateinit var visitNotificationEventService: VisitNotificationEventService
 
@@ -40,7 +42,7 @@ class VisitNotificationEventServiceTest {
 
   @BeforeEach
   fun beforeEachTestSetup() {
-    visitNotificationEventService = VisitNotificationEventService(visitService, visitNotificationEventRepository, prisonerService, visitNotificationFlaggingService, pairedNotificationEventsUtil, prisonerContactRegistryClient, activitiesApiClient)
+    visitNotificationEventService = VisitNotificationEventService(visitService, visitNotificationEventRepository, prisonerService, visitNotificationFlaggingService, pairedNotificationEventsUtil, prisonerContactRegistryClient, activitiesApiClient, alertsApiClient)
 
     whenever(prisonerService.getPrisoner(primaryNonAssociationNumber)).thenReturn(
       PrisonerDto(

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -53,6 +53,11 @@ activities:
     url: http://localhost:8096
     timeout: 5s
 
+alerts:
+  api:
+    url: http://localhost:8097
+    timeout: 10s
+
 policy:
   session:
     non-association:


### PR DESCRIPTION
## What does this pull request do?

Since a person-alerts.updated is also sent when an alert is deactivated - adding a check to see if an alert is active before adding an update event.

## What is the intent behind these changes?

Handling alerts from alerts API