### PR TITLE
VB-6283 - Visit request rejection reason

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/ApproveRejectionVisitRequestBodyDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/ApproveRejectionVisitRequestBodyDto.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.RejectionReason
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRequestRejectionReason
 
 data class ApproveRejectionVisitRequestBodyDto(
   @field:Schema(description = "Reference of the visit for approval", required = true)
@@ -12,5 +12,5 @@ data class ApproveRejectionVisitRequestBodyDto(
   @field:NotNull
   val actionedBy: String,
   @field:Schema(description = "Reason for rejecting a visit request", required = false)
-  val rejectionReason: RejectionReason? = null,
+  val visitRequestRejectionReason: VisitRequestRejectionReason? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/ApproveRejectionVisitRequestBodyDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/ApproveRejectionVisitRequestBodyDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.visitscheduler.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.RejectionReason
 
 data class ApproveRejectionVisitRequestBodyDto(
   @field:Schema(description = "Reference of the visit for approval", required = true)
@@ -10,4 +11,6 @@ data class ApproveRejectionVisitRequestBodyDto(
   @field:Schema(description = "Username for user who actioned this request", required = true)
   @field:NotNull
   val actionedBy: String,
+  @field:Schema(description = "Reason for rejecting a visit request", required = false)
+  val rejectionReason: RejectionReason? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/RejectionReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/RejectionReason.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.visitscheduler.dto.enums
+
+enum class RejectionReason {
+  NO_VISIT_ALLOWANCE,
+  ALERT_OR_RESTRICTION,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/VisitRequestRejectionReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/dto/enums/VisitRequestRejectionReason.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.visitscheduler.dto.enums
 
-enum class RejectionReason {
+enum class VisitRequestRejectionReason {
   NO_VISIT_ALLOWANCE,
   ALERT_OR_RESTRICTION,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/TelemetryClientService.kt
@@ -18,7 +18,8 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitorDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.application.ApplicationDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.audit.EventAuditDto
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.AutoRejectionReason
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.REQUESTED_VISIT_AUTO_REJECTED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.REQUESTED_VISIT_REJECTED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.TelemetryVisitEvents
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.TelemetryVisitEvents.ADD_PRISON_EXCLUDE_DATE_EVENT
@@ -264,11 +265,10 @@ class TelemetryClientService(
   fun trackVisitRequestAutoRejectedEvent(
     bookedVisitDto: VisitDto,
     eventAuditDto: EventAuditDto,
-    rejectionReason: AutoRejectionReason,
   ) {
     trackEvent(
       TelemetryVisitEvents.VISIT_REQUEST_AUTO_REJECTED_EVENT,
-      createVisitRequestApprovedOrRejectedTrackData(bookedVisitDto, eventAuditDto, rejectionReason),
+      createVisitRequestApprovedOrRejectedTrackData(bookedVisitDto, eventAuditDto),
     )
   }
 
@@ -363,12 +363,15 @@ class TelemetryClientService(
   private fun createVisitRequestApprovedOrRejectedTrackData(
     visitDto: VisitDto,
     eventAudit: EventAuditDto,
-    rejectionReason: AutoRejectionReason? = null,
   ): MutableMap<String, String> {
     val data = createDefaultVisitData(visitDto)
 
-    if (rejectionReason != null) {
-      data["autoRejectionReason"] = rejectionReason.description
+    eventAudit.text?.let {
+      when (eventAudit.type) {
+        REQUESTED_VISIT_AUTO_REJECTED -> data["autoRejectionReason"] = it
+        REQUESTED_VISIT_REJECTED -> data["rejectionReason"] = it
+        else -> {}
+      }
     }
 
     createEventAuditData(eventAudit, data)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitEventAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitEventAuditService.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.MIGR
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.REQUESTED_VISIT_WITHDRAWN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.RESERVED_VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.RejectionReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PRISONER
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
@@ -300,6 +301,7 @@ class VisitEventAuditService {
     actionedByValue: String,
     visit: VisitDto,
     isApproved: Boolean,
+    rejectionReason: RejectionReason? = null,
   ): EventAuditDto {
     val actionedBy = createOrGetActionBy(actionedByValue, STAFF)
 
@@ -318,7 +320,7 @@ class VisitEventAuditService {
           sessionTemplateReference = visit.sessionTemplateReference,
           eventType,
           applicationMethodType = ApplicationMethodType.WEBSITE,
-          text = null,
+          text = if (isApproved) null else rejectionReason?.name,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitEventAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitEventAuditService.kt
@@ -24,12 +24,12 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.MIGR
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.REQUESTED_VISIT_WITHDRAWN
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType.RESERVED_VISIT
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.RejectionReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PRISONER
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.SYSTEM
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRequestRejectionReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.ActionedBy
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.EventAudit
@@ -301,7 +301,7 @@ class VisitEventAuditService {
     actionedByValue: String,
     visit: VisitDto,
     isApproved: Boolean,
-    rejectionReason: RejectionReason? = null,
+    visitRequestRejectionReason: VisitRequestRejectionReason? = null,
   ): EventAuditDto {
     val actionedBy = createOrGetActionBy(actionedByValue, STAFF)
 
@@ -320,7 +320,7 @@ class VisitEventAuditService {
           sessionTemplateReference = visit.sessionTemplateReference,
           eventType,
           applicationMethodType = ApplicationMethodType.WEBSITE,
-          text = if (isApproved) null else rejectionReason?.name,
+          text = if (isApproved) null else visitRequestRejectionReason?.name,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsApprovalRejectionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsApprovalRejectionService.kt
@@ -44,7 +44,7 @@ class VisitRequestsApprovalRejectionService(
       approvalVisitRequestBodyDto.actionedBy,
       actionedVisitDto,
       isApproved,
-      approvalVisitRequestBodyDto.rejectionReason,
+      approvalVisitRequestBodyDto.visitRequestRejectionReason,
     )
 
     val unflagEventReason = if (isApproved) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsApprovalRejectionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsApprovalRejectionService.kt
@@ -40,7 +40,12 @@ class VisitRequestsApprovalRejectionService(
 
     val actionedVisitDto = visitDtoBuilder.build(visitRepository.findByReference(visitReference)!!)
 
-    val eventAuditDto = visitEventAuditService.saveVisitRequestApprovedOrRejectedEventAudit(approvalVisitRequestBodyDto.actionedBy, actionedVisitDto, isApproved)
+    val eventAuditDto = visitEventAuditService.saveVisitRequestApprovedOrRejectedEventAudit(
+      approvalVisitRequestBodyDto.actionedBy,
+      actionedVisitDto,
+      isApproved,
+      approvalVisitRequestBodyDto.rejectionReason,
+    )
 
     val unflagEventReason = if (isApproved) {
       UnFlagEventReason.VISIT_REQUEST_APPROVED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/VisitRequestsService.kt
@@ -121,7 +121,6 @@ class VisitRequestsService(
       telemetryClientService.trackVisitRequestAutoRejectedEvent(
         autoRejectResponseDto.visitDto,
         autoRejectResponseDto.eventAuditDto,
-        autoRejectionReason,
       )
 
       val snsDomainEventPublishDto = SnsDomainEventPublishDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/task/AutoRejectVisitRequestsScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/task/AutoRejectVisitRequestsScheduleTest.kt
@@ -5,7 +5,7 @@ import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
+import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
@@ -15,6 +15,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.transaction.annotation.Propagation.SUPPORTS
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.AutoRejectionReason.MINIMUM_BOOKING_WINDOW_REACHED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitSubStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.integration.IntegrationTestBase
@@ -61,10 +62,16 @@ class AutoRejectVisitRequestsScheduleTest : IntegrationTestBase() {
     autoRejectVisitRequestsTask.autoRejectRequestVisits()
 
     // Then
-    verify(telemetryClient, times(1)).trackEvent(eq("visit-request-auto-rejected"), any(), isNull())
+    verify(telemetryClient, times(1)).trackEvent(
+      eq("visit-request-auto-rejected"),
+      check {
+        assertThat(it["autoRejectionReason"]).isEqualTo(MINIMUM_BOOKING_WINDOW_REACHED.description)
+      },
+      isNull(),
+    )
     verify(telemetryClient).trackEvent(
       eq("prison-visit.cancelled-domain-event"),
-      org.mockito.kotlin.check {
+      check {
         assertThat(it["reference"]).isEqualTo(requestVisitForRejectionMdi.reference)
       },
       isNull(),
@@ -97,10 +104,16 @@ class AutoRejectVisitRequestsScheduleTest : IntegrationTestBase() {
     autoRejectVisitRequestsTask.autoRejectRequestVisits()
 
     // Then
-    verify(telemetryClient, times(1)).trackEvent(eq("visit-request-auto-rejected"), any(), isNull())
+    verify(telemetryClient, times(1)).trackEvent(
+      eq("visit-request-auto-rejected"),
+      check {
+        assertThat(it["autoRejectionReason"]).isEqualTo(MINIMUM_BOOKING_WINDOW_REACHED.description)
+      },
+      isNull(),
+    )
     verify(telemetryClient).trackEvent(
       eq("prison-visit.cancelled-domain-event"),
-      org.mockito.kotlin.check {
+      check {
         assertThat(it["reference"]).isEqualTo(requestVisitForRejectionHei.reference)
       },
       isNull(),
@@ -133,10 +146,16 @@ class AutoRejectVisitRequestsScheduleTest : IntegrationTestBase() {
     autoRejectVisitRequestsTask.autoRejectRequestVisits()
 
     // Then
-    verify(telemetryClient, times(1)).trackEvent(eq("visit-request-auto-rejected"), any(), isNull())
+    verify(telemetryClient, times(1)).trackEvent(
+      eq("visit-request-auto-rejected"),
+      check {
+        assertThat(it["autoRejectionReason"]).isEqualTo(MINIMUM_BOOKING_WINDOW_REACHED.description)
+      },
+      isNull(),
+    )
     verify(telemetryClient).trackEvent(
       eq("prison-visit.cancelled-domain-event"),
-      org.mockito.kotlin.check {
+      check {
         assertThat(it["reference"]).isEqualTo(requestVisitForRejectionCfi.reference)
       },
       isNull(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/RejectVisitRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/RejectVisitRequestTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.RejectionReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
@@ -67,7 +68,11 @@ class RejectVisitRequestTest : IntegrationTestBase() {
     val visitPrimary = createApplicationAndVisit(sessionTemplate = sessionTemplateDefault, visitRestriction = VisitRestriction.OPEN, visitStatus = BOOKED, visitSubStatus = VisitSubStatus.REQUESTED)
     eventAuditEntityHelper.create(visitPrimary, type = EventAuditType.REQUESTED_VISIT)
 
-    val rejectVisitRequestBodyDto = ApproveRejectionVisitRequestBodyDto(visitReference = visitPrimary.reference, actionedBy = "user1")
+    val rejectVisitRequestBodyDto = ApproveRejectionVisitRequestBodyDto(
+      visitReference = visitPrimary.reference,
+      actionedBy = "user1",
+      rejectionReason = RejectionReason.NO_VISIT_ALLOWANCE,
+    )
 
     // When
     val responseSpec = callRejectVisitRequest(webTestClient, visitPrimary.reference, rejectVisitRequestBodyDto, roleVisitSchedulerHttpHeaders)
@@ -86,6 +91,8 @@ class RejectVisitRequestTest : IntegrationTestBase() {
         EventAuditType.REQUESTED_VISIT,
         EventAuditType.REQUESTED_VISIT_REJECTED,
       )
+      assertThat(it.single { event -> event.type == EventAuditType.REQUESTED_VISIT_REJECTED }.text)
+        .isEqualTo(RejectionReason.NO_VISIT_ALLOWANCE.name)
     }
 
     verify(telemetryClient).trackEvent(
@@ -94,6 +101,7 @@ class RejectVisitRequestTest : IntegrationTestBase() {
         assertThat(map["reference"]).isEqualTo(visitPrimary.reference)
         assertThat(map["visitStatus"]).isEqualTo(VisitStatus.CANCELLED.name)
         assertThat(map["visitSubStatus"]).isEqualTo(VisitSubStatus.REJECTED.name)
+        assertThat(map["rejectionReason"]).isEqualTo(RejectionReason.NO_VISIT_ALLOWANCE.name)
         true
       },
       isNull(),
@@ -129,6 +137,7 @@ class RejectVisitRequestTest : IntegrationTestBase() {
         EventAuditType.REQUESTED_VISIT,
         EventAuditType.REQUESTED_VISIT_REJECTED,
       )
+      assertThat(it.single { event -> event.type == EventAuditType.REQUESTED_VISIT_REJECTED }.text).isNull()
     }
 
     val visitNotifications = testVisitNotificationEventRepository.findAllOrderById()
@@ -143,6 +152,16 @@ class RejectVisitRequestTest : IntegrationTestBase() {
       isNull(),
     )
     verify(telemetryClient, times(1)).trackEvent(eq("unflagged-visit-event"), any(), isNull())
+
+    verify(telemetryClient).trackEvent(
+      eq("visit-request-rejected"),
+      argThat { map ->
+        assertThat(map["reference"]).isEqualTo(visitPrimary.reference)
+        assertThat(map).doesNotContainKey("rejectionReason")
+        true
+      },
+      isNull(),
+    )
 
     assertVisitRequestRejectedDomainEvent(visitPrimary.reference)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/RejectVisitRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/RejectVisitRequestTest.kt
@@ -24,8 +24,8 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.VisitDto
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.EventAuditType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.NotificationEventType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.OutcomeStatus
-import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.RejectionReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UnFlagEventReason
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRequestRejectionReason
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus.BOOKED
@@ -71,7 +71,7 @@ class RejectVisitRequestTest : IntegrationTestBase() {
     val rejectVisitRequestBodyDto = ApproveRejectionVisitRequestBodyDto(
       visitReference = visitPrimary.reference,
       actionedBy = "user1",
-      rejectionReason = RejectionReason.NO_VISIT_ALLOWANCE,
+      visitRequestRejectionReason = VisitRequestRejectionReason.NO_VISIT_ALLOWANCE,
     )
 
     // When
@@ -92,7 +92,7 @@ class RejectVisitRequestTest : IntegrationTestBase() {
         EventAuditType.REQUESTED_VISIT_REJECTED,
       )
       assertThat(it.single { event -> event.type == EventAuditType.REQUESTED_VISIT_REJECTED }.text)
-        .isEqualTo(RejectionReason.NO_VISIT_ALLOWANCE.name)
+        .isEqualTo(VisitRequestRejectionReason.NO_VISIT_ALLOWANCE.name)
     }
 
     verify(telemetryClient).trackEvent(
@@ -101,7 +101,7 @@ class RejectVisitRequestTest : IntegrationTestBase() {
         assertThat(map["reference"]).isEqualTo(visitPrimary.reference)
         assertThat(map["visitStatus"]).isEqualTo(VisitStatus.CANCELLED.name)
         assertThat(map["visitSubStatus"]).isEqualTo(VisitSubStatus.REJECTED.name)
-        assertThat(map["rejectionReason"]).isEqualTo(RejectionReason.NO_VISIT_ALLOWANCE.name)
+        assertThat(map["rejectionReason"]).isEqualTo(VisitRequestRejectionReason.NO_VISIT_ALLOWANCE.name)
         true
       },
       isNull(),


### PR DESCRIPTION
## What does this pull request do?

Add a rejection reason to the event audit when a visit is manually rejected. The event audit free text field will be populated with the rejectionReason enum value. The frontend will map this to a set of paragraphs which can be displayed in the visit history timeline to give extra information to staff about why the visit was rejected.





## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6283