### PR TITLE
VB-6495 - NONE visit order session restriction

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/repository/VisitRepository.kt
@@ -252,15 +252,41 @@ interface VisitRepository :
   ): List<Visit>
 
   @Query(
+    "SELECT v.* FROM visit v " +
+      "JOIN session_slot sl ON v.session_slot_id = sl.id " +
+      "JOIN prison p ON v.prison_id = p.id " +
+      "LEFT JOIN session_template st ON sl.session_template_reference = st.reference " +
+      "WHERE sl.slot_start >= :startDateTime AND " +
+      "v.prisoner_id = :prisonerId AND " +
+      "(:prisonCode is null OR p.code = :prisonCode) AND " +
+      "v.visit_status = 'BOOKED' AND " +
+      "(cast(:endDateTime as date) is null OR sl.slot_end < :endDateTime) AND " +
+      "(st.visit_order_restriction IS NULL OR st.visit_order_restriction != 'NONE') " +
+      "ORDER BY sl.slot_start, v.id",
+    nativeQuery = true,
+  )
+  fun getBookedVisitsThatCountTowardsRemandLimit(
+    @Param("prisonerId") prisonerId: String,
+    @Param("prisonCode") prisonCode: String?,
+    @Param("startDateTime") startDateTime: LocalDateTime,
+    @Param("endDateTime") endDateTime: LocalDateTime? = null,
+  ): List<Visit>
+
+  @Query(
     """
-    SELECT count(distinct v.id) FROM Visit v 
-      WHERE v.sessionSlot.slotDate >= :startDate AND 
-      v.sessionSlot.slotDate <= :endDate AND 
-      v.prisonerId = :prisonerId AND 
-      v.prison.code = :prisonCode AND 
-      v.visitStatus = 'BOOKED' AND 
-      (:#{#excludeVisitReference} is null OR v.reference != :excludeVisitReference)
+    SELECT count(distinct v.id) FROM visit v
+      JOIN session_slot sl ON v.session_slot_id = sl.id
+      JOIN prison p ON v.prison_id = p.id
+      LEFT JOIN session_template st ON sl.session_template_reference = st.reference
+      WHERE sl.slot_date >= :startDate AND
+      sl.slot_date <= :endDate AND
+      v.prisoner_id = :prisonerId AND
+      p.code = :prisonCode AND
+      v.visit_status = 'BOOKED' AND
+      (:excludeVisitReference is null OR v.reference != :excludeVisitReference) AND
+      (st.visit_order_restriction IS NULL OR st.visit_order_restriction != 'NONE')
       """,
+    nativeQuery = true,
   )
   fun getCountOfBookedVisits(
     @Param("prisonerId") prisonerId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationValidationService.kt
@@ -259,7 +259,7 @@ class ApplicationValidationService(
       val weekEndDate = weekStartDate.plusDays(6)
       val totalBookedVisitsForWeek = visitRepository.getCountOfBookedVisits(prisonerId = prisoner.prisonerId, prisonCode = prison.code, startDate = weekStartDate, endDate = weekEndDate, excludeVisitReference = existingBooking?.reference)
 
-      // if the remand visit limit per week has been reached return APPLICATION_INVALID_REMAND_VISIT_LIMIT_FOR_WEEK_REACHED
+      // if the remand visit limit per week has been reached, return APPLICATION_INVALID_REMAND_VISIT_LIMIT_FOR_WEEK_REACHED
       if (totalBookedVisitsForWeek >= prison.remandVisitLimitPerWeek.toLong()) {
         LOG.info("{} visit(s) already booked for REMAND prisoner - {} on week starting on - {}, so visit for {} cannot be booked.", totalBookedVisitsForWeek, prisoner.prisonerId, weekStartDate, sessionDate)
         return APPLICATION_INVALID_REMAND_VISIT_LIMIT_FOR_WEEK_REACHED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationValidationService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationValidati
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationValidationErrorCodes.APPLICATION_INVALID_USER_TYPE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationValidationErrorCodes.APPLICATION_INVALID_VISIT_ALREADY_BOOKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ConvictionStatus
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType.NONE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PRISONER
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
@@ -253,6 +254,10 @@ class ApplicationValidationService(
         return null
       }
 
+      if (isNoVisitOrderSession(application)) {
+        return null
+      }
+
       // get the number of booked visits for the week
       val sessionDate = application.sessionSlot.slotDate
       val weekStartDate = sessionDate.with(TemporalAdjusters.previousOrSame(prison.weekStartDay))
@@ -268,6 +273,10 @@ class ApplicationValidationService(
 
     return null
   }
+
+  private fun isNoVisitOrderSession(application: Application): Boolean = application.sessionSlot.sessionTemplateReference
+    ?.let { sessionTemplateRepository.findByReference(it)?.visitOrderRestriction == NONE }
+    ?: false
 
   private fun checkVOLimits(prisoner: PrisonerDto): ApplicationValidationErrorCodes? {
     // check VO limits if prisoner is not on Remand.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/ApplicationValidationService.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Prison
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.Visit
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.application.Application
 import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionSlot
+import uk.gov.justice.digital.hmpps.visitscheduler.model.entity.session.SessionTemplate
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.PrisonExcludeDateRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionTemplateExcludeDateRepository
 import uk.gov.justice.digital.hmpps.visitscheduler.repository.SessionTemplateRepository
@@ -87,6 +88,7 @@ class ApplicationValidationService(
     }
 
     checkPrison(prison.code, prisoner.prisonCode)
+    val sessionTemplate = getSessionTemplate(application)
 
     // check if the prison has blocked the application's date for visits
     checkIfPrisonDateBlocked(application)?.also {
@@ -98,7 +100,7 @@ class ApplicationValidationService(
       errorCodes.add(it)
     }
 
-    checkSessionSlot(application, prisoner, prison)?.also {
+    checkSessionSlot(application, prisoner, prison, sessionTemplate)?.also {
       errorCodes.add(it)
     }
 
@@ -117,7 +119,7 @@ class ApplicationValidationService(
     }
 
     // check if remand limit reached for a remand prisoner
-    checkRemandLimitReachedForWeek(prisoner = prisoner, prison = prison, application = application, existingBooking = existingBooking)?.also {
+    checkRemandLimitReachedForWeek(prisoner = prisoner, prison = prison, application = application, existingBooking = existingBooking, sessionTemplate = sessionTemplate)?.also {
       errorCodes.add(it)
     }
 
@@ -178,11 +180,13 @@ class ApplicationValidationService(
     return emptyList()
   }
 
-  private fun checkSessionSlot(application: Application, prisoner: PrisonerDto, prison: Prison): ApplicationValidationErrorCodes? {
+  private fun getSessionTemplate(application: Application): SessionTemplate? = application.sessionSlot.sessionTemplateReference
+    ?.let { sessionTemplateRepository.findByReference(it) }
+
+  private fun checkSessionSlot(application: Application, prisoner: PrisonerDto, prison: Prison, sessionTemplate: SessionTemplate?): ApplicationValidationErrorCodes? {
     val sessionSlot = application.sessionSlot
 
     sessionSlot.sessionTemplateReference?.let {
-      val sessionTemplate = sessionTemplateRepository.findByReference(it)
       if (sessionTemplate != null) {
         val prisonerHousingLevels =
           prisonerService.getPrisonerHousingLevels(application.prisonerId, prison.code, listOf(sessionTemplate))
@@ -244,7 +248,7 @@ class ApplicationValidationService(
     return null
   }
 
-  private fun checkRemandLimitReachedForWeek(prisoner: PrisonerDto, prison: Prison, application: Application, existingBooking: Visit?): ApplicationValidationErrorCodes? {
+  private fun checkRemandLimitReachedForWeek(prisoner: PrisonerDto, prison: Prison, application: Application, existingBooking: Visit?, sessionTemplate: SessionTemplate?): ApplicationValidationErrorCodes? {
     // ignore if prisoner is not a REMAND prisoner
     if (!ConvictionStatus.isRemand(prisoner.convictedStatus)) {
       return null
@@ -254,7 +258,7 @@ class ApplicationValidationService(
         return null
       }
 
-      if (isNoVisitOrderSession(application)) {
+      if (isNoVisitOrderSession(sessionTemplate)) {
         return null
       }
 
@@ -274,9 +278,7 @@ class ApplicationValidationService(
     return null
   }
 
-  private fun isNoVisitOrderSession(application: Application): Boolean = application.sessionSlot.sessionTemplateReference
-    ?.let { sessionTemplateRepository.findByReference(it)?.visitOrderRestriction == NONE }
-    ?: false
+  private fun isNoVisitOrderSession(sessionTemplate: SessionTemplate?): Boolean = sessionTemplate?.visitOrderRestriction == NONE
 
   private fun checkVOLimits(prisoner: PrisonerDto): ApplicationValidationErrorCodes? {
     // check VO limits if prisoner is not on Remand.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -290,7 +290,7 @@ class SessionService(
     val adjustedStartDate = dateRange.fromDate.with(TemporalAdjusters.previousOrSame(prison.weekStartDay))
     val adjustedToDate = dateRange.toDate.with(TemporalAdjusters.nextOrSame(prison.weekStartDay.plus(6)))
 
-    val visits = visitRepository.getBookedVisits(
+    val visits = visitRepository.getBookedVisitsThatCountTowardsRemandLimit(
       prisonerId = prisoner.prisonerId,
       prisonCode = prison.code,
       startDateTime = adjustedStartDate.atStartOfDay(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionConflict.DOU
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionConflict.NON_ASSOCIATION
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionConflict.REMAND_VISITS_LIMIT_REACHED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionRestriction
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType.NONE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.prison.api.PrisonerNonAssociationDetailDto
@@ -307,6 +308,7 @@ class SessionService(
         limitReachedSessions.addAll(
           visitSessions
             .filter { it.startTimestamp.toLocalDate() in weekStartDate..weekEndDate }
+            .filter { it.visitOrderRestriction != NONE }
             .filter { !doubleBookingOrReservationSessions.contains(it) },
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsRemandLimitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsRemandLimitTest.kt
@@ -81,6 +81,31 @@ class GetSessionsRemandLimitTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when remand limit is reached then sessions with no visit order restriction are not flagged as limit reached`() {
+    // Given
+    val startDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    createVisits(remandPrisonerId, listOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY), startDate)
+
+    val noneVisitOrderSessionTemplate = sessionTemplateEntityHelper.create(
+      validFromDate = LocalDate.now().minusMonths(1),
+      dayOfWeek = DayOfWeek.WEDNESDAY,
+      prisonCode = prisonCode,
+      visitOrderRestrictionType = NONE,
+    )
+
+    // When
+    val responseSpec = callGetSessions(prisonCode, remandPrisonerId, userType = STAFF, authHttpHeaders = authHttpHeaders)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val visitSessionResults = getResults(returnResult)
+    val noneVisitOrderSessions = visitSessionResults.filter { it.sessionTemplateReference == noneVisitOrderSessionTemplate.reference }
+
+    assertThat(noneVisitOrderSessions).isNotEmpty
+    assertThat(noneVisitOrderSessions).noneMatch { it.sessionConflicts.contains(REMAND_VISITS_LIMIT_REACHED) }
+  }
+
+  @Test
   fun `when remand prisoner has visits booked but weekly limit has not been reached then REMAND_VISITS_LIMIT_REACHED flag is not set for non booked sessions`() {
     // Given
     val startDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsRemandLimitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/session/GetSessionsRemandLimitTest.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient.BodyContentSpec
 import uk.gov.justice.digital.hmpps.visitscheduler.controller.VISIT_SESSION_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionConflict.REMAND_VISITS_LIMIT_REACHED
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType.NONE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.sessions.VisitSessionDto
@@ -89,6 +90,41 @@ class GetSessionsRemandLimitTest : IntegrationTestBase() {
     createVisits(remandPrisonerId, week1VisitDays, startDate)
     createVisits(remandPrisonerId, week2VisitDays, startDate.plusWeeks(1))
     createVisits(remandPrisonerId, week3VisitDays, startDate.plusWeeks(2))
+
+    // When
+    val responseSpec = callGetSessions(prisonCode, remandPrisonerId, userType = STAFF, authHttpHeaders = authHttpHeaders)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val visitSessionResults = getResults(returnResult)
+    assertThat(visitSessionResults.size).isEqualTo(14)
+    assertThat(visitSessionResults).noneMatch { it.sessionConflicts.contains(REMAND_VISITS_LIMIT_REACHED) }
+  }
+
+  @Test
+  fun `when remand prisoner has visits booked on sessions with no visit order restriction then they do not count towards weekly limit`() {
+    // Given
+    val startDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    createVisits(remandPrisonerId, listOf(DayOfWeek.MONDAY), startDate)
+
+    val noneVisitOrderSessionTemplate = sessionTemplateEntityHelper.create(
+      validFromDate = LocalDate.now().minusMonths(1),
+      dayOfWeek = DayOfWeek.TUESDAY,
+      prisonCode = prisonCode,
+      isActive = false,
+      visitOrderRestrictionType = NONE,
+    )
+    val noneVisitOrderVisitDate = startDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.TUESDAY))
+    visitEntityHelper.create(
+      prisonerId = remandPrisonerId,
+      prisonCode = prisonCode,
+      visitRoom = noneVisitOrderSessionTemplate.visitRoom,
+      slotDate = noneVisitOrderVisitDate,
+      visitStart = noneVisitOrderSessionTemplate.startTime,
+      visitEnd = noneVisitOrderSessionTemplate.endTime,
+      visitStatus = VisitStatus.BOOKED,
+      sessionTemplate = noneVisitOrderSessionTemplate,
+    )
 
     // When
     val responseSpec = callGetSessions(prisonCode, remandPrisonerId, userType = STAFF, authHttpHeaders = authHttpHeaders)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/integration/visit/BookVisitValidationTest.kt
@@ -24,6 +24,8 @@ import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationValidati
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.ApplicationValidationErrorCodes.APPLICATION_INVALID_VISIT_DATE_BLOCKED
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.IncentiveLevel
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.PrisonerCategoryType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType
+import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.SessionTemplateVisitOrderRestrictionType.NONE
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.UserType
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.visitscheduler.dto.enums.VisitStatus
@@ -748,6 +750,54 @@ class BookVisitValidationTest : IntegrationTestBase() {
     createVisit(remandPrisonerId, remandPrisonCode, mondayVisitDate.plusDays(1), VisitStatus.CANCELLED)
     // 1 booked visit for last week - Sunday
     createVisit(remandPrisonerId, remandPrisonCode, mondayVisitDate.minusDays(1), VisitStatus.BOOKED)
+    // When
+    val responseSpec = callVisitBook(webTestClient, roleVisitSchedulerHttpHeaders, remandPrisonerApplicationInProgress.reference)
+
+    // Then
+    responseSpec.expectStatus().isOk
+  }
+
+  @Test
+  fun `when prisoner is on remand and booked NONE visits would exceed the remand limit for the week visit is booked successfully - public service`() {
+    // Given
+    val today = LocalDate.now()
+    prisonEntityHelper.create(prisonCode = remandPrisonCode, remandVisitLimitPerWeek = 2, weekStartDay = DayOfWeek.MONDAY)
+    val mondayVisitDate = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId = remandPrisonerId, prisonCode = remandPrisonCode, convictedStatus = "Remand")
+    nonAssociationsApiMockServer.stubGetPrisonerNonAssociationEmpty(remandPrisonerId)
+    prisonApiMockServer.stubGetPrisonerHousingLocation(remandPrisonerId, "$remandPrisonCode-C-1-C001")
+    val remandPrisonerApplicationInProgress = createApplication(prisonerId = remandPrisonerId, prisonCode = remandPrisonCode, userType = UserType.PUBLIC, applicationDate = today)
+
+    createVisit(remandPrisonerId, remandPrisonCode, mondayVisitDate, VisitStatus.BOOKED)
+    createVisit(remandPrisonerId, remandPrisonCode, mondayVisitDate.plusDays(1), VisitStatus.BOOKED, visitOrderRestrictionType = NONE)
+
+    // When
+    val responseSpec = callVisitBook(webTestClient, roleVisitSchedulerHttpHeaders, remandPrisonerApplicationInProgress.reference)
+
+    // Then
+    responseSpec.expectStatus().isOk
+  }
+
+  @Test
+  fun `when prisoner is on remand and target session has no visit order restriction then remand limit is ignored - public service`() {
+    // Given
+    val today = LocalDate.now()
+    prisonEntityHelper.create(prisonCode = remandPrisonCode, remandVisitLimitPerWeek = 2, weekStartDay = DayOfWeek.MONDAY)
+    val mondayVisitDate = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    prisonOffenderSearchMockServer.stubGetPrisonerByString(prisonerId = remandPrisonerId, prisonCode = remandPrisonCode, convictedStatus = "Remand")
+    nonAssociationsApiMockServer.stubGetPrisonerNonAssociationEmpty(remandPrisonerId)
+    prisonApiMockServer.stubGetPrisonerHousingLocation(remandPrisonerId, "$remandPrisonCode-C-1-C001")
+    val remandPrisonerApplicationInProgress = createApplication(
+      prisonerId = remandPrisonerId,
+      prisonCode = remandPrisonCode,
+      userType = UserType.PUBLIC,
+      applicationDate = today,
+      visitOrderRestrictionType = NONE,
+    )
+
+    createVisit(remandPrisonerId, remandPrisonCode, mondayVisitDate, VisitStatus.BOOKED)
+    createVisit(remandPrisonerId, remandPrisonCode, mondayVisitDate.plusDays(1), VisitStatus.BOOKED)
+
     // When
     val responseSpec = callVisitBook(webTestClient, roleVisitSchedulerHttpHeaders, remandPrisonerApplicationInProgress.reference)
 
@@ -2121,8 +2171,14 @@ class BookVisitValidationTest : IntegrationTestBase() {
 
   fun getValidationErrorResponse(responseSpec: WebTestClient.ResponseSpec): ApplicationValidationErrorResponse = objectMapper.readValue(responseSpec.expectBody().returnResult().responseBody, ApplicationValidationErrorResponse::class.java)
 
-  private fun createApplication(prisonerId: String, prisonCode: String, applicationDate: LocalDate, userType: UserType): Application {
-    val sessionTemplate = sessionTemplateEntityHelper.create(prisonCode = prisonCode, dayOfWeek = applicationDate.dayOfWeek)
+  private fun createApplication(
+    prisonerId: String,
+    prisonCode: String,
+    applicationDate: LocalDate,
+    userType: UserType,
+    visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
+  ): Application {
+    val sessionTemplate = sessionTemplateEntityHelper.create(prisonCode = prisonCode, dayOfWeek = applicationDate.dayOfWeek, visitOrderRestrictionType = visitOrderRestrictionType)
 
     var application = applicationEntityHelper.create(
       prisonerId = prisonerId,
@@ -2139,8 +2195,14 @@ class BookVisitValidationTest : IntegrationTestBase() {
     return application
   }
 
-  private fun createVisit(prisonerId: String, prisonCode: String, visitDate: LocalDate, visitStatus: VisitStatus): Visit {
-    val sessionTemplate = sessionTemplateEntityHelper.create(prisonCode = prisonCode, dayOfWeek = visitDate.dayOfWeek)
+  private fun createVisit(
+    prisonerId: String,
+    prisonCode: String,
+    visitDate: LocalDate,
+    visitStatus: VisitStatus,
+    visitOrderRestrictionType: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
+  ): Visit {
+    val sessionTemplate = sessionTemplateEntityHelper.create(prisonCode = prisonCode, dayOfWeek = visitDate.dayOfWeek, visitOrderRestrictionType = visitOrderRestrictionType)
     val visitSubStatus = if (visitStatus == VisitStatus.BOOKED) VisitSubStatus.AUTO_APPROVED else VisitSubStatus.CANCELLED
 
     val visit = visitEntityHelper.create(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceRemandLimitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitscheduler/service/SessionServiceRemandLimitTest.kt
@@ -128,7 +128,7 @@ class SessionServiceRemandLimitTest {
       prisonerService.getPrisonerNonAssociationList(prisonerId),
     ).thenReturn(emptyList())
 
-    whenever(visitRepository.getBookedVisits(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1))
+    whenever(visitRepository.getBookedVisitsThatCountTowardsRemandLimit(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1))
 
     // When
     val sessions = sessionService.getAllVisitSessions(prisonCode, prisonerId, userType = STAFF)
@@ -197,7 +197,7 @@ class SessionServiceRemandLimitTest {
     ).thenReturn(emptyList())
 
     whenever(visitRepository.hasActiveVisitForSessionSlot(any(), any(), anyOrNull())).thenReturn(false)
-    whenever(visitRepository.getBookedVisits(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1))
+    whenever(visitRepository.getBookedVisitsThatCountTowardsRemandLimit(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1))
 
     // When
     val sessions = sessionService.getAllVisitSessions(prisonCode, prisonerId, userType = STAFF)
@@ -267,7 +267,7 @@ class SessionServiceRemandLimitTest {
     ).thenReturn(emptyList())
 
     whenever(visitRepository.hasActiveVisitForSessionSlot(any(), any(), anyOrNull())).thenReturn(false)
-    whenever(visitRepository.getBookedVisits(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1, visit2))
+    whenever(visitRepository.getBookedVisitsThatCountTowardsRemandLimit(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1, visit2))
 
     // When
     val sessions = sessionService.getAllVisitSessions(prisonCode, prisonerId, userType = STAFF)
@@ -334,7 +334,7 @@ class SessionServiceRemandLimitTest {
     ).thenReturn(emptyList())
 
     whenever(visitRepository.hasActiveVisitForSessionSlot(any(), any(), anyOrNull())).thenReturn(false)
-    whenever(visitRepository.getBookedVisits(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1))
+    whenever(visitRepository.getBookedVisitsThatCountTowardsRemandLimit(any(), anyOrNull(), any(), anyOrNull())).thenReturn(listOf(visit1))
 
     // When
     val sessions = sessionService.getAllVisitSessions(prisonCode, prisonerId, userType = STAFF)


### PR DESCRIPTION
## What does this pull request do?

As part of this story, updates remand weekly-limit logic so that visits associated with session templates having visit-order restriction NONE are excluded from remand-limit counting, and adds/updates tests around the “Get sessions” remand-limit behaviour.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6495
https://dsdmoj.atlassian.net/browse/VB-6765