### PR TITLE
VB-6319 - Remand prisoner limits for social visits

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/PrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/PrisonDto.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
+import java.time.DayOfWeek
 
 @Schema(description = "Prison dto")
 data class PrisonDto(
@@ -20,6 +21,7 @@ data class PrisonDto(
   @field:NotNull
   @field:Min(0)
   val policyNoticeDaysMin: Int,
+
   @param:Schema(description = "maximum number of days notice from the current date to booked a visit", example = "28", required = true)
   @field:NotNull
   @field:Min(0)
@@ -29,17 +31,28 @@ data class PrisonDto(
   @field:NotNull
   @field:Min(1)
   val maxTotalVisitors: Int,
+
   @param:Schema(description = "Max number of adults")
   @field:NotNull
   @field:Min(1)
   val maxAdultVisitors: Int,
+
   @param:Schema(description = "Max number of children")
   @field:NotNull
   @field:Min(0)
   val maxChildVisitors: Int,
+
   @param:Schema(description = "Age of adults in years")
   @field:NotNull
   val adultAgeYears: Int,
+
+  @param:Schema(description = "The week day of which the prison week starts on. Enum value, any day of the week MONDAY - SUNDAY", defaultValue = "MONDAY")
+  var weekStartDay: DayOfWeek = DayOfWeek.MONDAY,
+
+  @param:Schema(description = "The limit per prison week, the number of remand visits that can be booked per week", defaultValue = "3")
+  @field:Min(1)
+  var remandVisitLimitPerWeek: Int = 3,
+
   @param:Schema(description = "prison user client", required = false)
   val clients: List<UserClientDto> = mutableListOf(),
 ) {
@@ -52,6 +65,8 @@ data class PrisonDto(
     maxAdultVisitors = prisonEntity.maxAdultVisitors,
     maxChildVisitors = prisonEntity.maxChildVisitors,
     adultAgeYears = prisonEntity.adultAgeYears,
+    weekStartDay = prisonEntity.weekStartDay,
+    remandVisitLimitPerWeek = prisonEntity.remandVisitLimitPerWeek,
     clients = prisonEntity.clients.map { UserClientDto(it.userType, it.active) }.toList(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/Prison.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/model/entity/Prison.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.visitscheduler.model.entity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -12,6 +14,7 @@ import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.PrisonDto
+import java.time.DayOfWeek
 import java.time.LocalDateTime
 
 @Entity
@@ -25,17 +28,28 @@ class Prison(
 
   @Column(name = "policy_notice_days_min")
   var policyNoticeDaysMin: Int,
+
   @Column(name = "policy_notice_days_max")
   var policyNoticeDaysMax: Int,
 
   @Column(name = "max_total_visitors")
   var maxTotalVisitors: Int,
+
   @Column(name = "max_adult_visitors")
   var maxAdultVisitors: Int,
+
   @Column(name = "max_child_visitors")
   var maxChildVisitors: Int,
+
   @Column(name = "adult_age_years")
   var adultAgeYears: Int,
+
+  @Column(name = "week_start_day")
+  @Enumerated(EnumType.STRING)
+  var weekStartDay: DayOfWeek,
+
+  @Column(name = "remand_visit_limit_per_week")
+  var remandVisitLimitPerWeek: Int,
 
   @CreationTimestamp
   @Column
@@ -78,5 +92,7 @@ class Prison(
     maxAdultVisitors = dto.maxAdultVisitors,
     maxChildVisitors = dto.maxChildVisitors,
     adultAgeYears = dto.adultAgeYears,
+    weekStartDay = dto.weekStartDay,
+    remandVisitLimitPerWeek = dto.remandVisitLimitPerWeek,
   )
 }

--- a/src/main/resources/db/migration/V4_4__add_remand_limit_fields_to_prison_table.sql
+++ b/src/main/resources/db/migration/V4_4__add_remand_limit_fields_to_prison_table.sql
@@ -1,0 +1,11 @@
+alter table prison
+    add column week_start_day varchar(10) not null default 'MONDAY',
+    add column remand_visit_limit_per_week integer not null default 3;
+
+alter table prison
+    add constraint prison_week_start_day_valid
+        check (week_start_day in ('MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'));
+
+alter table prison
+    add constraint remand_visit_limit_per_week_positive
+        check (remand_visit_limit_per_week > 0);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityDataLoader.kt
@@ -95,7 +95,9 @@ class PrisonEntityHelper(
       maxAdultVisitors: Int = 3,
       maxChildVisitors: Int = 3,
       adultAgeYears: Int = 18,
-    ): Prison = Prison(code = prisonCode, active = activePrison, policyNoticeDaysMin, policyNoticeDaysMax, maxTotalVisitors, maxAdultVisitors, maxChildVisitors, adultAgeYears)
+      weekStartDay: DayOfWeek = DayOfWeek.MONDAY,
+      remandVisitLimitPerWeek: Int = 3,
+    ): Prison = Prison(code = prisonCode, active = activePrison, policyNoticeDaysMin, policyNoticeDaysMax, maxTotalVisitors, maxAdultVisitors, maxChildVisitors, adultAgeYears, weekStartDay, remandVisitLimitPerWeek)
 
     fun createPrisonDto(
       prisonCode: String = "AWE",
@@ -107,6 +109,8 @@ class PrisonEntityHelper(
       maxAdultVisitors: Int = 3,
       maxChildVisitors: Int = 3,
       adultAgeYears: Int = 18,
+      weekStartDay: DayOfWeek = DayOfWeek.MONDAY,
+      remandVisitLimitPerWeek: Int = 3,
     ): PrisonDto = PrisonDto(
       code = prisonCode,
       active = activePrison,
@@ -117,6 +121,8 @@ class PrisonEntityHelper(
       maxChildVisitors = maxChildVisitors,
       adultAgeYears = adultAgeYears,
       clients = clients,
+      weekStartDay = weekStartDay,
+      remandVisitLimitPerWeek = remandVisitLimitPerWeek,
     )
 
     fun updatePrisonDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityTestBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/helper/EntityTestBuilder.kt
@@ -43,7 +43,9 @@ fun prison(
   maxChildVisitors: Int = 3,
   adultAgeYears: Int = 18,
   isActive: Boolean = true,
-): Prison = Prison(code = prisonCode, active = isActive, policyNoticeDaysMin, policyNoticeDaysMax, maxTotalVisitors, maxAdultVisitors, maxChildVisitors, adultAgeYears)
+  weekStartDay: DayOfWeek = DayOfWeek.MONDAY,
+  remandVisitLimitPerWeek: Int = 3,
+): Prison = Prison(code = prisonCode, active = isActive, policyNoticeDaysMin, policyNoticeDaysMax, maxTotalVisitors, maxAdultVisitors, maxChildVisitors, adultAgeYears, weekStartDay, remandVisitLimitPerWeek)
 
 fun sessionTemplate(
   name: String = "sessionTemplate_",
@@ -115,6 +117,8 @@ fun sessionTemplate(
   maxAdultVisitors: Int = 3,
   maxChildVisitors: Int = 3,
   adultAgeYears: Int = 18,
+  weekStartDay: DayOfWeek = DayOfWeek.MONDAY,
+  remandVisitLimitPerWeek: Int = 3,
   isActive: Boolean = true,
   includeLocationGroupType: Boolean = true,
   includeCategoryGroupType: Boolean = true,
@@ -122,7 +126,7 @@ fun sessionTemplate(
   userTypes: List<UserType> = listOf(UserType.STAFF, UserType.PUBLIC),
   visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
 ): SessionTemplate {
-  val prison = Prison(code = prisonCode, active = isActive, policyNoticeDaysMin, policyNoticeDaysMax, maxTotalVisitors, maxAdultVisitors, maxChildVisitors, adultAgeYears)
+  val prison = Prison(code = prisonCode, active = isActive, policyNoticeDaysMin, policyNoticeDaysMax, maxTotalVisitors, maxAdultVisitors, maxChildVisitors, adultAgeYears, weekStartDay, remandVisitLimitPerWeek)
 
   var sessionTemplate = SessionTemplate(
     name = name + dayOfWeek,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/prison/PrisonConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/prison/PrisonConfigTest.kt
@@ -64,6 +64,8 @@ class PrisonConfigTest : IntegrationTestBase() {
     Assertions.assertThat(result.maxAdultVisitors).isEqualTo(prisonDto.maxAdultVisitors)
     Assertions.assertThat(result.maxChildVisitors).isEqualTo(prisonDto.maxChildVisitors)
     Assertions.assertThat(result.adultAgeYears).isEqualTo(prisonDto.adultAgeYears)
+    Assertions.assertThat(result.weekStartDay).isEqualTo(prisonDto.weekStartDay)
+    Assertions.assertThat(result.remandVisitLimitPerWeek).isEqualTo(prisonDto.remandVisitLimitPerWeek)
 
     verify(prisonConfigServiceSpy, times(1)).createPrison(any())
     verify(prisonRepositorySpy, times(1)).saveAndFlush(any())
@@ -298,6 +300,8 @@ class PrisonConfigTest : IntegrationTestBase() {
     Assertions.assertThat(returnedPrison.active).isTrue
     Assertions.assertThat(returnedPrison.policyNoticeDaysMin).isEqualTo(prison.policyNoticeDaysMin)
     Assertions.assertThat(returnedPrison.policyNoticeDaysMax).isEqualTo(prison.policyNoticeDaysMax)
+    Assertions.assertThat(returnedPrison.weekStartDay).isEqualTo(prison.weekStartDay)
+    Assertions.assertThat(returnedPrison.remandVisitLimitPerWeek).isEqualTo(prison.remandVisitLimitPerWeek)
   }
 
   private fun getPrison(returnResult: WebTestClient.BodyContentSpec): PrisonDto = objectMapper.readValue(returnResult.returnResult().responseBody, PrisonDto::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitStoreServiceTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionSlot
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.PrisonRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.VisitRepository
+import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
@@ -91,6 +92,8 @@ internal class VisitStoreServiceTest {
         maxAdultVisitors = 1,
         maxChildVisitors = 1,
         adultAgeYears = 18,
+        weekStartDay = DayOfWeek.MONDAY,
+        remandVisitLimitPerWeek = 3,
       )
 
     private val sessionSlot = SessionSlot(
@@ -184,6 +187,8 @@ internal class VisitStoreServiceTest {
         maxAdultVisitors = 1,
         maxChildVisitors = 1,
         adultAgeYears = 18,
+        weekStartDay = DayOfWeek.MONDAY,
+        remandVisitLimitPerWeek = 3,
       )
 
     private val sessionSlot = SessionSlot(


### PR DESCRIPTION
## What does this pull request do?

Add new columns in the Prison table and corresponding entity, to capture the prisons "week start date" which is how we determine what day of the week the prison starts their week. Also add a limit INT field to store the value of "max visits per week for remand prisoners".

Update DTOs to use default value to not break existing contracts with certain admin endpoints.


## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6319
https://dsdmoj.atlassian.net/browse/VB-6728